### PR TITLE
feat: Added speed benchmark results for NVIDIA RTX 5080

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ To learn more about how to participate in this project, please read the [onboard
 
 </details>
 
+### NVIDIA GeForce RTX 5080 GPU 
+<details open>
+  <summary>Toggle view</summary>
+
+
+| Backbone | Fusion Method | FPS | Average Latency [ms] | Worst-Case Latency [ms] | Latency Jitter [ms] | Peak VRAM Allocated [MB] | Peak VRAM Reserved [MB] |
+| -------- | ------------- | --- | --------------- | ------------------ | -------------- | ------------------- | ------------------ |
+| SwinV2 Tiny | Feature Concat | 118.09 | 8.47 | 8.83 | 0.34 | 1068.52 | 1218.00 |
+| SwinV2 Tiny | Spatial Attention | 106.45 | 9.39 | 9.74 | 0.29 | 1070.18 | 1218.00 |
+| SwinV2 Tiny | BEV Fusion | 103.26 | 9.68 | 10.02 | 0.30 | 1070.18 | 1220.00 |
+| ConvNextV2 Tiny | Feature Concat | 111.24 | 8.99 | 9.28 | 0.25 | 1093.58 | 1284.00 |
+| ConvNextV2 Tiny | Spatial Attention | 101.10 | 9.89 | 10.35 | 0.41 | 1093.58 | 1284.00 |
+| ConvNextV2 Tiny | BEV Fusion | 98.39 | 10.16 | 10.45 | 0.25 | 1093.58 | 1284.00 |
+
+</details>
+
 ### Add benchmarks for your own GPU .... 
 
 To obtain benchmarks for your GPU, simply run the [benchmarking script](https://github.com/autowarefoundation/auto_e2e/tree/main/Model/speed_benchmark). There, you can also read more about the meaning of benchmark parameters.


### PR DESCRIPTION
These are the results of running the speed benchmark on a system with an NVIDIA RTX 5080 GPU.
 
The pinned `torch==2.4.1+cu118 (CUDA 11.8)` build predates the Blackwell architecture and ships no `sm_120` kernels, so it cannot run on the RTX 5080. The benchmark was therefore executed against a `CUDA 12.8` build of PyTorch, whose compiled architecture list includes `sm_120`:

  - `torch 2.11.0+cu128`
  - `torchvision 0.26.0+cu128`
  - `CUDA build 12.8`
