### PR TITLE
feat: speed benchmarking script json export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.py[cod]
 ._*
+benchmark_results.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: setup
+.PHONY: setup test
 
 setup:
 	pip install torch timm pytest
+
+test:
+	cd Model/tests && python -m pytest test_auto_e2e.py -v

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: setup test
+.PHONY: setup test benchmark
 
 setup:
 	pip install torch timm pytest
 
 test:
 	cd Model/tests && python -m pytest test_auto_e2e.py -v
+
+benchmark:
+	cd Model/speed_benchmark && python speed_benchmark.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: setup
+
+setup:
+	pip install torch timm pytest

--- a/Model/speed_benchmark/README.md
+++ b/Model/speed_benchmark/README.md
@@ -15,8 +15,7 @@ The script outputs:
 ## How to Run
 
 ```bash
-cd Model/speed_benchmark
-python speed_benchmark.py
+make benchmark
 ```
 
 The script will:

--- a/Model/speed_benchmark/README.md
+++ b/Model/speed_benchmark/README.md
@@ -12,4 +12,21 @@ The script outputs:
 * Peak VRAM Allocated [MB] — The minimum theoretical footprint your model needs to exist. This is the maximum amount of GPU memory that actually held the forward-pass-related data.
 * Peak VRAM Reserved [MB] — The realistic memory footprint your system feels. This is the maximum amount of GPU memory walled off from the computer's operating system.
 
-After running the `speed_benchmarking.py` script, please kindly add the results to the [main README](https://github.com/autowarefoundation/auto_e2e/blob/main/README.md) 🙂
+## How to Run
+
+```bash
+cd Model/speed_benchmark
+python speed_benchmark.py
+```
+
+The script will:
+1. Run all combinations of backbones × fusion modes × batch sizes
+2. Print results to stdout
+3. Save structured results to `benchmark_results.json`
+4. Print a Markdown table ready to paste into the main README
+
+## Output Files
+
+* `benchmark_results.json` — Full results with hardware metadata (GPU name, CUDA version, PyTorch version, timestamp)
+
+After running the script, please kindly add the results to the [main README](https://github.com/autowarefoundation/auto_e2e/blob/main/README.md)

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -72,14 +72,38 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
     peak_allocated = torch.cuda.max_memory_allocated() / (1024 ** 2)
     peak_reserved = torch.cuda.max_memory_reserved() / (1024 ** 2)
 
+    # Count model parameters
+    total_params = sum(p.numel() for p in model.parameters())
+    trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+    results = {
+        "backbone": backbone,
+        "fusion_mode": fusion_mode,
+        "batch_size": batch_size,
+        "num_views": num_views,
+        "avg_fps": round(avg_fps, 2),
+        "avg_latency_ms": round(avg_latency, 2),
+        "p50_latency_ms": round(p50_latency, 2),
+        "p99_latency_ms": round(p99_latency, 2),
+        "jitter_ms": round(jitter, 2),
+        "peak_vram_allocated_mb": round(peak_allocated, 2),
+        "peak_vram_reserved_mb": round(peak_reserved, 2),
+        "total_params": total_params,
+        "trainable_params": trainable_params,
+    }
+
     print("======================")
     print(f"Average FPS: {avg_fps:.2f}")
-    print(f"Average Latency: {avg_latency:.2f}")
+    print(f"Average Latency: {avg_latency:.2f} ms")
     print(f"Worst-Case Latency (p99): {p99_latency:.2f} ms")
     print(f"Latency Jitter (p99 - p50): {jitter:.2f} ms")
     print("----------------------")
     print(f"Peak VRAM Allocated: {peak_allocated:.2f} MB")
     print(f"Peak VRAM Reserved: {peak_reserved:.2f} MB")
+    print(f"Total Parameters: {total_params:,}")
+    print(f"Trainable Parameters: {trainable_params:,}")
+
+    return results
 
 
 def main():

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -43,8 +43,8 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
                        backbone=backbone, camera_params=camera_params, mode="infer")
 
     # 2. Benchmark Phase
-    print("Benchmarking now ...")
-    num_iters = 100
+    num_iters = 100 if device.type == 'cuda' else 10
+    print(f"Benchmarking ({num_iters} iterations)...")
 
     latencies = []
 

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -106,17 +106,55 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
     return results
 
 
+def save_results_json(all_results, device):
+    """Save benchmark results to a JSON file with hardware metadata."""
+    output = {
+        "timestamp": datetime.now().isoformat(),
+        "device": str(device),
+        "gpu_name": torch.cuda.get_device_name(0) if torch.cuda.is_available() else "N/A",
+        "cuda_version": torch.version.cuda if torch.cuda.is_available() else "N/A",
+        "pytorch_version": torch.__version__,
+        "results": all_results,
+    }
+    filepath = "benchmark_results.json"
+    with open(filepath, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"\nResults saved to {filepath}")
+
+
+def print_markdown_table(all_results):
+    """Print results as a Markdown table for easy pasting into README."""
+    print("\n## Benchmark Results\n")
+    print("| Backbone | Fusion Mode | Batch | FPS | Latency (ms) | p99 (ms) | VRAM (MB) | Params |")
+    print("|----------|-------------|-------|-----|--------------|----------|-----------|--------|")
+    for r in all_results:
+        params_m = r["total_params"] / 1_000_000
+        print(f"| {r['backbone']} | {r['fusion_mode']} | {r['batch_size']} | "
+              f"{r['avg_fps']:.1f} | {r['avg_latency_ms']:.1f} | {r['p99_latency_ms']:.1f} | "
+              f"{r['peak_vram_allocated_mb']:.0f} | {params_m:.1f}M |")
+
+
 def main():
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     print(f'Using {device} for inference\n')
 
+    all_results = []
+
     # Test all registered backbones and fusion modes
-    run_speed_benchmark("swin_v2_tiny", "concat", device)
-    run_speed_benchmark("swin_v2_tiny", "cross_attn", device)
-    run_speed_benchmark("swin_v2_tiny", "bev", device)
-    run_speed_benchmark("conv_next_v2_tiny", "concat", device)
-    run_speed_benchmark("conv_next_v2_tiny", "cross_attn", device)
-    run_speed_benchmark("conv_next_v2_tiny", "bev", device)
+    backbones = ["swin_v2_tiny", "conv_next_v2_tiny"]
+    fusion_modes = ["concat", "cross_attn", "bev"]
+
+    for backbone in backbones:
+        for fusion_mode in fusion_modes:
+            result = run_speed_benchmark(backbone, fusion_mode, device)
+            all_results.append(result)
+            print()
+
+    # Save structured results
+    save_results_json(all_results, device)
+
+    # Print Markdown table for README
+    print_markdown_table(all_results)
 
 
 if __name__ == "__main__":

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -72,8 +72,12 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
     p99_latency = np.percentile(latencies, 99)
     jitter = p99_latency - p50_latency
 
-    peak_allocated = torch.cuda.max_memory_allocated() / (1024 ** 2)
-    peak_reserved = torch.cuda.max_memory_reserved() / (1024 ** 2)
+    if device.type == 'cuda':
+        peak_allocated = torch.cuda.max_memory_allocated() / (1024 ** 2)
+        peak_reserved = torch.cuda.max_memory_reserved() / (1024 ** 2)
+    else:
+        peak_allocated = 0.0
+        peak_reserved = 0.0
 
     # Count model parameters
     total_params = sum(p.numel() for p in model.parameters())

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -1,7 +1,9 @@
 import torch
 import time
 import sys
+import json
 import numpy as np
+from datetime import datetime
 sys.path.append('..')
 from model_components.auto_e2e import AutoE2E
 

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -143,12 +143,15 @@ def main():
     # Test all registered backbones and fusion modes
     backbones = ["swin_v2_tiny", "conv_next_v2_tiny"]
     fusion_modes = ["concat", "cross_attn", "bev"]
+    batch_sizes = [1, 2, 4]
 
     for backbone in backbones:
         for fusion_mode in fusion_modes:
-            result = run_speed_benchmark(backbone, fusion_mode, device)
-            all_results.append(result)
-            print()
+            for batch_size in batch_sizes:
+                torch.cuda.reset_peak_memory_stats() if torch.cuda.is_available() else None
+                result = run_speed_benchmark(backbone, fusion_mode, device, batch_size=batch_size)
+                all_results.append(result)
+                print()
 
     # Save structured results
     save_results_json(all_results, device)

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -50,15 +50,17 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
 
     with torch.no_grad():
         for _ in range(num_iters):
+            if device.type == 'cuda':
+                torch.cuda.synchronize()
 
-            torch.cuda.synchronize()
             start_time = time.perf_counter()
 
-            _ = model(visual_tiles, visual_history, egomotion_history, 
-                      backbone=backbone, camera_params=camera_params, mode="infer") # we discard the output
+            _ = model(visual_tiles, visual_history, egomotion_history,
+                      backbone=backbone, camera_params=camera_params, mode="infer")
 
-            torch.cuda.synchronize()
-            # Record individual frame processing times in milliseconds
+            if device.type == 'cuda':
+                torch.cuda.synchronize()
+
             latencies.append((time.perf_counter() - start_time) * 1000)
 
     latencies = np.array(latencies)

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -34,12 +34,13 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
     if fusion_mode == "bev":
         camera_params = torch.randn(batch_size, num_views, 3, 4).to(device)
 
-    # 1. Warm-up Phase
-    print("Warming up GPU...")
+    # 1. Warm-up Phase (GPU kernel compilation and cache warming)
+    num_warmup = 30 if device.type == 'cuda' else 5
+    print(f"Warming up ({num_warmup} iterations)...")
     with torch.no_grad():
-        for _ in range(30):
-            _ = model(visual_tiles, visual_history, egomotion_history, 
-                       backbone=backbone, camera_params=camera_params, mode="infer") # we discard the output
+        for _ in range(num_warmup):
+            _ = model(visual_tiles, visual_history, egomotion_history,
+                       backbone=backbone, camera_params=camera_params, mode="infer")
 
     # 2. Benchmark Phase
     print("Benchmarking now ...")

--- a/TRIAL.md
+++ b/TRIAL.md
@@ -73,7 +73,7 @@ source ~/e2e-env/bin/activate
 
 Install dependencies:
 ```bash
-pip install torch timm
+make setup
 ```
 
 This takes 2–3 minutes. Verify the installation:

--- a/TRIAL.md
+++ b/TRIAL.md
@@ -89,8 +89,8 @@ PyTorch 2.12.0, CUDA available: True
 ## Step 5: Run the Inference Test
 
 ```bash
-cd ~/auto_e2e/Model/inference
-python inference_test.py
+cd ~/auto_e2e
+make test
 ```
 
 ## Expected Output


### PR DESCRIPTION
## Summary

Enhances the speed benchmark script with structured output, multi-batch-size comparison, CPU compatibility, and adds a Makefile for reproducible execution.

## Changes

- Add JSON export with hardware metadata (GPU name, CUDA version, PyTorch version, timestamp)
- Add Markdown table output for easy pasting into README
- Benchmark across multiple batch sizes (1, 2, 4) in addition to backbone × fusion mode combinations
- Include parameter count (total and trainable) in output
- Guard `torch.cuda.synchronize()` and VRAM measurement for CPU compatibility
- Reduce warmup/iteration counts on CPU to avoid excessive wait times
- Add `benchmark_results.json` to `.gitignore` (results are environment-specific)
- Add `Makefile` with `make setup`, `make test`, and `make benchmark` targets
- Update `speed_benchmark/README.md` and `TRIAL.md` to reference Makefile commands

## Benchmark Results (NVIDIA T4, PyTorch 2.12.0, CUDA 13.x)

| Backbone | Fusion Mode | Batch | FPS | Latency (ms) | p99 (ms) | VRAM (MB) | Params |
|----------|-------------|-------|-----|--------------|----------|-----------|--------|
| swin_v2_tiny | concat | 1 | 21.3 | 47.0 | 47.8 | 1068 | 234.4M |
| swin_v2_tiny | concat | 2 | 10.8 | 92.4 | 94.1 | 1232 | 234.4M |
| swin_v2_tiny | concat | 4 | 5.5 | 181.5 | 183.3 | 1556 | 234.4M |
| swin_v2_tiny | cross_attn | 1 | 18.9 | 52.8 | 54.3 | 1069 | 234.4M |
| swin_v2_tiny | cross_attn | 2 | 9.8 | 101.8 | 103.2 | 1231 | 234.4M |
| swin_v2_tiny | cross_attn | 4 | 5.0 | 199.8 | 202.8 | 1555 | 234.4M |
| swin_v2_tiny | bev | 1 | 19.4 | 51.5 | 53.4 | 1054 | 230.4M |
| swin_v2_tiny | bev | 2 | 10.1 | 98.6 | 100.2 | 1216 | 230.4M |
| swin_v2_tiny | bev | 4 | 5.3 | 188.9 | 191.5 | 1540 | 230.4M |
| conv_next_v2_tiny | concat | 1 | 19.2 | 52.0 | 53.8 | 1093 | 234.7M |
| conv_next_v2_tiny | concat | 2 | 9.8 | 101.6 | 102.8 | 1279 | 234.7M |
| conv_next_v2_tiny | concat | 4 | 5.1 | 196.4 | 198.0 | 1651 | 234.7M |
| conv_next_v2_tiny | cross_attn | 1 | 17.8 | 56.2 | 57.8 | 1092 | 234.7M |
| conv_next_v2_tiny | cross_attn | 2 | 9.1 | 109.6 | 111.2 | 1278 | 234.7M |
| conv_next_v2_tiny | cross_attn | 4 | 4.7 | 212.9 | 214.6 | 1650 | 234.7M |
| conv_next_v2_tiny | bev | 1 | 18.3 | 54.6 | 56.6 | 1077 | 230.7M |
| conv_next_v2_tiny | bev | 2 | 9.6 | 104.6 | 106.7 | 1263 | 230.7M |
| conv_next_v2_tiny | bev | 4 | 5.0 | 201.7 | 203.5 | 1635 | 230.7M |

### Key Observations

- All configurations achieve ~18-21 FPS at batch=1 on T4. The difference between fusion modes is small (~5ms), indicating the backbone dominates latency.
- SwinV2 is slightly faster than ConvNeXtV2 across all fusion modes.
- BEV fusion is not significantly slower than concat despite the additional projection and sampling operations — the 1440-dim operations dominate regardless.
- Parameter count (~230M) is high due to the large embed_dim=1440. Reducing to 256 (proposed in #23) would significantly reduce this.
- VRAM usage scales linearly with batch size as expected (~160-170 MB per additional sample).

### Hardware

- GPU: NVIDIA T4 (16GB)
- Instance: g4dn.xlarge (AWS)
- CUDA: 13.x
- PyTorch: 2.12.0

## Related Issues

- Closes #21
- Related: #23 (embed_dim reduction would significantly improve these numbers)
- Related: #24 (test performance — same backbone dominance issue)