### PR TITLE
feat(dependencies): appended the requirements file to make it fully compatible with default pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+--extra-index-url https://download.pytorch.org/whl/cu118
 timm==1.0.27
 torch==2.4.1+cu118


### PR DESCRIPTION
Originally, the pip failed to locate `torch==2.4.1+cu118`

By adding `--extra-index-url https://download.pytorch.org/whl/cu118` this was fixed, and now everybody who clones the repository can simply type `pip install -r requirements.txt` and all the required packages will be installed without complications.