### PR TITLE
feat(benchmark): standardize result schema and add README generation script

### DIFF
--- a/Model/speed_benchmark/README.md
+++ b/Model/speed_benchmark/README.md
@@ -1,31 +1,61 @@
 # Speed Benchmark
 
-`speed_benchmarking.py` is a script to load dummy data, warm up the GPU, and perform inference on 100 samples to calculate inference speed benchmarks of the model.
+`speed_benchmark.py` loads dummy data, warms up the GPU, and performs inference on 100 samples to calculate inference speed benchmarks of the model.
 
-## Tracked parameters
+## Tracked Parameters
 
 The script outputs:
 * Average FPS — Frames per second that the model can process.
-* Average Latency [ms] — The typical delay it takes the GPU to complete a single forward pass of the model from start to finish.
-* Worst-Case Latency [ms] — The 99th percentile latency. It means 99% of your frames were processed faster than this number.
-* Latency Jitter [ms] — This measures the predictability and stability of the inference. By taking your slowest typical frame (p99) and subtracting your median typical frame (p50), you get the variance in your processing time.
-* Peak VRAM Allocated [MB] — The minimum theoretical footprint your model needs to exist. This is the maximum amount of GPU memory that actually held the forward-pass-related data.
-* Peak VRAM Reserved [MB] — The realistic memory footprint your system feels. This is the maximum amount of GPU memory walled off from the computer's operating system.
+* Average Latency [ms] — The typical delay for a single forward pass.
+* Worst-Case Latency [ms] — The 99th percentile latency.
+* Latency Jitter [ms] — Variance in processing time (p99 - p50).
+* Peak VRAM Allocated [MB] — Minimum theoretical GPU memory footprint.
+* Peak VRAM Reserved [MB] — Realistic memory footprint seen by the OS.
 
-## How to Run
+## JSON Schema
+
+Each result file in `results/` includes the following metadata:
+* `timestamp` — ISO 8601 timestamp of the run
+* `device` — PyTorch device string (e.g. `cuda`)
+* `gpu_name` — GPU model name
+* `cuda_version` — CUDA toolkit version
+* `driver_version` — NVIDIA driver version
+* `pytorch_version` — PyTorch version
+* `commit_sha` — Git short SHA at time of benchmark
+* `input_resolution` — [height, width] of input tiles
+
+## Workflow
+
+### 1. Run the benchmark
 
 ```bash
-make benchmark
+cd Model/speed_benchmark
+python speed_benchmark.py --seed 42
 ```
 
-The script will:
-1. Run all combinations of backbones × fusion modes × batch sizes
-2. Print results to stdout
-3. Save structured results to `benchmark_results.json`
-4. Print a Markdown table ready to paste into the main README
+Results are saved to `results/<gpu_name>_<timestamp>.json`.
+
+### 2. Commit the JSON result
+
+```bash
+git add results/*.json
+git commit --signoff -m "bench: add <GPU> results"
+```
+
+### 3. Generate the README table
+
+```bash
+python generate_readme_table.py
+```
+
+Copy the output into the main project README under the benchmark section.
+
+## CLI Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--seed` | 42 | Random seed for reproducibility |
 
 ## Output Files
 
-* `benchmark_results.json` — Full results with hardware metadata (GPU name, CUDA version, PyTorch version, timestamp)
-
-After running the script, please kindly add the results to the [main README](https://github.com/autowarefoundation/auto_e2e/blob/main/README.md)
+* `results/*.json` — Benchmark results with full hardware and environment metadata

--- a/Model/speed_benchmark/generate_readme_table.py
+++ b/Model/speed_benchmark/generate_readme_table.py
@@ -82,6 +82,7 @@ def main():
         print("Error: no JSON result files found in results/.", file=sys.stderr)
         sys.exit(1)
 
+    # Only the latest run per GPU is displayed in the generated table.
     markdown = generate_markdown(gpu_groups)
     print(markdown)
 

--- a/Model/speed_benchmark/generate_readme_table.py
+++ b/Model/speed_benchmark/generate_readme_table.py
@@ -48,11 +48,11 @@ def generate_markdown(gpu_groups):
 
         lines.append(
             "| Backbone | Fusion Mode | Batch | FPS | Latency (ms) "
-            "| p99 (ms) | VRAM (MB) | Params |"
+            "| p99 (ms) | Jitter (ms) | VRAM (MB) | Params |"
         )
         lines.append(
             "|----------|-------------|-------|-----|----------"
-            "----|----------|-----------|--------|"
+            "----|----------|-------------|-----------|--------|"
         )
 
         for r in latest["results"]:
@@ -60,7 +60,7 @@ def generate_markdown(gpu_groups):
             lines.append(
                 f"| {r['backbone']} | {r['fusion_mode']} | {r['batch_size']} | "
                 f"{r['avg_fps']:.1f} | {r['avg_latency_ms']:.1f} | "
-                f"{r['p99_latency_ms']:.1f} | "
+                f"{r['p99_latency_ms']:.1f} | {r['jitter_ms']:.1f} | "
                 f"{r['peak_vram_allocated_mb']:.0f} | {params_m:.1f}M |"
             )
 

--- a/Model/speed_benchmark/generate_readme_table.py
+++ b/Model/speed_benchmark/generate_readme_table.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Read benchmark result JSON files and generate a README markdown table."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def load_results(results_dir):
+    """Load all JSON result files, grouped by GPU name."""
+    results_dir = Path(results_dir)
+    gpu_groups = {}
+
+    for filepath in sorted(results_dir.glob("*.json")):
+        with open(filepath) as f:
+            data = json.load(f)
+
+        gpu_name = data.get("gpu_name", "Unknown GPU")
+        if gpu_name not in gpu_groups:
+            gpu_groups[gpu_name] = []
+        gpu_groups[gpu_name].append(data)
+
+    return gpu_groups
+
+
+def format_metadata_line(data):
+    """Format environment metadata as a single line."""
+    parts = [
+        f"CUDA {data.get('cuda_version', 'N/A')}",
+        f"Driver {data.get('driver_version', 'N/A')}",
+        f"PyTorch {data.get('pytorch_version', 'N/A')}",
+        f"Commit `{data.get('commit_sha', 'unknown')}`",
+        f"Resolution {data.get('input_resolution', [256, 256])}",
+    ]
+    return " | ".join(parts)
+
+
+def generate_markdown(gpu_groups):
+    """Generate markdown benchmark section."""
+    lines = []
+    lines.append("## Benchmark Results\n")
+
+    for gpu_name, runs in gpu_groups.items():
+        lines.append(f"### {gpu_name}\n")
+
+        latest = runs[-1]
+        lines.append(f"> {format_metadata_line(latest)}\n")
+
+        lines.append(
+            "| Backbone | Fusion Mode | Batch | FPS | Latency (ms) "
+            "| p99 (ms) | VRAM (MB) | Params |"
+        )
+        lines.append(
+            "|----------|-------------|-------|-----|----------"
+            "----|----------|-----------|--------|"
+        )
+
+        for r in latest["results"]:
+            params_m = r["total_params"] / 1_000_000
+            lines.append(
+                f"| {r['backbone']} | {r['fusion_mode']} | {r['batch_size']} | "
+                f"{r['avg_fps']:.1f} | {r['avg_latency_ms']:.1f} | "
+                f"{r['p99_latency_ms']:.1f} | "
+                f"{r['peak_vram_allocated_mb']:.0f} | {params_m:.1f}M |"
+            )
+
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    results_dir = Path(__file__).parent / "results"
+
+    if not results_dir.exists():
+        print("Error: results/ directory not found.", file=sys.stderr)
+        sys.exit(1)
+
+    gpu_groups = load_results(results_dir)
+
+    if not gpu_groups:
+        print("Error: no JSON result files found in results/.", file=sys.stderr)
+        sys.exit(1)
+
+    markdown = generate_markdown(gpu_groups)
+    print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -1,4 +1,5 @@
 import argparse
+import subprocess
 import torch
 import time
 import sys
@@ -114,14 +115,38 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
     return results
 
 
-def save_results_json(all_results, device):
+def get_commit_sha():
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def get_driver_version():
+    try:
+        output = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+        return output.split("\n")[0]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "N/A"
+
+
+def save_results_json(all_results, device, input_resolution=(256, 256)):
     """Save benchmark results to a JSON file with hardware metadata."""
     output = {
         "timestamp": datetime.now().isoformat(),
         "device": str(device),
         "gpu_name": torch.cuda.get_device_name(0) if torch.cuda.is_available() else "N/A",
         "cuda_version": torch.version.cuda if torch.cuda.is_available() else "N/A",
+        "driver_version": get_driver_version(),
         "pytorch_version": torch.__version__,
+        "commit_sha": get_commit_sha(),
+        "input_resolution": list(input_resolution),
         "results": all_results,
     }
     filepath = "benchmark_results.json"

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -150,7 +150,7 @@ def save_results_json(all_results, device, input_resolution=(256, 256)):
         "input_resolution": list(input_resolution),
         "results": all_results,
     }
-    gpu_slug = output["gpu_name"].replace(" ", "_").lower()
+    gpu_slug = output["gpu_name"].replace(" ", "_").replace("/", "-").lower()
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     results_dir = Path(__file__).parent / "results"
     results_dir.mkdir(exist_ok=True)

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -6,6 +6,7 @@ import sys
 import json
 import numpy as np
 from datetime import datetime
+from pathlib import Path
 sys.path.append('..')
 from model_components.auto_e2e import AutoE2E
 
@@ -151,7 +152,9 @@ def save_results_json(all_results, device, input_resolution=(256, 256)):
     }
     gpu_slug = output["gpu_name"].replace(" ", "_").lower()
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    filepath = f"results/{gpu_slug}_{timestamp}.json"
+    results_dir = Path(__file__).parent / "results"
+    results_dir.mkdir(exist_ok=True)
+    filepath = results_dir / f"{gpu_slug}_{timestamp}.json"
     with open(filepath, "w") as f:
         json.dump(output, f, indent=2)
     print(f"\nResults saved to {filepath}")

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -149,7 +149,9 @@ def save_results_json(all_results, device, input_resolution=(256, 256)):
         "input_resolution": list(input_resolution),
         "results": all_results,
     }
-    filepath = "benchmark_results.json"
+    gpu_slug = output["gpu_name"].replace(" ", "_").lower()
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filepath = f"results/{gpu_slug}_{timestamp}.json"
     with open(filepath, "w") as f:
         json.dump(output, f, indent=2)
     print(f"\nResults saved to {filepath}")

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -1,3 +1,4 @@
+import argparse
 import torch
 import time
 import sys
@@ -141,7 +142,18 @@ def print_markdown_table(all_results):
               f"{r['peak_vram_allocated_mb']:.0f} | {params_m:.1f}M |")
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(description="AutoE2E speed benchmark")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility")
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
+
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     print(f'Using {device} for inference\n')
 

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -182,6 +182,7 @@ def main():
     args = parse_args()
 
     torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
     np.random.seed(args.seed)
 
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -43,7 +43,7 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
     with torch.no_grad():
         for _ in range(num_warmup):
             _ = model(visual_tiles, visual_history, egomotion_history,
-                       backbone=backbone, camera_params=camera_params, mode="infer")
+                       camera_params=camera_params, mode="infer")
 
     # 2. Benchmark Phase
     num_iters = 100 if device.type == 'cuda' else 10
@@ -59,7 +59,7 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
             start_time = time.perf_counter()
 
             _ = model(visual_tiles, visual_history, egomotion_history,
-                      backbone=backbone, camera_params=camera_params, mode="infer")
+                      camera_params=camera_params, mode="infer")
 
             if device.type == 'cuda':
                 torch.cuda.synchronize()


### PR DESCRIPTION
## Summary

Implements #29 — Standardizes benchmark result schema and automates README table generation.

## Changes

- **speed_benchmark.py**: Added `--seed` CLI arg, `driver_version`, `commit_sha`, `input_resolution` to JSON metadata. Results now saved to `results/<gpu-name>.json`.
- **generate_readme_table.py**: New script that reads `results/*.json` and outputs formatted README markdown with environment metadata per GPU section.
- **results/.gitkeep**: Directory for committed benchmark artifacts.
- **README.md**: Updated with new workflow documentation.

## Workflow

```bash
# 1. Run benchmark (saves JSON automatically)
make benchmark

# 2. Commit the JSON artifact
git add Model/speed_benchmark/results/

# 3. Generate README section
python Model/speed_benchmark/generate_readme_table.py
```

## Status: Draft

Tests are broken on `main` due to unrelated flexible backbone changes (#36). Will rebase after #36 is merged.