### PR TITLE
feat(losses): implement trajectory imitation loss

### DIFF
--- a/Model/model_components/losses/__init__.py
+++ b/Model/model_components/losses/__init__.py
@@ -1,0 +1,3 @@
+from .trajectory_loss import TrajectoryImitationLoss
+
+__all__ = ["TrajectoryImitationLoss"]

--- a/Model/model_components/losses/trajectory_loss.py
+++ b/Model/model_components/losses/trajectory_loss.py
@@ -5,7 +5,8 @@ import torch.nn as nn
 class TrajectoryImitationLoss(nn.Module):
     """Primary task loss: imitation loss over predicted trajectory."""
 
-    def __init__(self, loss_type: str = "smooth_l1", temporal_decay: float = 1.0):
+    def __init__(self, loss_type: str = "smooth_l1", temporal_decay: float = 1.0,
+                 num_timesteps: int = 64, num_signals: int = 2):
         super().__init__()
         if loss_type == "smooth_l1":
             self.loss_fn = nn.SmoothL1Loss(reduction="none")
@@ -15,6 +16,8 @@ class TrajectoryImitationLoss(nn.Module):
             raise ValueError(f"Unsupported loss_type: {loss_type}")
 
         self.temporal_decay = temporal_decay
+        self.num_timesteps = num_timesteps
+        self.num_signals = num_signals
 
     def _build_temporal_weights(self, num_timesteps: int, device: torch.device) -> torch.Tensor:
         if self.temporal_decay == 1.0:
@@ -23,16 +26,14 @@ class TrajectoryImitationLoss(nn.Module):
         return self.temporal_decay ** t
 
     def forward(self, trajectory_pred: torch.Tensor, trajectory_target: torch.Tensor) -> torch.Tensor:
-        # trajectory shape: (B, 128) -> reshape to (B, 64, 2)
         B = trajectory_pred.shape[0]
-        pred = trajectory_pred.view(B, 64, 2)
-        target = trajectory_target.view(B, 64, 2)
+        pred = trajectory_pred.view(B, self.num_timesteps, self.num_signals)
+        target = trajectory_target.view(B, self.num_timesteps, self.num_signals)
 
         per_element_loss = self.loss_fn(pred, target)
-        # Average over the 2 signals (acceleration, curvature)
         per_timestep_loss = per_element_loss.mean(dim=2)
 
-        weights = self._build_temporal_weights(64, trajectory_pred.device)
+        weights = self._build_temporal_weights(self.num_timesteps, trajectory_pred.device)
         weighted_loss = per_timestep_loss * weights.unsqueeze(0)
 
         return weighted_loss.mean()

--- a/Model/model_components/losses/trajectory_loss.py
+++ b/Model/model_components/losses/trajectory_loss.py
@@ -15,15 +15,15 @@ class TrajectoryImitationLoss(nn.Module):
         else:
             raise ValueError(f"Unsupported loss_type: {loss_type}")
 
-        self.temporal_decay = temporal_decay
         self.num_timesteps = num_timesteps
         self.num_signals = num_signals
 
-    def _build_temporal_weights(self, num_timesteps: int, device: torch.device) -> torch.Tensor:
-        if self.temporal_decay == 1.0:
-            return torch.ones(num_timesteps, device=device)
-        t = torch.arange(num_timesteps, device=device, dtype=torch.float32)
-        return self.temporal_decay ** t
+        if temporal_decay == 1.0:
+            weights = torch.ones(num_timesteps)
+        else:
+            t = torch.arange(num_timesteps, dtype=torch.float32)
+            weights = temporal_decay ** t
+        self.register_buffer("temporal_weights", weights)
 
     def forward(self, trajectory_pred: torch.Tensor, trajectory_target: torch.Tensor) -> torch.Tensor:
         B = trajectory_pred.shape[0]
@@ -33,7 +33,6 @@ class TrajectoryImitationLoss(nn.Module):
         per_element_loss = self.loss_fn(pred, target)
         per_timestep_loss = per_element_loss.mean(dim=2)
 
-        weights = self._build_temporal_weights(self.num_timesteps, trajectory_pred.device)
-        weighted_loss = per_timestep_loss * weights.unsqueeze(0)
+        weighted_loss = per_timestep_loss * self.temporal_weights.unsqueeze(0)
 
         return weighted_loss.mean()

--- a/Model/model_components/losses/trajectory_loss.py
+++ b/Model/model_components/losses/trajectory_loss.py
@@ -1,0 +1,38 @@
+import torch
+import torch.nn as nn
+
+
+class TrajectoryImitationLoss(nn.Module):
+    """Primary task loss: imitation loss over predicted trajectory."""
+
+    def __init__(self, loss_type: str = "smooth_l1", temporal_decay: float = 1.0):
+        super().__init__()
+        if loss_type == "smooth_l1":
+            self.loss_fn = nn.SmoothL1Loss(reduction="none")
+        elif loss_type == "mse":
+            self.loss_fn = nn.MSELoss(reduction="none")
+        else:
+            raise ValueError(f"Unsupported loss_type: {loss_type}")
+
+        self.temporal_decay = temporal_decay
+
+    def _build_temporal_weights(self, num_timesteps: int, device: torch.device) -> torch.Tensor:
+        if self.temporal_decay == 1.0:
+            return torch.ones(num_timesteps, device=device)
+        t = torch.arange(num_timesteps, device=device, dtype=torch.float32)
+        return self.temporal_decay ** t
+
+    def forward(self, trajectory_pred: torch.Tensor, trajectory_target: torch.Tensor) -> torch.Tensor:
+        # trajectory shape: (B, 128) -> reshape to (B, 64, 2)
+        B = trajectory_pred.shape[0]
+        pred = trajectory_pred.view(B, 64, 2)
+        target = trajectory_target.view(B, 64, 2)
+
+        per_element_loss = self.loss_fn(pred, target)
+        # Average over the 2 signals (acceleration, curvature)
+        per_timestep_loss = per_element_loss.mean(dim=2)
+
+        weights = self._build_temporal_weights(64, trajectory_pred.device)
+        weighted_loss = per_timestep_loss * weights.unsqueeze(0)
+
+        return weighted_loss.mean()

--- a/Model/tests/test_trajectory_loss.py
+++ b/Model/tests/test_trajectory_loss.py
@@ -1,0 +1,55 @@
+import torch
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from model_components.losses import TrajectoryImitationLoss
+
+
+class TestTrajectoryImitationLoss:
+    def test_output_is_scalar(self):
+        loss_fn = TrajectoryImitationLoss()
+        pred = torch.randn(4, 128)
+        target = torch.randn(4, 128)
+        loss = loss_fn(pred, target)
+        assert loss.dim() == 0
+
+    def test_gradient_flows_to_input(self):
+        loss_fn = TrajectoryImitationLoss()
+        pred = torch.randn(4, 128, requires_grad=True)
+        target = torch.randn(4, 128)
+        loss = loss_fn(pred, target)
+        loss.backward()
+        assert pred.grad is not None
+        assert pred.grad.shape == (4, 128)
+
+    def test_temporal_weighting_changes_loss(self):
+        pred = torch.randn(4, 128)
+        target = torch.randn(4, 128)
+
+        uniform_loss = TrajectoryImitationLoss(temporal_decay=1.0)(pred, target)
+        decayed_loss = TrajectoryImitationLoss(temporal_decay=0.9)(pred, target)
+
+        assert not torch.isclose(uniform_loss, decayed_loss)
+
+    def test_zero_input_produces_zero_loss(self):
+        loss_fn = TrajectoryImitationLoss()
+        pred = torch.zeros(4, 128)
+        target = torch.zeros(4, 128)
+        loss = loss_fn(pred, target)
+        assert loss.item() == 0.0
+
+    def test_smooth_l1_vs_mse_differ(self):
+        pred = torch.randn(4, 128)
+        target = torch.randn(4, 128)
+
+        l1_loss = TrajectoryImitationLoss(loss_type="smooth_l1")(pred, target)
+        mse_loss = TrajectoryImitationLoss(loss_type="mse")(pred, target)
+
+        assert not torch.isclose(l1_loss, mse_loss)
+
+    def test_invalid_loss_type_raises(self):
+        with pytest.raises(ValueError, match="Unsupported loss_type"):
+            TrajectoryImitationLoss(loss_type="l1")

--- a/Model/tests/test_trajectory_loss.py
+++ b/Model/tests/test_trajectory_loss.py
@@ -32,7 +32,7 @@ class TestTrajectoryImitationLoss:
         uniform_loss = TrajectoryImitationLoss(temporal_decay=1.0)(pred, target)
         decayed_loss = TrajectoryImitationLoss(temporal_decay=0.9)(pred, target)
 
-        assert not torch.isclose(uniform_loss, decayed_loss)
+        assert uniform_loss.item() != decayed_loss.item()
 
     def test_zero_input_produces_zero_loss(self):
         loss_fn = TrajectoryImitationLoss()
@@ -48,7 +48,7 @@ class TestTrajectoryImitationLoss:
         l1_loss = TrajectoryImitationLoss(loss_type="smooth_l1")(pred, target)
         mse_loss = TrajectoryImitationLoss(loss_type="mse")(pred, target)
 
-        assert not torch.isclose(l1_loss, mse_loss)
+        assert l1_loss.item() != mse_loss.item()
 
     def test_invalid_loss_type_raises(self):
         with pytest.raises(ValueError, match="Unsupported loss_type"):


### PR DESCRIPTION
## Summary

Implements #15 — The primary task loss for AutoE2E training.

## Changes

- **Model/model_components/losses/__init__.py** — losses package
- **Model/model_components/losses/trajectory_loss.py** — `TrajectoryImitationLoss` (nn.Module)
- **Model/tests/test_trajectory_loss.py** — Unit tests

## Design

- Supports `smooth_l1` (default) and `mse` loss types
- Optional temporal weighting: exponential decay `λ^t` where `λ` is configurable (default 1.0 = uniform)
- Input: `trajectory_pred (B, 128)`, `trajectory_target (B, 128)` — 64 timesteps × 2 signals [acceleration, curvature]
- Output: scalar loss

```python
from model_components.losses import TrajectoryImitationLoss

criterion = TrajectoryImitationLoss(loss_type="smooth_l1", temporal_decay=0.98)
loss = criterion(trajectory_pred, trajectory_target)
loss.backward()
```

## Test plan

- [x] Unit tests pass (`test_trajectory_loss.py`)
- [x] Output is scalar
- [x] Gradient flows to input
- [x] Temporal weighting changes loss value
- [x] smooth_l1 vs mse produce different values

## Status: Draft

Tests on `main` are broken due to unrelated flexible backbone changes (#36). Will rebase after #36 is merged.