### PR TITLE
feat (data parsing): add data parsing and forward pass testing for NVIDIA Physical AI dataset

### DIFF
--- a/Model/data_parsing/README.md
+++ b/Model/data_parsing/README.md
@@ -1,3 +1,22 @@
-# Data Parsing
+# Nvidia Physical AI Data
 
-This folder contains libraries to help parse multiple E2E datsets
+## Data format description
+
+```
+data/
+    camera/
+        camera_front_wide_120fov/
+            <clip_uuid>.camera_front_wide_120fov.mp4
+            <clip_uuid>.camera_front_wide_120fov.timestamps.parquet
+        camera_front_tele_30fov/    ...
+        camera_cross_left_120fov/   ...
+        camera_cross_right_120fov/  ...
+        camera_rear_left_70fov/     ...
+        camera_rear_right_70fov/    ...
+        camera_rear_tele_30fov/     ...
+    labels/
+        egomotion/
+            <clip_uuid>.egomotion.parquet
+```
+
+Each clip is 20s. The egomotion parquet contains 100Hz motion data; camera videos run at 30fps. Both use a shared per-clip timestamp reference (t=0 = clip anchor), which is used to align camera frames to egomotion moments.

--- a/Model/data_parsing/nvidia_physical_ai/README.md
+++ b/Model/data_parsing/nvidia_physical_ai/README.md
@@ -1,1 +1,88 @@
-# Data parsing recipe for [Nvidia Physical AI Dataset](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles)
+# Data parsing recipe for [NVIDIA Physical AI Dataset](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles)
+
+Parser for the NVIDIA Physical AI dataset, producing tensors directly consumable by AutoE2E's `forward()`.
+
+Download (a subset of) the dataset into `data`.
+
+## Model inputs produced
+
+- `visual_tiles` `(8, 3, H, W)` — 7 camera frames + 1 map tile placeholder
+- `egomotion_history` `(256,)` — 64 past timesteps × 4 signals at 10 Hz
+- `visual_history` `(896,)` — zero-initialised; populated during sequential inference
+- `trajectory_target` `(128,)` — 64 future timesteps × 2 signals (supervision target)
+
+### Egomotion history signals `(256,) = 64 × 4`
+
+- `[0]` Speed (m/s) — `sqrt(vx^2 + vy^2)`
+- `[1]` Acceleration (m/s^2) — `ax`
+- `[2]` Yaw angle (rad) — quaternion → ZYX Euler via `EgomotionState.pose`
+- `[3]` Curvature (rad/m) — `curvature`
+
+### Trajectory target signals `(128,) = 64 × 2`
+
+- `[0]` Acceleration (m/s^2) — `ax`
+- `[1]` Curvature (rad/m) — `curvature`
+
+## Sampling
+
+A sample is defined by a `sample_idx` — an index into the 10 Hz downsampled egomotion sequence. A `sample_idx` is valid when there are at least 64 rows behind it (history window) and 64 rows ahead (target window). For a typical 20s clip (~200 rows at 10 Hz) this gives ~72 valid sample points per clip.
+
+All valid `(clip_uuid, sample_idx)` pairs are enumerated at dataset construction time. `__getitem__` does I/O only — no index arithmetic at call time.
+
+## Usage
+
+```python
+from data_parsing.nvidia_physical_ai import NvidiaAVDataset
+from torch.utils.data import DataLoader
+
+dataset = NvidiaAVDataset(
+    subset_root="/path/to/nvidia_av_camera_subset",
+    backbone_name="swin_tiny_patch4_window7_224.ms_in22k",
+)
+
+# Single clip for forward pass validation
+dataset = NvidiaAVDataset(
+    subset_root="/path/to/nvidia_av_camera_subset",
+    backbone_name="swin_tiny_patch4_window7_224.ms_in22k",
+    clip_uuids=["fd1d1b6b-59bf-4292-8295-5028aa6aa5e3"],
+)
+
+loader = DataLoader(dataset, batch_size=8, shuffle=True, num_workers=4)
+
+for batch in loader:
+    visual_tiles      = batch["visual_tiles"].to(device)       # (B, 8, 3, H, W)
+    visual_history    = batch["visual_history"].to(device)     # (B, 896)
+    egomotion_history = batch["egomotion_history"].to(device)  # (B, 256)
+    trajectory_target = batch["trajectory_target"].to(device)  # (B, 128)
+
+    trajectory, compressed, future = model(visual_tiles, visual_history, egomotion_history)
+    loss = criterion(trajectory, trajectory_target)
+```
+
+## Image preprocessing
+
+Preprocessing is derived at runtime from the backbone's own config via timm:
+
+```python
+data_config = timm.data.resolve_model_data_config(backbone)
+transform = timm.data.create_transform(**data_config, is_training=False)
+```
+
+This means normalisation, resize, and crop parameters always match the backbone's training. If the backbone changes, pass a different `backbone_name` to `NvidiaAVDataset`.
+
+## Forward pass test
+
+```bash
+cd Model/data_parsing/nvidia_physical_ai
+python forward_pass_test.py \
+    --dataset_root data \
+    --clip_uuid fd1d1b6b-59bf-4292-8295-5028aa6aa5e3
+```
+
+## Additional dependencies
+
+```
+physical_ai_av   # NVIDIA dataset SDK (pip install git+https://github.com/NVlabs/physical_ai_av.git); requires python >= 3.11
+timm             # backbone config and transforms
+pandas
+```

--- a/Model/data_parsing/nvidia_physical_ai/README.md
+++ b/Model/data_parsing/nvidia_physical_ai/README.md
@@ -36,13 +36,13 @@ from data_parsing.nvidia_physical_ai import NvidiaAVDataset
 from torch.utils.data import DataLoader
 
 dataset = NvidiaAVDataset(
-    subset_root="/path/to/nvidia_av_camera_subset",
+    data_root="/path/to/nvidia_physical_ai_dataset",
     backbone_name="swin_tiny_patch4_window7_224.ms_in22k",
 )
 
 # Single clip for forward pass validation
 dataset = NvidiaAVDataset(
-    subset_root="/path/to/nvidia_av_camera_subset",
+    data_root="/path/to/nvidia_physical_ai_dataset",
     backbone_name="swin_tiny_patch4_window7_224.ms_in22k",
     clip_uuids=["fd1d1b6b-59bf-4292-8295-5028aa6aa5e3"],
 )

--- a/Model/data_parsing/nvidia_physical_ai/__init__.py
+++ b/Model/data_parsing/nvidia_physical_ai/__init__.py
@@ -1,0 +1,13 @@
+from .camera import CAMERA_NAMES, NUM_VIEWS, load_camera_frame
+from .dataset import NvidiaAVDataset
+from .egomotion import EGOMOTION_DIM, load_egomotion
+ 
+__all__ = [
+    "NvidiaAVDataset",
+    "load_camera_frame",
+    "CAMERA_NAMES",
+    "load_egomotion",
+    "NUM_VIEWS",
+    "EGOMOTION_DIM",
+]
+ 

--- a/Model/data_parsing/nvidia_physical_ai/camera.py
+++ b/Model/data_parsing/nvidia_physical_ai/camera.py
@@ -31,18 +31,40 @@ CAMERA_NAMES: list[str] = [
 # Total views fed to the model = 7 cameras + 1 map tile.
 NUM_VIEWS = 8
 
+def _make_map_tile(transform: Compose, reference: torch.Tensor) -> torch.Tensor:
+    """Return a zero map tile matching the shape of a transformed camera frame.
 
-def _make_map_tile(transform: Compose) -> torch.Tensor:
-    """Return a placeholder map tile matching the transform output shape.
+    The transform is accepted for API consistency with the real renderer
+    that will replace this placeholder.
 
     TODO: Replace with a real renderer once a map source is integrated.
-          The tile should pass through the same transform as camera frames.
     """
-    dummy = Image.fromarray(np.zeros((256, 256, 3), dtype=np.uint8))
-    return transform(dummy)
+    return torch.zeros_like(reference)
 
 
-def _egomotion_ts_to_frame_idx(timestamps_path: Path, egomotion_timestamp_us: int) -> int:
+# def _egomotion_ts_to_frame_idx(timestamps_path: Path, egomotion_timestamp_us: int) -> int:
+#     """Find the camera frame index closest to an egomotion timestamp.
+
+#     Both egomotion and camera timestamps are in microseconds relative to the
+#     same clip anchor (t=0). This finds the camera frame whose timestamp is
+#     nearest to the egomotion timestamp at the sample point.
+
+#     Args:
+#         timestamps_path: Path to the sidecar timestamps parquet for this camera.
+#         egomotion_timestamp_us: Egomotion timestamp in microseconds at the
+#             desired sample point, read directly from the egomotion parquet.
+
+#     Returns:
+#         0-based frame index into the video.
+#     """
+#     df = pd.read_parquet(timestamps_path)
+#     camera_timestamps_us = df["timestamp"].to_numpy()
+#     return int(np.argmin(np.abs(camera_timestamps_us - egomotion_timestamp_us)))
+
+def _egomotion_ts_to_frame_idx(
+    egomotion_timestamp_us: int,
+    camera_timestamps_us: np.ndarray,
+) -> int:
     """Find the camera frame index closest to an egomotion timestamp.
 
     Both egomotion and camera timestamps are in microseconds relative to the
@@ -50,17 +72,16 @@ def _egomotion_ts_to_frame_idx(timestamps_path: Path, egomotion_timestamp_us: in
     nearest to the egomotion timestamp at the sample point.
 
     Args:
-        timestamps_path: Path to the sidecar timestamps parquet for this camera.
         egomotion_timestamp_us: Egomotion timestamp in microseconds at the
             desired sample point, read directly from the egomotion parquet.
+        camera_timestamps_us: Pre-loaded array of camera timestamps in
+            microseconds for this clip+camera. Pass this from NvidiaAVDataset
+            to avoid re-reading the timestamps parquet on every __getitem__.
 
     Returns:
         0-based frame index into the video.
     """
-    df = pd.read_parquet(timestamps_path)
-    camera_timestamps_us = df["timestamp"].to_numpy()
     return int(np.argmin(np.abs(camera_timestamps_us - egomotion_timestamp_us)))
-
 
 def load_camera_frame(
     data_root: Path | str,
@@ -68,6 +89,7 @@ def load_camera_frame(
     egomotion_timestamp_us: int,
     transform: Compose,
     camera_names: list[str] | None = None,
+    camera_timestamps: dict[str, np.ndarray] | None = None,
 ) -> torch.Tensor:
     """Load and preprocess the camera frame aligned to an egomotion timestamp.
 
@@ -80,10 +102,10 @@ def load_camera_frame(
             Defaults to ``CAMERA_NAMES``.
 
     Returns:
-        Float tensor of shape (8, 3, 224, 224):
+        Float tensor of shape (8, 3, H, W):
         7 camera views followed by 1 map tile (currently zeros).
     """
-    data_root = Path(data_root)
+    data_root = Path(data_root) 
     camera_root = data_root / "camera"
 
     if not camera_root.exists():
@@ -97,20 +119,24 @@ def load_camera_frame(
     for cam_name in camera_names:
         cam_dir = camera_root / cam_name
         video_path = cam_dir / f"{clip_uuid}.{cam_name}.mp4"
-        timestamps_path = cam_dir / f"{clip_uuid}.{cam_name}.timestamps.parquet"
 
         if not video_path.exists():
             raise FileNotFoundError(f"Camera video not found: {video_path}")
+        
+        if camera_timestamps is not None:
+            timestamps_us = camera_timestamps[cam_name]
+        else:
+            timestamps_path = cam_dir / f"{clip_uuid}.{cam_name}.timestamps.parquet"
+            if not timestamps_path.exists():
+                raise FileNotFoundError(
+                    f"Camera timestamps parquet not found: {timestamps_path}. "
+                    "Cannot align camera frame to egomotion timestamp without it."
+                )
+            timestamps_us = pd.read_parquet(timestamps_path)["timestamp"].to_numpy()
 
-        if not timestamps_path.exists():
-            raise FileNotFoundError(
-                f"Camera timestamps parquet not found: {timestamps_path}. "
-                "Cannot align camera frame to egomotion timestamp without it."
-            )
+        frame_idx = _egomotion_ts_to_frame_idx(egomotion_timestamp_us, timestamps_us)
 
-        frame_idx = _egomotion_ts_to_frame_idx(timestamps_path, egomotion_timestamp_us)
-
-        video_data = io.BytesIO(video_path.read_bytes())
+        video_data = io.BytesIO(video_path.read_bytes()) #TODO: major bottleneck for training - consider sampling images in a seperate data processing step.
         reader = SeekVideoReader(video_data=video_data)
         try:
             indices = np.array([frame_idx], dtype=np.int64)
@@ -119,8 +145,9 @@ def load_camera_frame(
             reader.close()
 
         pil_frame = Image.fromarray(rgb_frames[0])
-        camera_tensors.append(transform(pil_frame))  # (3, 224, 224)
+        camera_tensors.append(transform(pil_frame))  # (3, H, W)
 
-    camera_tensors.append(_make_map_tile(transform))
+    map_tile = _make_map_tile(transform, camera_tensors[0])  # (3, H, W)
+    camera_tensors.append(map_tile)
 
-    return torch.stack(camera_tensors, dim=0)  # (8, 3, 224, 224)
+    return torch.stack(camera_tensors, dim=0)  # (8, 3, H, W)

--- a/Model/data_parsing/nvidia_physical_ai/camera.py
+++ b/Model/data_parsing/nvidia_physical_ai/camera.py
@@ -1,0 +1,126 @@
+"""Camera frame loading for the NVIDIA PhysicalAI-Autonomous-Vehicles dataset.
+
+TODO: The NVIDIA dataset does not include rendered map tiles. The 8th view is
+currently a zero tensor of shape (3, H, W). Replace ``_make_map_tile``
+with a real renderer once one is available.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from PIL import Image
+from physical_ai_av.video import SeekVideoReader
+from torchvision.transforms import Compose
+
+# Camera directories present in the NVIDIA PhysicalAI-Autonomous-Vehicles dataset.
+CAMERA_NAMES: list[str] = [
+    "camera_front_wide_120fov",
+    "camera_front_tele_30fov",
+    "camera_cross_left_120fov",
+    "camera_cross_right_120fov",
+    "camera_rear_left_70fov",
+    "camera_rear_right_70fov",
+    "camera_rear_tele_30fov",
+]
+
+# Total views fed to the model = 7 cameras + 1 map tile.
+NUM_VIEWS = 8
+
+
+def _make_map_tile(transform: Compose) -> torch.Tensor:
+    """Return a placeholder map tile matching the transform output shape.
+
+    TODO: Replace with a real renderer once a map source is integrated.
+          The tile should pass through the same transform as camera frames.
+    """
+    dummy = Image.fromarray(np.zeros((256, 256, 3), dtype=np.uint8))
+    return transform(dummy)
+
+
+def _egomotion_ts_to_frame_idx(timestamps_path: Path, egomotion_timestamp_us: int) -> int:
+    """Find the camera frame index closest to an egomotion timestamp.
+
+    Both egomotion and camera timestamps are in microseconds relative to the
+    same clip anchor (t=0). This finds the camera frame whose timestamp is
+    nearest to the egomotion timestamp at the sample point.
+
+    Args:
+        timestamps_path: Path to the sidecar timestamps parquet for this camera.
+        egomotion_timestamp_us: Egomotion timestamp in microseconds at the
+            desired sample point, read directly from the egomotion parquet.
+
+    Returns:
+        0-based frame index into the video.
+    """
+    df = pd.read_parquet(timestamps_path)
+    camera_timestamps_us = df["timestamp"].to_numpy()
+    return int(np.argmin(np.abs(camera_timestamps_us - egomotion_timestamp_us)))
+
+
+def load_camera_frame(
+    data_root: Path | str,
+    clip_uuid: str,
+    egomotion_timestamp_us: int,
+    transform: Compose,
+    camera_names: list[str] | None = None,
+) -> torch.Tensor:
+    """Load and preprocess the camera frame aligned to an egomotion timestamp.
+
+    Args:
+        data_root: Root directory of the dataset subset.
+        clip_uuid: UUID of the clip to load.
+        egomotion_timestamp_us: Egomotion timestamp in microseconds at the
+            desired sample point, read directly from the egomotion parquet.
+        camera_names: Ordered list of camera directory names to load.
+            Defaults to ``CAMERA_NAMES``.
+
+    Returns:
+        Float tensor of shape (8, 3, 224, 224):
+        7 camera views followed by 1 map tile (currently zeros).
+    """
+    data_root = Path(data_root)
+    camera_root = data_root / "camera"
+
+    if not camera_root.exists():
+        raise FileNotFoundError(f"Camera directory not found: {camera_root}")
+
+    if camera_names is None:
+        camera_names = CAMERA_NAMES
+
+    camera_tensors = []
+
+    for cam_name in camera_names:
+        cam_dir = camera_root / cam_name
+        video_path = cam_dir / f"{clip_uuid}.{cam_name}.mp4"
+        timestamps_path = cam_dir / f"{clip_uuid}.{cam_name}.timestamps.parquet"
+
+        if not video_path.exists():
+            raise FileNotFoundError(f"Camera video not found: {video_path}")
+
+        if not timestamps_path.exists():
+            raise FileNotFoundError(
+                f"Camera timestamps parquet not found: {timestamps_path}. "
+                "Cannot align camera frame to egomotion timestamp without it."
+            )
+
+        frame_idx = _egomotion_ts_to_frame_idx(timestamps_path, egomotion_timestamp_us)
+
+        video_data = io.BytesIO(video_path.read_bytes())
+        reader = SeekVideoReader(video_data=video_data)
+        try:
+            indices = np.array([frame_idx], dtype=np.int64)
+            rgb_frames = reader.decode_images_from_frame_indices(indices)
+        finally:
+            reader.close()
+
+        pil_frame = Image.fromarray(rgb_frames[0])
+        camera_tensors.append(transform(pil_frame))  # (3, 224, 224)
+
+    camera_tensors.append(_make_map_tile(transform))
+
+    return torch.stack(camera_tensors, dim=0)  # (8, 3, 224, 224)

--- a/Model/data_parsing/nvidia_physical_ai/camera.py
+++ b/Model/data_parsing/nvidia_physical_ai/camera.py
@@ -42,25 +42,6 @@ def _make_map_tile(transform: Compose, reference: torch.Tensor) -> torch.Tensor:
     return torch.zeros_like(reference)
 
 
-# def _egomotion_ts_to_frame_idx(timestamps_path: Path, egomotion_timestamp_us: int) -> int:
-#     """Find the camera frame index closest to an egomotion timestamp.
-
-#     Both egomotion and camera timestamps are in microseconds relative to the
-#     same clip anchor (t=0). This finds the camera frame whose timestamp is
-#     nearest to the egomotion timestamp at the sample point.
-
-#     Args:
-#         timestamps_path: Path to the sidecar timestamps parquet for this camera.
-#         egomotion_timestamp_us: Egomotion timestamp in microseconds at the
-#             desired sample point, read directly from the egomotion parquet.
-
-#     Returns:
-#         0-based frame index into the video.
-#     """
-#     df = pd.read_parquet(timestamps_path)
-#     camera_timestamps_us = df["timestamp"].to_numpy()
-#     return int(np.argmin(np.abs(camera_timestamps_us - egomotion_timestamp_us)))
-
 def _egomotion_ts_to_frame_idx(
     egomotion_timestamp_us: int,
     camera_timestamps_us: np.ndarray,

--- a/Model/data_parsing/nvidia_physical_ai/dataset.py
+++ b/Model/data_parsing/nvidia_physical_ai/dataset.py
@@ -1,0 +1,182 @@
+"""PyTorch Dataset for the NVIDIA PhysicalAI-Autonomous-Vehicles dataset.
+
+Usage
+-----
+    from data_parsing.nvidia_physical_ai import NvidiaAVDataset
+
+    # All valid samples across all clips (for training)
+    dataset = NvidiaAVDataset(data_root="/path/to/nvidia_av_camera_subset")
+
+    # Single clip (for smoke tests / forward pass validation)
+    dataset = NvidiaAVDataset(
+        data_root="/path/to/nvidia_av_camera_subset",
+        clip_uuids=["fd1d1b6b-59bf-4292-8295-5028aa6aa5e3"],
+    )
+
+    sample = dataset[0]
+    # sample["visual_tiles"]       (8, 3, 224, 224)
+    # sample["egomotion_history"]  (256,)
+    # sample["visual_history"]     (896,)
+    # sample["trajectory_target"]  (128,)
+    # sample["clip_uuid"]          str
+    # sample["sample_idx"]         int
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TypedDict
+
+import timm
+import pandas as pd
+import torch
+from torch.utils.data import Dataset
+
+from .camera import CAMERA_NAMES, load_camera_frame
+from .egomotion import (
+    MIN_ROWS,
+    _DOWNSAMPLE_STEP,
+    _FUTURE_TIMESTEPS,
+    _HISTORY_TIMESTEPS,
+    load_egomotion,
+)
+
+logger = logging.getLogger(__name__)
+
+_VISUAL_HISTORY_DIM = 896
+_DISCOVERY_CAMERA = "camera_front_wide_120fov"
+
+
+class ClipSample(TypedDict):
+    visual_tiles: torch.Tensor        # (8, 3, 224, 224)
+    egomotion_history: torch.Tensor   # (256,)
+    visual_history: torch.Tensor      # (896,)
+    trajectory_target: torch.Tensor   # (128,)
+    clip_uuid: str
+    sample_idx: int
+
+
+class NvidiaAVDataset(Dataset):
+    """Dataset where each item is one valid (clip_uuid, sample_idx) pair.
+
+    All valid sample indices across all clips are enumerated at construction
+    time. __getitem__ does only I/O — no index arithmetic at call time.
+
+    Args:
+        data_root: Path to the subset directory.
+        camera_names: Camera views to load. Defaults to ``CAMERA_NAMES``.
+        clip_uuids: Optional explicit list of clip UUIDs. If ``None``, all
+            valid clips are discovered automatically. Pass a single-element
+            list for smoke tests or forward pass validation.
+    """
+
+    def __init__(
+        self,
+        data_root: Path | str,
+        backbone_name: str = "swin_tiny_patch4_window7_224.ms_in22k",
+        camera_names: list[str] | None = None,
+        clip_uuids: list[str] | None = None,
+    ) -> None:
+        self.data_root = Path(data_root)
+        self.camera_names = camera_names or CAMERA_NAMES
+
+        # Build the image transform from the backbone's own config so that
+        # preprocessing always matches what the backbone expects.
+        # create_model loads config only — no pretrained weights downloaded here.
+        _backbone = timm.create_model(backbone_name, pretrained=False)
+        data_config = timm.data.resolve_model_data_config(_backbone)
+        self.transform = timm.data.create_transform(**data_config, is_training=False)
+        del _backbone
+
+        clips = clip_uuids if clip_uuids is not None else self._discover_clip_uuids()
+        if not clips:
+            raise ValueError(
+                f"No valid clips found under: {self.data_root / 'camera' / _DISCOVERY_CAMERA}"
+            )
+
+        # Build the flat sample index: list of (clip_uuid, sample_idx, egomotion_timestamp_us).
+        # Precomputing this means __getitem__ never touches pandas.
+        self._samples: list[tuple[str, int, int]] = []
+        for clip_uuid in clips:
+            self._samples.extend(self._valid_samples_for_clip(clip_uuid))
+
+        if not self._samples:
+            raise ValueError("No valid samples found across all clips.")
+
+        logger.info(
+            "NvidiaAVDataset: %d samples from %d clips", len(self._samples), len(clips)
+        )
+
+    def _discover_clip_uuids(self) -> list[str]:
+        """Scan the reference camera directory for clip UUIDs."""
+        discovery_dir = self.data_root / "camera" / _DISCOVERY_CAMERA
+        if not discovery_dir.exists():
+            raise FileNotFoundError(
+                f"Reference camera directory not found: {discovery_dir}"
+            )
+        return sorted(p.name.split(".")[0] for p in discovery_dir.glob("*.mp4"))
+
+    def _valid_samples_for_clip(
+        self, clip_uuid: str
+    ) -> list[tuple[str, int, int]]:
+        """Return all valid (clip_uuid, sample_idx, egomotion_timestamp_us) for one clip.
+
+        A sample_idx is valid when there are _HISTORY_TIMESTEPS rows behind it
+        and _FUTURE_TIMESTEPS rows ahead of it in the downsampled sequence.
+        """
+        parquet_path = (
+            self.data_root / "labels" / "egomotion" / f"{clip_uuid}.egomotion.parquet"
+        )
+        if not parquet_path.exists():
+            logger.warning("Egomotion parquet missing for clip %s, skipping.", clip_uuid)
+            return []
+
+        df = pd.read_parquet(parquet_path)
+        df_ds = df.iloc[::_DOWNSAMPLE_STEP].reset_index(drop=True)
+
+        if len(df_ds) < MIN_ROWS:
+            logger.warning(
+                "Clip %s has only %d rows after downsampling (need %d), skipping.",
+                clip_uuid, len(df_ds), MIN_ROWS,
+            )
+            return []
+
+        min_idx = _HISTORY_TIMESTEPS           # first valid sample_idx
+        max_idx = len(df_ds) - _FUTURE_TIMESTEPS  # last valid sample_idx (inclusive)
+
+        return [
+            (clip_uuid, sample_idx, int(df_ds.iloc[sample_idx]["timestamp"]))
+            for sample_idx in range(min_idx, max_idx + 1)
+        ]
+
+    def __len__(self) -> int:
+        return len(self._samples)
+
+    def __getitem__(self, idx: int) -> ClipSample:
+        clip_uuid, sample_idx, egomotion_timestamp_us = self._samples[idx]
+
+        visual_tiles = load_camera_frame(
+            self.data_root,
+            clip_uuid,
+            egomotion_timestamp_us=egomotion_timestamp_us,
+            transform=self.transform,
+            camera_names=self.camera_names,
+        )
+
+        egomotion_history, trajectory_target = load_egomotion(
+            self.data_root,
+            clip_uuid,
+            sample_idx=sample_idx,
+        )
+
+        visual_history = torch.zeros(_VISUAL_HISTORY_DIM, dtype=torch.float32)
+
+        return ClipSample(
+            visual_tiles=visual_tiles,
+            egomotion_history=egomotion_history,
+            visual_history=visual_history,
+            trajectory_target=trajectory_target,
+            clip_uuid=clip_uuid,
+            sample_idx=sample_idx,
+        )

--- a/Model/data_parsing/nvidia_physical_ai/dataset.py
+++ b/Model/data_parsing/nvidia_physical_ai/dataset.py
@@ -29,12 +29,14 @@ from pathlib import Path
 from typing import TypedDict
 
 import timm
+import numpy as np
 import pandas as pd
 import torch
 from torch.utils.data import Dataset
 
 from .camera import CAMERA_NAMES, load_camera_frame
 from .egomotion import (
+    _EGOMOTION_COLUMNS,
     MIN_ROWS,
     _DOWNSAMPLE_STEP,
     _FUTURE_TIMESTEPS,
@@ -94,12 +96,18 @@ class NvidiaAVDataset(Dataset):
             raise ValueError(
                 f"No valid clips found under: {self.data_root / 'camera' / _DISCOVERY_CAMERA}"
             )
+        
+        self._egomotion_dfs: dict[str, pd.DataFrame] = {}
+        self._camera_timestamps: dict[tuple[str, str], np.ndarray] = {}
 
         # Build the flat sample index: list of (clip_uuid, sample_idx, egomotion_timestamp_us).
         # Precomputing this means __getitem__ never touches pandas.
         self._samples: list[tuple[str, int, int]] = []
         for clip_uuid in clips:
-            self._samples.extend(self._valid_samples_for_clip(clip_uuid))
+            samples = self._valid_samples_for_clip(clip_uuid)
+            if samples:
+                self._samples.extend(samples)
+                self._load_camera_timestamps(clip_uuid)
 
         if not self._samples:
             raise ValueError("No valid samples found across all clips.")
@@ -107,6 +115,18 @@ class NvidiaAVDataset(Dataset):
         logger.info(
             "NvidiaAVDataset: %d samples from %d clips", len(self._samples), len(clips)
         )
+
+    def _load_camera_timestamps(self, clip_uuid: str) -> None:
+        """Load and cache camera timestamp arrays for all cameras in a clip."""
+        for cam_name in self.camera_names:
+            timestamps_path = (
+                self.data_root / "camera" / cam_name
+                / f"{clip_uuid}.{cam_name}.timestamps.parquet"
+            )
+ 
+            self._camera_timestamps[(clip_uuid, cam_name)] = (
+                pd.read_parquet(timestamps_path)["timestamp"].to_numpy()
+            )
 
     def _discover_clip_uuids(self) -> list[str]:
         """Scan the reference camera directory for clip UUIDs."""
@@ -117,14 +137,62 @@ class NvidiaAVDataset(Dataset):
             )
         return sorted(p.name.split(".")[0] for p in discovery_dir.glob("*.mp4"))
 
+    def _validate_clip(self, clip_uuid: str) -> bool:
+        """Validate a clip before adding it to the sample index.
+
+        Checks:
+        - All expected camera video files and timestamp parquets exist.
+
+        Returns True if the clip passes all checks, False otherwise.
+        """
+
+        # Check camera file completeness
+        for cam_name in self.camera_names:
+            cam_dir = self.data_root / "camera" / cam_name
+            video_path = cam_dir / f"{clip_uuid}.{cam_name}.mp4"
+            timestamps_path = cam_dir / f"{clip_uuid}.{cam_name}.timestamps.parquet"
+
+            if not video_path.exists():
+                logger.warning(
+                    "Clip %s: missing video file for camera %s. Skipping.",
+                    clip_uuid, cam_name,
+                )
+                return False
+
+            if not timestamps_path.exists():
+                logger.warning(
+                    "Clip %s: missing timestamps parquet for camera %s. Skipping.",
+                    clip_uuid, cam_name,
+                )
+                return False
+
+        return True
+
+
+    def _validate_egomotion_timestamps(self, clip_uuid: str, df_ds: pd.DataFrame) -> bool:
+        """Check that downsampled egomotion timestamps are strictly monotonically increasing."""
+        timestamps = df_ds["timestamp"].to_numpy()
+        if not np.all(np.diff(timestamps) > 0):
+            logger.warning(
+                "Clip %s: egomotion timestamps are not strictly monotonically increasing. Skipping.",
+                clip_uuid,
+            )
+            return False
+        return True
+
     def _valid_samples_for_clip(
         self, clip_uuid: str
     ) -> list[tuple[str, int, int]]:
         """Return all valid (clip_uuid, sample_idx, egomotion_timestamp_us) for one clip.
+        Also checks whether all required columns are present in the parquet.
 
         A sample_idx is valid when there are _HISTORY_TIMESTEPS rows behind it
         and _FUTURE_TIMESTEPS rows ahead of it in the downsampled sequence.
         """
+
+        if not self._validate_clip(clip_uuid):
+            return []
+        
         parquet_path = (
             self.data_root / "labels" / "egomotion" / f"{clip_uuid}.egomotion.parquet"
         )
@@ -132,7 +200,20 @@ class NvidiaAVDataset(Dataset):
             logger.warning("Egomotion parquet missing for clip %s, skipping.", clip_uuid)
             return []
 
-        df = pd.read_parquet(parquet_path)
+        # Checking for required columns
+        try:
+            df = pd.read_parquet(parquet_path, columns=_EGOMOTION_COLUMNS)
+        except KeyError as e:
+            logger.warning(
+                "Clip %s: egomotion parquet missing columns: %s. Skipping.", clip_uuid, e
+            )
+            return []
+        except Exception as e:
+            logger.warning(
+                "Clip %s: failed to read egomotion parquet: %s. Skipping.", clip_uuid, e
+            )
+            return []
+        
         df_ds = df.iloc[::_DOWNSAMPLE_STEP].reset_index(drop=True)
 
         if len(df_ds) < MIN_ROWS:
@@ -141,9 +222,14 @@ class NvidiaAVDataset(Dataset):
                 clip_uuid, len(df_ds), MIN_ROWS,
             )
             return []
+        
+        if not self._validate_egomotion_timestamps(clip_uuid, df_ds):
+            return []
+        
+        self._egomotion_dfs[clip_uuid] = df_ds  # cache the downsampled df for later use in __getitem__
 
         min_idx = _HISTORY_TIMESTEPS           # first valid sample_idx
-        max_idx = len(df_ds) - _FUTURE_TIMESTEPS  # last valid sample_idx (inclusive)
+        max_idx = len(df_ds) - _FUTURE_TIMESTEPS  - 1   # last valid sample_idx (inclusive) corrected by -1
 
         return [
             (clip_uuid, sample_idx, int(df_ds.iloc[sample_idx]["timestamp"]))
@@ -156,18 +242,25 @@ class NvidiaAVDataset(Dataset):
     def __getitem__(self, idx: int) -> ClipSample:
         clip_uuid, sample_idx, egomotion_timestamp_us = self._samples[idx]
 
+        camera_timestamps = {
+            cam_name: self._camera_timestamps.get((clip_uuid, cam_name))
+            for cam_name in self.camera_names
+        }
+
         visual_tiles = load_camera_frame(
             self.data_root,
             clip_uuid,
             egomotion_timestamp_us=egomotion_timestamp_us,
             transform=self.transform,
             camera_names=self.camera_names,
+            camera_timestamps=camera_timestamps,
         )
 
         egomotion_history, trajectory_target = load_egomotion(
             self.data_root,
             clip_uuid,
             sample_idx=sample_idx,
+            df=self._egomotion_dfs[clip_uuid],
         )
 
         visual_history = torch.zeros(_VISUAL_HISTORY_DIM, dtype=torch.float32)

--- a/Model/data_parsing/nvidia_physical_ai/egomotion.py
+++ b/Model/data_parsing/nvidia_physical_ai/egomotion.py
@@ -1,0 +1,138 @@
+"""Egomotion loading for the NVIDIA PhysicalAI-Autonomous-Vehicles dataset.
+
+The parquet contains 100Hz egomotion with columns:
+    timestamp, qx, qy, qz, qw, x, y, z, vx, vy, vz, ax, ay, az, curvature
+
+Downsamples to 10Hz and produces:
+
+    egomotion_history  (256,) — 64 timesteps before the sample point x 4 signals
+                                [speed, acceleration, yaw_angle, curvature]
+
+    trajectory_target  (128,) — 64 timesteps after the sample point x 2 signals
+                                [acceleration, curvature]
+                                Matches DrivingPolicy's fc3 output exactly.
+
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from physical_ai_av.egomotion import EgomotionState
+
+# Must match DrivingPolicy dimensions. Placing here for package export. 
+_HISTORY_TIMESTEPS = 64         # 6.4 s of past context at 10 Hz
+_FUTURE_TIMESTEPS = 64          # 6.4 s of future prediction at 10 Hz
+_NUM_HISTORY_SIGNALS = 4        # speed, acceleration, yaw_angle, curvature
+_NUM_TARGET_SIGNALS = 2         # acceleration, curvature
+
+EGOMOTION_DIM = _HISTORY_TIMESTEPS * _NUM_HISTORY_SIGNALS   # 256
+TRAJECTORY_DIM = _FUTURE_TIMESTEPS * _NUM_TARGET_SIGNALS    # 128
+
+# Minimum rows in the downsampled sequence for a clip to be usable.
+MIN_ROWS = _HISTORY_TIMESTEPS + _FUTURE_TIMESTEPS  # 128
+
+# The parquet is ~100Hz; downsample to the model's 10Hz.
+# TODO: check sampling integrity (e.g. no missing rows).
+_SOURCE_HZ = 100.0
+_TARGET_HZ = 10.0
+_DOWNSAMPLE_STEP = int(_SOURCE_HZ / _TARGET_HZ)  # keep every 10th row
+
+
+def _to_history_signals(state: EgomotionState) -> np.ndarray:
+    """Extract the 4 history signals from an EgomotionState.
+
+    Returns:
+        Float32 array of shape (T, 4): [speed, acceleration, yaw_angle, curvature].
+    """
+    vx = state.velocity[:, 0]
+    vy = state.velocity[:, 1]
+    speed = np.sqrt(vx ** 2 + vy ** 2)
+    acceleration = state.acceleration[:, 0]
+    yaw_angle = state.pose.rotation.as_euler("ZYX")[:, 0]
+    curvature = state.curvature[:, 0]
+    return np.stack([speed, acceleration, yaw_angle, curvature], axis=1).astype(np.float32)
+
+
+def _to_target_signals(state: EgomotionState) -> np.ndarray:
+    """Extract the 2 trajectory target signals from an EgomotionState.
+
+    Returns:
+        Float32 array of shape (T, 2): [acceleration, curvature].
+    """
+    acceleration = state.acceleration[:, 0]
+    curvature = state.curvature[:, 0]
+    return np.stack([acceleration, curvature], axis=1).astype(np.float32)
+
+
+def _load_downsampled_df(data_root: Path, clip_uuid: str) -> pd.DataFrame:
+    """Load and downsample the egomotion parquet to 10Hz."""
+
+    parquet_path = data_root / "labels" / "egomotion" / f"{clip_uuid}.egomotion.parquet"
+    if not parquet_path.exists():
+        raise FileNotFoundError(f"Egomotion parquet not found: {parquet_path}")
+
+    df = pd.read_parquet(parquet_path)
+    if df.empty:
+        raise ValueError(f"Egomotion parquet is empty: {parquet_path}")
+
+    return df.iloc[::_DOWNSAMPLE_STEP].reset_index(drop=True)
+
+
+def load_egomotion(
+    data_root: Path | str,
+    clip_uuid: str,
+    sample_idx: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Load egomotion history and trajectory target in a single parquet read.
+
+    Selects a sample point within the clip, takes the 64 timesteps before it
+    as the egomotion history, and the 64 timesteps after it as the trajectory
+    target. Both windows are always fully populated — no padding.
+
+    Args:
+        data_root: Root directory of the dataset.
+        clip_uuid: UUID of the clip to load.
+        sample_idx: Index into the downsampled (10Hz) sequence to treat as
+            the current moment. Must satisfy:
+                64 <= sample_idx <= len(df) - 64
+            Defaults to the midpoint of the valid range. During training,
+            pass a random value in the valid range to augment over time
+            within the clip.
+
+    Returns:
+        egomotion_history: Float tensor of shape ``(256,)``.
+        trajectory_target: Float tensor of shape ``(128,)``.
+    """
+    df = _load_downsampled_df(Path(data_root), clip_uuid)
+
+    if len(df) < MIN_ROWS:
+        raise ValueError(
+            f"Clip {clip_uuid} has only {len(df)} rows after downsampling "
+            f"(need at least {MIN_ROWS}). Clip may be too short."
+        )
+
+    min_idx = _HISTORY_TIMESTEPS                   # 64
+    max_idx = len(df) - _FUTURE_TIMESTEPS          # e.g. 136 for a 200-row clip
+
+    if sample_idx is None:
+        sample_idx = (min_idx + max_idx) // 2
+    elif not (min_idx <= sample_idx <= max_idx):
+        raise ValueError(
+            f"sample_idx {sample_idx} out of valid range [{min_idx}, {max_idx}] "
+            f"for clip {clip_uuid} ({len(df)} rows)."
+        )
+
+    history_df = df.iloc[sample_idx - _HISTORY_TIMESTEPS:sample_idx].reset_index(drop=True)
+    future_df = df.iloc[sample_idx:sample_idx + _FUTURE_TIMESTEPS].reset_index(drop=True)
+
+    history_signals = _to_history_signals(EgomotionState.from_egomotion_df(history_df))
+    future_signals = _to_target_signals(EgomotionState.from_egomotion_df(future_df))
+
+    return (
+        torch.from_numpy(history_signals.flatten()),   # (256,)
+        torch.from_numpy(future_signals.flatten()),    # (128,)
+    )

--- a/Model/data_parsing/nvidia_physical_ai/egomotion.py
+++ b/Model/data_parsing/nvidia_physical_ai/egomotion.py
@@ -33,7 +33,7 @@ EGOMOTION_DIM = _HISTORY_TIMESTEPS * _NUM_HISTORY_SIGNALS   # 256
 TRAJECTORY_DIM = _FUTURE_TIMESTEPS * _NUM_TARGET_SIGNALS    # 128
 
 # Minimum rows in the downsampled sequence for a clip to be usable.
-MIN_ROWS = _HISTORY_TIMESTEPS + _FUTURE_TIMESTEPS  # 128
+MIN_ROWS = _HISTORY_TIMESTEPS + _FUTURE_TIMESTEPS + 1  # 129
 
 # The parquet is ~100Hz; downsample to the model's 10Hz.
 # TODO: check sampling integrity (e.g. no missing rows).
@@ -41,6 +41,8 @@ _SOURCE_HZ = 100.0
 _TARGET_HZ = 10.0
 _DOWNSAMPLE_STEP = int(_SOURCE_HZ / _TARGET_HZ)  # keep every 10th row
 
+# To read in just the required columns
+_EGOMOTION_COLUMNS = ["timestamp", "qx", "qy", "qz", "qw", "x", "y", "z", "vx", "vy", "vz", "ax", "ay", "az", "curvature"]
 
 def _to_history_signals(state: EgomotionState) -> np.ndarray:
     """Extract the 4 history signals from an EgomotionState.
@@ -75,7 +77,7 @@ def _load_downsampled_df(data_root: Path, clip_uuid: str) -> pd.DataFrame:
     if not parquet_path.exists():
         raise FileNotFoundError(f"Egomotion parquet not found: {parquet_path}")
 
-    df = pd.read_parquet(parquet_path)
+    df = pd.read_parquet(parquet_path, columns=_EGOMOTION_COLUMNS)
     if df.empty:
         raise ValueError(f"Egomotion parquet is empty: {parquet_path}")
 
@@ -86,6 +88,7 @@ def load_egomotion(
     data_root: Path | str,
     clip_uuid: str,
     sample_idx: int | None = None,
+    df: pd.DataFrame | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Load egomotion history and trajectory target in a single parquet read.
 
@@ -98,7 +101,7 @@ def load_egomotion(
         clip_uuid: UUID of the clip to load.
         sample_idx: Index into the downsampled (10Hz) sequence to treat as
             the current moment. Must satisfy:
-                64 <= sample_idx <= len(df) - 64
+                _HISTORY_TIMESTEPS <= sample_idx <= len(df) - _FUTURE_TIMESTEPS - 1
             Defaults to the midpoint of the valid range. During training,
             pass a random value in the valid range to augment over time
             within the clip.
@@ -107,7 +110,8 @@ def load_egomotion(
         egomotion_history: Float tensor of shape ``(256,)``.
         trajectory_target: Float tensor of shape ``(128,)``.
     """
-    df = _load_downsampled_df(Path(data_root), clip_uuid)
+    if df is None:
+        df = _load_downsampled_df(data_root, clip_uuid)
 
     if len(df) < MIN_ROWS:
         raise ValueError(
@@ -116,7 +120,7 @@ def load_egomotion(
         )
 
     min_idx = _HISTORY_TIMESTEPS                   # 64
-    max_idx = len(df) - _FUTURE_TIMESTEPS          # e.g. 136 for a 200-row clip
+    max_idx = len(df) - _FUTURE_TIMESTEPS - 1         # e.g. 135 for a 200-row clip
 
     if sample_idx is None:
         sample_idx = (min_idx + max_idx) // 2
@@ -127,7 +131,7 @@ def load_egomotion(
         )
 
     history_df = df.iloc[sample_idx - _HISTORY_TIMESTEPS:sample_idx].reset_index(drop=True)
-    future_df = df.iloc[sample_idx:sample_idx + _FUTURE_TIMESTEPS].reset_index(drop=True)
+    future_df = df.iloc[sample_idx + 1:sample_idx + 1 + _FUTURE_TIMESTEPS].reset_index(drop=True)
 
     history_signals = _to_history_signals(EgomotionState.from_egomotion_df(history_df))
     future_signals = _to_target_signals(EgomotionState.from_egomotion_df(future_df))

--- a/Model/data_parsing/nvidia_physical_ai/forward_pass_test.py
+++ b/Model/data_parsing/nvidia_physical_ai/forward_pass_test.py
@@ -1,0 +1,82 @@
+"""
+Forward pass test for AutoE2E using the NVIDIA PhysicalAI-Autonomous-Vehicles dataset.
+
+Loads a single clip, runs one batch through the data pipeline, and optionally
+through the model. No backprop — this is a data pipeline and model integration
+check only.
+
+Usage:
+    python Model/data_parsing/nvidia_physical_ai/forward_pass_test.py \
+        --dataset_root /path/to/nvidia_av_camera_subset \
+        --clip_uuid fd1d1b6b-59bf-4292-8295-5028aa6aa5e3
+"""
+
+import argparse
+import pathlib
+import sys
+
+import torch
+from torch.utils.data import DataLoader
+
+_MODEL_DIR = pathlib.Path(__file__).parent.parent.parent.resolve()
+sys.path.insert(0, str(_MODEL_DIR))
+
+from data_parsing.nvidia_physical_ai import NvidiaAVDataset
+
+
+def main(dataset_root: str, clip_uuid: str, batch_size: int = 4) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+
+    if clip_uuid is not None:
+        clip_uuids = [clip_uuid]
+    else:
+        parquet_dir = pathlib.Path(dataset_root) / "labels" / "egomotion"
+        clip_uuids = [p.stem.split(".")[0] for p in sorted(parquet_dir.glob("*.egomotion.parquet"))]
+        print(f"Discovered {len(clip_uuids)} clips")
+
+    dataset = NvidiaAVDataset(
+        data_root=dataset_root,
+        backbone_name="swin_tiny_patch4_window7_224.ms_in22k",
+        clip_uuids=clip_uuids,
+    )
+    print(f"Valid samples in clip: {len(dataset)}")
+
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False, num_workers=0)
+
+    batch = next(iter(loader))
+    visual_tiles = batch["visual_tiles"].to(device)           # (B, 8, 3, 224, 224)
+    visual_history = batch["visual_history"].to(device)       # (B, 896)
+    egomotion_history = batch["egomotion_history"].to(device) # (B, 256)
+    trajectory_target = batch["trajectory_target"].to(device) # (B, 128)
+
+    print(f"visual_tiles: {tuple(visual_tiles.shape)}")
+    print(f"egomotion_history: {tuple(egomotion_history.shape)}")
+    print(f"trajectory_target: {tuple(trajectory_target.shape)}")
+    print(f"sample_idx: {batch['sample_idx'].tolist()}")
+
+    # --- forward pass ---
+    from model_components.auto_e2e import AutoE2E
+    model = AutoE2E().to(device)
+    trajectory_, compressed_, future_ = model(visual_tiles, visual_history, egomotion_history)
+    print(f"trajectory output: {tuple(trajectory_.shape)}") 
+    print(f"compressed visual feature output: {tuple(compressed_.shape)}") 
+    print(f"future visual features: {[tuple(f.shape) for f in future_]}") 
+    # --------------------
+
+    # TODO (training): wire in loss and backprop
+    # loss = F.mse_loss(trajectory, trajectory_target)
+    # loss.backward()
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset_root", type=str, required=True)
+    parser.add_argument("--clip_uuid", type=str, default=None,
+                    help="Single clip UUID to test. Defaults to all clips under dataset_root.")
+    parser.add_argument("--batch_size", type=int, default=4)
+    args = parser.parse_args()
+
+    main(args.dataset_root, args.clip_uuid, args.batch_size)

--- a/Model/data_parsing/nvidia_physical_ai/forward_pass_test.py
+++ b/Model/data_parsing/nvidia_physical_ai/forward_pass_test.py
@@ -6,14 +6,23 @@ through the model. No backprop — this is a data pipeline and model integration
 check only.
 
 Usage:
-    python Model/data_parsing/nvidia_physical_ai/forward_pass_test.py \
-        --dataset_root /path/to/nvidia_av_camera_subset \
+    cd Model/data_parsing/nvidia_physical_ai
+    python forward_pass_test.py \
+        --dataset_root data \
         --clip_uuid fd1d1b6b-59bf-4292-8295-5028aa6aa5e3
+
+    # Offline / CI (no pretrained weights):
+    cd Model/data_parsing/nvidia_physical_ai
+    python forward_pass_test.py \
+        --dataset_root data \
+        --clip_uuid fd1d1b6b-59bf-4292-8295-5028aa6aa5e3 \
+        --no-pretrained
 """
 
 import argparse
 import pathlib
 import sys
+import time
 
 import torch
 from torch.utils.data import DataLoader
@@ -22,11 +31,15 @@ _MODEL_DIR = pathlib.Path(__file__).parent.parent.parent.resolve()
 sys.path.insert(0, str(_MODEL_DIR))
 
 from data_parsing.nvidia_physical_ai import NvidiaAVDataset
+from model_components.auto_e2e import AutoE2E
 
 
-def main(dataset_root: str, clip_uuid: str, batch_size: int = 4) -> None:
+def main(dataset_root: str, clip_uuid: str, batch_size: int = 4, pretrained_backbone: bool = True) -> None:
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Device: {device}")
+
+    if device.type == "cuda":
+        torch.cuda.reset_peak_memory_stats()
 
     if clip_uuid is not None:
         clip_uuids = [clip_uuid]
@@ -35,12 +48,18 @@ def main(dataset_root: str, clip_uuid: str, batch_size: int = 4) -> None:
         clip_uuids = [p.stem.split(".")[0] for p in sorted(parquet_dir.glob("*.egomotion.parquet"))]
         print(f"Discovered {len(clip_uuids)} clips")
 
+    t0 = time.time()
     dataset = NvidiaAVDataset(
         data_root=dataset_root,
         backbone_name="swin_tiny_patch4_window7_224.ms_in22k",
         clip_uuids=clip_uuids,
     )
     print(f"Valid samples in clip: {len(dataset)}")
+
+    egomotion_mb = sum(df.memory_usage(deep=True).sum() for df in dataset._egomotion_dfs.values()) / (1024 ** 2)
+    timestamps_mb = sum(arr.nbytes for arr in dataset._camera_timestamps.values()) / (1024 ** 2)
+    print(f"Egomotion cache: {egomotion_mb:.1f} MB")
+    print(f"Timestamp cache: {timestamps_mb:.1f} MB")
 
     loader = DataLoader(dataset, batch_size=batch_size, shuffle=False, num_workers=0)
 
@@ -49,19 +68,26 @@ def main(dataset_root: str, clip_uuid: str, batch_size: int = 4) -> None:
     visual_history = batch["visual_history"].to(device)       # (B, 896)
     egomotion_history = batch["egomotion_history"].to(device) # (B, 256)
     trajectory_target = batch["trajectory_target"].to(device) # (B, 128)
+    t_dataset = time.time() - t0
+
+    print(f"Dataset creation for {len(clip_uuids)} clips: {t_dataset:.2f}s")
 
     print(f"visual_tiles: {tuple(visual_tiles.shape)}")
     print(f"egomotion_history: {tuple(egomotion_history.shape)}")
     print(f"trajectory_target: {tuple(trajectory_target.shape)}")
-    print(f"sample_idx: {batch['sample_idx'].tolist()}")
 
-    # --- forward pass ---
-    from model_components.auto_e2e import AutoE2E
-    model = AutoE2E().to(device)
+    # --------------------
+    # forward pass
+    model = AutoE2E(pretrained_backbone=pretrained_backbone).to(device)
+
+    t0 = time.time()
     trajectory_, compressed_, future_ = model(visual_tiles, visual_history, egomotion_history)
-    print(f"trajectory output: {tuple(trajectory_.shape)}") 
-    print(f"compressed visual feature output: {tuple(compressed_.shape)}") 
-    print(f"future visual features: {[tuple(f.shape) for f in future_]}") 
+    t_forward = time.time() - t0
+    print(f"Forward pass: {t_forward:.2f}s")
+
+    print(f"trajectory output: {tuple(trajectory_.shape)}")
+    print(f"compressed visual feature output: {tuple(compressed_.shape)}")
+    print(f"future visual features: {[tuple(f.shape) for f in future_]}")
     # --------------------
 
     # TODO (training): wire in loss and backprop
@@ -77,6 +103,8 @@ if __name__ == "__main__":
     parser.add_argument("--clip_uuid", type=str, default=None,
                     help="Single clip UUID to test. Defaults to all clips under dataset_root.")
     parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--no-pretrained",  action="store_true",
+                    help="Skip downloading pretrained weights for the backbone and initialize randomly.")
     args = parser.parse_args()
 
-    main(args.dataset_root, args.clip_uuid, args.batch_size)
+    main(args.dataset_root, args.clip_uuid, args.batch_size, pretrained_backbone = not args.no_pretrained)

--- a/Model/data_parsing/nvidia_physical_ai/forward_pass_test.py
+++ b/Model/data_parsing/nvidia_physical_ai/forward_pass_test.py
@@ -51,7 +51,7 @@ def main(dataset_root: str, clip_uuid: str, batch_size: int = 4, pretrained_back
     t0 = time.time()
     dataset = NvidiaAVDataset(
         data_root=dataset_root,
-        backbone_name="swin_tiny_patch4_window7_224.ms_in22k",
+        backbone_name="swinv2_tiny_window8_256",
         clip_uuids=clip_uuids,
     )
     print(f"Valid samples in clip: {len(dataset)}")

--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -6,13 +6,13 @@ from .future_state import FutureState
 
 
 class AutoE2E(nn.Module):
-    def __init__(self, backbone="swin_v2_tiny", num_views=8, fusion_mode="concat"):
+    def __init__(self, backbone="swin_v2_tiny", num_views=8, fusion_mode="concat", pretrained_backbone=True):
         super(AutoE2E, self).__init__()
 
         self.num_views = num_views
 
         # Backbone feature extractor
-        self.Backbone = Backbone(backbone=backbone)
+        self.Backbone = Backbone(backbone=backbone, pretrained=pretrained_backbone)
 
         # Multi-scale feature fusion with view unification
         self.FeatureFusion = FeatureFusion(num_views=num_views, fusion_mode=fusion_mode)

--- a/Model/model_components/backbone.py
+++ b/Model/model_components/backbone.py
@@ -10,4 +10,4 @@ class Backbone(nn.Module):
          
     def forward(self, image):
         features = self.backbone(image)
-        return features
+        return features   

--- a/Model/model_components/backbone.py
+++ b/Model/model_components/backbone.py
@@ -2,12 +2,12 @@ import torch.nn as nn
 from .backbones import build_backbone
 
 class Backbone(nn.Module):
-    def __init__(self, backbone="swin_v2_tiny"):
+    def __init__(self, backbone="swin_v2_tiny", pretrained: bool = True):
         super().__init__()
 
         # Pre-trained backbone (pluggable)
-        self.backbone = build_backbone(backbone)
+        self.backbone = build_backbone(backbone, pretrained=pretrained)
          
     def forward(self, image):
         features = self.backbone(image)
-        return features   
+        return features

--- a/Model/model_components/backbones/__init__.py
+++ b/Model/model_components/backbones/__init__.py
@@ -1,15 +1,18 @@
 import timm
 
 BACKBONE_REGISTRY = {
-    "swin_v2_tiny": lambda **kwargs: timm.create_model("swinv2_tiny_window8_256", pretrained=True, features_only=True, **kwargs),
-    "conv_next_v2_tiny": lambda **kwargs: timm.create_model("convnextv2_tiny", pretrained=True, features_only=True, **kwargs)
+    "swin_v2_tiny": lambda pretrained=True, **kwargs: timm.create_model(
+        "swinv2_tiny_window8_256", pretrained=pretrained, features_only=True, **kwargs
+    ),
+    "conv_next_v2_tiny": lambda pretrained=True, **kwargs: timm.create_model(
+        "convnextv2_tiny", pretrained=pretrained, features_only=True, **kwargs
+    ),
 }
 
-
-def build_backbone(backbone, **kwargs):
+def build_backbone(backbone, pretrained=True, **kwargs):
     if backbone not in BACKBONE_REGISTRY:
         raise ValueError(
             f"Unknown backbone '{backbone}'. "
             f"Available: {list(BACKBONE_REGISTRY.keys())}"
         )
-    return BACKBONE_REGISTRY[backbone](**kwargs)
+    return BACKBONE_REGISTRY[backbone](pretrained=pretrained, **kwargs)


### PR DESCRIPTION
## Data parsing library for NVIDIA PhysicalAI dataset

Addresses #5 

### What's added

- `dataset.py` — `NvidiaAVDataset`, a `torch.utils.data.Dataset` where each item is a valid `(clip_uuid, sample_idx)` pair.
- `camera.py` — decodes camera frames from `.mp4` files using `physical_ai_av.video.SeekVideoReader`. Image preprocessing is derived from the backbone's own config via `timm.data.resolve_model_data_config`.
- `egomotion.py` — parses egomotion using `physical_ai_av.egomotion.EgomotionState`. Downsamples from ~100 Hz to 10 Hz before windowing. Produces both the history tensor `(256,)` and the trajectory supervision target `(128,)` that feeds into the trajectory loss.
- `forward_pass_test.py` — validates the data pipeline with a single forward pass.

### To note:

- **This uses the NVIDIA `physical_ai_av` SDK** (`pip install git+https://github.com/NVlabs/physical_ai_av.git`) for video decoding and egomotion.
- **Egomotion history uses `curvature` directly** (rad/m, available as a column in the egomotion parquet via `EgomotionState`) instead of `yaw_rate` as a proxy. The 4 input signals are `[speed, acceleration, yaw_angle, curvature]`.
- **Trajectory target** is `[acceleration, curvature]` over 64 future timesteps = `(128,)`, matching `DrivingPolicy`'s output.
- **Camera–egomotion alignment** is done by matching timestamps in shared microsecond clip-relative time (egomotion is ~100 Hz, camera is ~30 Hz, neither is perfectly locked).
- **Map tile** (8th view) is a zero placeholder for now. The dataset does not include rendered map tiles. `_make_map_tile` in `camera.py` is the single point to replace when a renderer is available.

@m-zain-khawaja 