### PR TITLE
feat (data_parsing): add Kitscenes dataset parser and forward pass test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.py[cod]
 ._*
 benchmark_results.json
+**/data/

--- a/Model/data_parsing/kit_scenes/README.md
+++ b/Model/data_parsing/kit_scenes/README.md
@@ -1,1 +1,118 @@
 # Data parsing recipe for [KIT Scenes Multimodal Dataset](https://kitscenes.com/multimodal/)
+
+Parser for the KITScenes Multimodal dataset, producing tensors directly consumable by AutoE2E's `forward()`.
+
+KITScenes ships per-frame JPEGs (not video), 6-DOF ego poses in `poses.txt`, and Lanelet2 HD maps. Cameras and ego poses share the 10 Hz reference timeline, so a single `frame_idx` indexes both. The four egomotion signals are *derived* from the pose stream by finite differencing — KITScenes does not store velocity/acceleration/curvature columns.
+
+## Setup
+
+The dataset is loaded through the [`kitscenes`](https://github.com/KIT-MRT/kitscenes) Python API (alpha, `0.1.x`). It is not on PyPI — install from source. Constraints: Linux x86_64, Python 3.8–3.12, `numpy<2.0`.
+
+```bash
+git clone https://github.com/KIT-MRT/kitscenes.git && cd kitscenes
+pip install --upgrade pip
+pip install -e ".[map]"   # [map] adds the vendored Lanelet2 wheel needed for the BEV map tile
+```
+
+The `[map]` extra installs the SDK's vendored Lanelet2 build, which the BEV map rasteriser needs. Without it the parser still runs — slot 7 (the map tile) falls back to a blank white tile rather than rasterised geometry. Use `pip install -e ".[all]"` for the full SDK.
+
+
+## Model inputs produced
+
+- `visual_tiles` `(8, 3, H, W)` — 7 camera frames + 1 BEV map tile
+- `egomotion_history` `(256,)` — 64 past timesteps × 4 signals at 10 Hz
+- `visual_history` `(896,)` — zero-initialised placeholder; populated during sequential inference
+- `trajectory_target` `(128,)` — 64 future timesteps × 2 signals (supervision target)
+
+The 7 camera views are the hi-res front camera plus the 6 surround ring cameras (`CAMERA_NAMES` in `camera.py`). The stereo front pair is dropped as it duplicates forward coverage.
+
+### Egomotion history signals `(256,) = 64 × 4`
+
+All four are derived from `poses.txt` (TUM format, UTM frame) by finite differencing on the real, possibly uneven, pose timestamps.
+
+- `[0]` Speed (m/s) — `‖d/dt translation_xy‖`
+- `[1]` Acceleration (m/s^2) — `d/dt speed`
+- `[2]` Yaw angle (rad) — quaternion → ZYX Euler, Z component
+- `[3]` Curvature (1/m) — `yaw_rate / speed`, with speed floored at 0.1 m/s
+
+### Trajectory target signals `(128,) = 64 × 2`
+
+- `[0]` Acceleration (m/s^2)
+- `[1]` Curvature (1/m)
+
+This matches `DrivingPolicy`'s `fc3` output exactly.
+
+## Sampling
+
+A sample is a `(scene_id, frame_idx)` pair, where `frame_idx` indexes the 10 Hz reference timeline. A `frame_idx` is valid when there are 64 frames behind it (history window) and 64 ahead (target window), within the span covered by *both* the ego poses and the camera frames. The current frame is excluded from both windows — history is `[idx-64, idx)`, target is `(idx, idx+64]`. A scene with `N` usable reference frames therefore yields `N − 128` valid samples.
+
+All valid pairs are enumerated at construction time, and the per-scene derived egomotion and UTM translation arrays are cached then. `__getitem__` does I/O only — no pose re-reads or index arithmetic at call time.
+
+## Usage
+
+```python
+from data_parsing.kit_scenes import KitScenesDataset
+from torch.utils.data import DataLoader
+
+# Whole split for training
+dataset = KitScenesDataset(
+    data_root="/path/to/kitscenes",   # the $KITSCENES_ROOT directory
+    backbone_name="swinv2_tiny_window8_256",
+    split="train",
+)
+
+# Single scene for forward pass validation
+dataset = KitScenesDataset(
+    data_root="/path/to/kitscenes",
+    backbone_name="swinv2_tiny_window8_256",
+    scene_ids=["c34c778f-ad8c-0aa9-7e1a-c86a73f887c7"],
+)
+
+loader = DataLoader(dataset, batch_size=8, shuffle=True, num_workers=4)
+
+for batch in loader:
+    visual_tiles = batch["visual_tiles"].to(device)           # (B, 8, 3, H, W)
+    visual_history = batch["visual_history"].to(device)       # (B, 896)
+    egomotion_history = batch["egomotion_history"].to(device) # (B, 256)
+    trajectory_target = batch["trajectory_target"].to(device) # (B, 128)
+
+    trajectory, compressed, future = model(visual_tiles, visual_history, egomotion_history)
+    loss = criterion(trajectory, trajectory_target)
+```
+
+## Image preprocessing
+
+Preprocessing is derived at runtime from the backbone's own config via timm, so normalisation, resize, and crop always match the backbone's training:
+
+```python
+data_config = timm.data.resolve_model_data_config(backbone)
+transform = timm.data.create_transform(**data_config, is_training=False)
+```
+
+The BEV map tile is passed through the same transform as the camera frames, so all 8 views share one shape and normalisation. Change the backbone by passing a different `backbone_name`.
+
+## BEV map tile (slot 7)
+
+`map.generate_bev_map_tile` rasterises a semantic, ego-centric tile from the scene's Lanelet2 HD map using OpenCV: road borders, lane dividers, centerlines, stop lines, and pedestrian crossings, coloured to mirror the SDK's `ml_converter` conventions. The tile is rotated so the ego heading points up (forward → up, left → left).
+
+Ego poses and the lanelet boundaries share the world frame (UTM 32N, metres); the tile is centred by subtracting the ego position, so the absolute UTM offset cancels. If the map is unavailable (`[map]` extra missing, or no `map.osm`), the tile is a blank white canvas. Inspect a tile with `map.visualise_bev_tile`.
+
+## Forward pass test
+
+Run from the repo root's `Model` directory. Use the absolute `$KITSCENES_ROOT` for `--dataset_root`:
+
+```bash
+cd Model/data_parsing/kit_scenes
+python forward_pass_test.py \
+    --dataset_root "$KITSCENES_ROOT" \
+    --scene_id c34c778f-ad8c-0aa9-7e1a-c86a73f887c7
+```
+
+Whole split, or offline/CI without pretrained weights:
+
+```bash
+python forward_pass_test.py --dataset_root "$KITSCENES_ROOT" --split test_e2e
+python forward_pass_test.py --dataset_root "$KITSCENES_ROOT" --scene_id <uuid> --no-pretrained
+```
+
+The test asserts input and output shapes (including that the trajectory head emits `(B, 128)`), so a dimension regression fails loudly instead of printing a wrong shape.

--- a/Model/data_parsing/kit_scenes/README.md
+++ b/Model/data_parsing/kit_scenes/README.md
@@ -6,20 +6,37 @@ KITScenes ships per-frame JPEGs (not video), 6-DOF ego poses in `poses.txt`, and
 
 ## Setup
 
-The dataset is loaded through the [`kitscenes`](https://github.com/KIT-MRT/kitscenes) Python API (alpha, `0.1.x`). It is not on PyPI — install from source. Constraints: Linux x86_64, Python 3.8–3.12, `numpy<2.0`.
+The dataset is loaded through the [`kitscenes`](https://github.com/KIT-MRT/kitscenes) Python API. Constraints: Linux x86_64, Python 3.8–3.12.
+
+### KITScenes SDK
 
 ```bash
+cd Model/data_parsing/kit_scenes
 git clone https://github.com/KIT-MRT/kitscenes.git && cd kitscenes
 pip install --upgrade pip
-pip install -e ".[map]"   # [map] adds the vendored Lanelet2 wheel needed for the BEV map tile
+pip install -e . --no-deps
 ```
 
-The `[map]` extra installs the SDK's vendored Lanelet2 build, which the BEV map rasteriser needs. Without it the parser still runs — slot 7 (the map tile) falls back to a blank black tile. Use `pip install -e ".[all]"` for the full SDK.
+### Lanelet2
+
+`generate_bev_map_tile` in `map.py` calls `get_lanelets_in_roi` which relies on `lanelet2` to parse the underlying vector map data. Install `lanelet2` using `pip`:
+```bash
+pip install lanelet2
+``` 
+
+If you encounter errors like `No matching distribution found for lanelet2`, install the pre-compiled C++ binaries and Python bindings using the RoboStack Conda channel instead:
+
+```bash
+conda install -c robostack-staging ros-humble-lanelet2-python
+```
+
+Without Lanelet2, map tiles fall back to zero tensors and the dataset still functions.
 
 
 ## Model inputs produced
 
-- `visual_tiles` `(8, 3, H, W)` — 7 camera frames + 1 BEV map tile
+- `visual_tiles` `(7, 3, H, W)` — 7 camera frames
+- `map_tile` `(3, H, W)` — BEV map tile (rasterization of Lanelet2 HD map)
 - `egomotion_history` `(256,)` — 64 past timesteps × 4 signals at 10 Hz
 - `visual_history` `(896,)` — zero-initialised placeholder; populated during sequential inference
 - `trajectory_target` `(128,)` — 64 future timesteps × 2 signals (supervision target)
@@ -44,7 +61,7 @@ All four are derived from `poses.txt` (TUM format) by finite differencing on the
 
 ## Sampling
 
-A sample is a `(scene_id, frame_idx)` pair, where `frame_idx` indexes the 10 Hz reference timeline. A `frame_idx` is valid when there are 64 frames behind it (history window) and 64 ahead (target window), within the span covered by *both* the ego poses and the camera frames. The current frame is excluded from both windows — history is `[idx-64, idx)`, target is `(idx, idx+64]`. A scene with `N` usable reference frames therefore yields `N − 128` valid samples.
+A sample is a `(scene_id, frame_idx)` pair, where `frame_idx` indexes the 10 Hz reference timeline. A `frame_idx` is valid when there are 64 frames behind it (history window) and 64 ahead (target window), within the span covered by *both* the ego poses and the camera frames. The current frame is excluded from both windows — history is `[idx-64, idx-1]`, target is `[idx+1, idx+64]`. A scene with `N` usable reference frames therefore yields `N − 128` valid samples.
 
 All valid pairs are enumerated at construction time, and per-scene derived arrays (egomotion, scene-local positions, camera projection matrices) are cached then. `__getitem__` does I/O only.
 
@@ -57,14 +74,14 @@ from torch.utils.data import DataLoader
 
 # Whole split for training
 dataset = KitScenesDataset(
-    data_root="/path/to/kitscenes",   # the $KITSCENES_ROOT directory
+    data_root="/path/to/kitscenes/data",   # the $KITSCENES_ROOT directory
     backbone_name="swinv2_tiny_window8_256",
     split="train",
 )
 
 # Single scene for forward pass validation
 dataset = KitScenesDataset(
-    data_root="/path/to/kitscenes",
+    data_root="/path/to/kitscenes/data",
     backbone_name="swinv2_tiny_window8_256",
     scene_ids=["c34c778f-ad8c-0aa9-7e1a-c86a73f887c7"],
 )
@@ -73,7 +90,8 @@ loader = DataLoader(dataset, batch_size=8, shuffle=True, num_workers=4)
 
 # Training loop
 for batch in loader:
-    visual_tiles = batch["visual_tiles"].to(device)           # (B, 8, 3, H, W)
+    visual_tiles = batch["visual_tiles"].to(device)           # (B, 7, 3, H, W)
+    map_tile = batch["map_tile"].to(device)                   # (B, 3, H, W)
     visual_history = batch["visual_history"].to(device)       # (B, 896)
     egomotion_history = batch["egomotion_history"].to(device) # (B, 256)
     trajectory_target = batch["trajectory_target"].to(device) # (B, 128)
@@ -81,16 +99,18 @@ for batch in loader:
 
     planner_loss, ego_hidden, future_visual_features = model(
         visual_tiles,
+        map_tile,
         visual_history,
         egomotion_history,
         camera_params=camera_params,
-        mode="train",
         trajectory_target=trajectory_target,
+        mode="train",
     )
 
 # Inference
 trajectory, ego_hidden, _ = model(
     visual_tiles,
+    map_tile,
     visual_history,
     egomotion_history,
     camera_params=camera_params,
@@ -100,20 +120,30 @@ trajectory, ego_hidden, _ = model(
 
 ## Image preprocessing
 
-Preprocessing is derived at runtime from the backbone's own config via timm, so normalisation, resize, and crop always match the backbone's training:
+Preprocessing is derived at runtime from the backbone's own config via timm, so normalisation, resize, and crop match the backbone's training:
 
 ```python
 data_config = timm.data.resolve_model_data_config(backbone)
 transform = timm.data.create_transform(**data_config, is_training=False)
 ```
 
-The BEV map tile is passed through the same transform as the camera frames, so all 8 views share one shape and normalisation. Change the backbone by passing a different `backbone_name`.
+## BEV map tile
 
-## BEV map tile (slot 7)
+### Rasterized maps (temporary, pending vectorized encoder)
 
-`map.generate_bev_map_tile` rasterises a semantic, ego-centric tile from the scene's Lanelet2 HD map using OpenCV: road borders, lane dividers, centerlines, stop lines, and pedestrian crossings, coloured to mirror the SDK's `ml_converter` conventions. The tile is rotated so the ego heading points up (forward → up, left → left).
+`map.generate_bev_map_tile` rasterizes a semantic, ego-centric tile from the scene's Lanelet2 HD map using OpenCV: road borders, lane dividers, centerlines, stop lines, and pedestrian crossings, coloured to mirror the SDK's `lanelet2_ml_converter` conventions. The tile is rotated so the ego heading points up (forward = up, left = left).
 
-Ego poses and the lanelet boundaries share the scene-local frame (metres from the map origin, axes aligned with UTM 32N); the tile is centred by subtracting the ego position, so the absolute offset cancels. If the map is unavailable (`[map]` extra missing, or no `map.osm`), the tile is a zero tensor. Inspect a tile with `map.visualise_bev_tile`.
+Ego poses and the lanelet boundaries share the scene-local frame (metres from the map origin, axes aligned with UTM 32N); the tile is centred by subtracting the ego position, so the absolute offset cancels. 
+
+**Important:** This rasterized map implementation for this dataset is **only applicable if the model will train using raster map representations**. The architecture is designed to support both vectorized (implementation pending) and rasterized map encoders. The `map.py` module serves as a reference implementation should rasterized maps be needed in the future.
+
+
+### Benchmarking on-demand vs. pre-rendered maps
+
+**Note:** The `rasterize_map_at_runtime` flag is provided for benchmarking. Currently, setting it to `False` (by running `forward_pass_test` with the `--no-rasterize-maps` flag) uses zero tensor fallback; actual pre-rendered raster map tile loading is not yet implemented.
+
+- `rasterize_map_at_runtime=True` (default): On-demand runtime rasterization of Lanelet2 map tiles via `map.generate_bev_map_tile`
+- `rasterize_map_at_runtime=False`: Zero tensor fallback, representative of scenarios without map data or pre-rendered/cached maps
 
 ## Forward pass test
 
@@ -129,8 +159,8 @@ python forward_pass_test.py \
 Whole split, or offline/CI without pretrained weights:
 
 ```bash
-python forward_pass_test.py --dataset_root "$KITSCENES_ROOT" --split test_e2e
+python forward_pass_test.py --dataset_root "$KITSCENES_ROOT" --split train
 python forward_pass_test.py --dataset_root "$KITSCENES_ROOT" --scene_id <uuid> --no-pretrained
 ```
 
-The test runs `mode="infer"` and asserts input and output shapes.
+The test exercises both inference (`mode="infer"`) and training (`mode="train"`) modes with BEV fusion, including camera projection matrices.

--- a/Model/data_parsing/kit_scenes/README.md
+++ b/Model/data_parsing/kit_scenes/README.md
@@ -14,7 +14,7 @@ pip install --upgrade pip
 pip install -e ".[map]"   # [map] adds the vendored Lanelet2 wheel needed for the BEV map tile
 ```
 
-The `[map]` extra installs the SDK's vendored Lanelet2 build, which the BEV map rasteriser needs. Without it the parser still runs — slot 7 (the map tile) falls back to a blank white tile rather than rasterised geometry. Use `pip install -e ".[all]"` for the full SDK.
+The `[map]` extra installs the SDK's vendored Lanelet2 build, which the BEV map rasteriser needs. Without it the parser still runs — slot 7 (the map tile) falls back to a blank black tile. Use `pip install -e ".[all]"` for the full SDK.
 
 
 ## Model inputs produced
@@ -23,12 +23,14 @@ The `[map]` extra installs the SDK's vendored Lanelet2 build, which the BEV map 
 - `egomotion_history` `(256,)` — 64 past timesteps × 4 signals at 10 Hz
 - `visual_history` `(896,)` — zero-initialised placeholder; populated during sequential inference
 - `trajectory_target` `(128,)` — 64 future timesteps × 2 signals (supervision target)
+- `camera_params` `(7, 3, 4)` — projection matrices `P = K_scaled @ T_ref_to_cam` for the 7 camera views, computed from KITScenes calibration and scaled to match the backbone's resize/crop transform. 
+
 
 The 7 camera views are the hi-res front camera plus the 6 surround ring cameras (`CAMERA_NAMES` in `camera.py`). The stereo front pair is dropped as it duplicates forward coverage.
 
 ### Egomotion history signals `(256,) = 64 × 4`
 
-All four are derived from `poses.txt` (TUM format, UTM frame) by finite differencing on the real, possibly uneven, pose timestamps.
+All four are derived from `poses.txt` (TUM format) by finite differencing on the real, possibly uneven, pose timestamps.
 
 - `[0]` Speed (m/s) — `‖d/dt translation_xy‖`
 - `[1]` Acceleration (m/s^2) — `d/dt speed`
@@ -40,13 +42,12 @@ All four are derived from `poses.txt` (TUM format, UTM frame) by finite differen
 - `[0]` Acceleration (m/s^2)
 - `[1]` Curvature (1/m)
 
-This matches `DrivingPolicy`'s `fc3` output exactly.
-
 ## Sampling
 
 A sample is a `(scene_id, frame_idx)` pair, where `frame_idx` indexes the 10 Hz reference timeline. A `frame_idx` is valid when there are 64 frames behind it (history window) and 64 ahead (target window), within the span covered by *both* the ego poses and the camera frames. The current frame is excluded from both windows — history is `[idx-64, idx)`, target is `(idx, idx+64]`. A scene with `N` usable reference frames therefore yields `N − 128` valid samples.
 
-All valid pairs are enumerated at construction time, and the per-scene derived egomotion and UTM translation arrays are cached then. `__getitem__` does I/O only — no pose re-reads or index arithmetic at call time.
+All valid pairs are enumerated at construction time, and per-scene derived arrays (egomotion, scene-local positions, camera projection matrices) are cached then. `__getitem__` does I/O only.
+
 
 ## Usage
 
@@ -70,14 +71,31 @@ dataset = KitScenesDataset(
 
 loader = DataLoader(dataset, batch_size=8, shuffle=True, num_workers=4)
 
+# Training loop
 for batch in loader:
     visual_tiles = batch["visual_tiles"].to(device)           # (B, 8, 3, H, W)
     visual_history = batch["visual_history"].to(device)       # (B, 896)
     egomotion_history = batch["egomotion_history"].to(device) # (B, 256)
     trajectory_target = batch["trajectory_target"].to(device) # (B, 128)
+    camera_params = batch["camera_params"].to(device)         # (B, 7, 3, 4)
 
-    trajectory, compressed, future = model(visual_tiles, visual_history, egomotion_history)
-    loss = criterion(trajectory, trajectory_target)
+    planner_loss, ego_hidden, future_visual_features = model(
+        visual_tiles,
+        visual_history,
+        egomotion_history,
+        camera_params=camera_params,
+        mode="train",
+        trajectory_target=trajectory_target,
+    )
+
+# Inference
+trajectory, ego_hidden, _ = model(
+    visual_tiles,
+    visual_history,
+    egomotion_history,
+    camera_params=camera_params,
+    mode="infer",
+)
 ```
 
 ## Image preprocessing
@@ -95,7 +113,7 @@ The BEV map tile is passed through the same transform as the camera frames, so a
 
 `map.generate_bev_map_tile` rasterises a semantic, ego-centric tile from the scene's Lanelet2 HD map using OpenCV: road borders, lane dividers, centerlines, stop lines, and pedestrian crossings, coloured to mirror the SDK's `ml_converter` conventions. The tile is rotated so the ego heading points up (forward → up, left → left).
 
-Ego poses and the lanelet boundaries share the world frame (UTM 32N, metres); the tile is centred by subtracting the ego position, so the absolute UTM offset cancels. If the map is unavailable (`[map]` extra missing, or no `map.osm`), the tile is a blank white canvas. Inspect a tile with `map.visualise_bev_tile`.
+Ego poses and the lanelet boundaries share the scene-local frame (metres from the map origin, axes aligned with UTM 32N); the tile is centred by subtracting the ego position, so the absolute offset cancels. If the map is unavailable (`[map]` extra missing, or no `map.osm`), the tile is a zero tensor. Inspect a tile with `map.visualise_bev_tile`.
 
 ## Forward pass test
 
@@ -115,4 +133,4 @@ python forward_pass_test.py --dataset_root "$KITSCENES_ROOT" --split test_e2e
 python forward_pass_test.py --dataset_root "$KITSCENES_ROOT" --scene_id <uuid> --no-pretrained
 ```
 
-The test asserts input and output shapes (including that the trajectory head emits `(B, 128)`), so a dimension regression fails loudly instead of printing a wrong shape.
+The test runs `mode="infer"` and asserts input and output shapes.

--- a/Model/data_parsing/kit_scenes/__init__.py
+++ b/Model/data_parsing/kit_scenes/__init__.py
@@ -1,0 +1,16 @@
+from .camera import CAMERA_NAMES, NUM_VIEWS, load_camera_frame
+from .dataset import KitScenesDataset
+from .egomotion import EGOMOTION_DIM, TRAJECTORY_DIM, load_egomotion, poses_to_arrays
+from .map import generate_bev_map_tile
+
+__all__ = [
+    "KitScenesDataset",
+    "load_camera_frame",
+    "CAMERA_NAMES",
+    "load_egomotion",
+    "poses_to_arrays",
+    "generate_bev_map_tile",
+    "NUM_VIEWS",
+    "EGOMOTION_DIM",
+    "TRAJECTORY_DIM",
+]

--- a/Model/data_parsing/kit_scenes/camera.py
+++ b/Model/data_parsing/kit_scenes/camera.py
@@ -43,6 +43,80 @@ CAMERA_NAMES: list[str] = [
 # Total views fed to the model = 7 cameras + 1 map tile.
 NUM_VIEWS = 8
 
+_BACKBONE_IMAGE_SIZE = 256
+
+def scale_intrinsic(
+    K: np.ndarray,
+    original_wh: tuple[int, int],
+    target_size: int = _BACKBONE_IMAGE_SIZE,
+) -> np.ndarray:
+    """Return K rescaled for a square ``target_size`` output.
+ 
+    Args:
+        K: (3, 3) pinhole camera matrix at the camera's native resolution.
+        original_wh: (width, height) of the native camera image.
+        target_size: Square side length after the backbone preprocessing
+            transform. Defaults to ``_BACKBONE_IMAGE_SIZE`` (256).
+ 
+    Returns:
+        (3, 3) float64 array with ``fx``, ``fy``, ``cx``, ``cy`` scaled.
+    """
+    orig_w, orig_h = original_wh
+    sx = target_size / orig_w
+    sy = target_size / orig_h
+    K_scaled = K.copy()
+    K_scaled[0, 0] *= sx   # fx
+    K_scaled[1, 1] *= sy   # fy
+    K_scaled[0, 2] *= sx   # cx
+    K_scaled[1, 2] *= sy   # cy
+    return K_scaled
+ 
+ 
+def compute_camera_projection_matrices(
+    loader: SensorDataLoader,
+    camera_names: list[str] | None = None,
+) -> torch.Tensor:
+    """Compute ``(3, 4)`` projection matrices for each camera view.
+ 
+    ``P = K_scaled @ T_ref_to_cam`` maps 3-D reference-frame points to
+    pixel coordinates in the backbone-resized image.
+ 
+    KIT Scenes ``calib.json`` always provides a ``resolution`` field, so
+    ``CameraCalibration.image_size`` is always populated and no image I/O
+    is required here.
+ 
+    Args:
+        loader: ``SensorDataLoader`` for the scene.
+        camera_names: Cameras to compute matrices for, in slot order.
+            Defaults to ``CAMERA_NAMES``.
+ 
+    Returns:
+        Float32 tensor of shape ``(len(camera_names), 3, 4)``.
+        Does not include a slot for the map tile.
+    """
+    if camera_names is None:
+        camera_names = CAMERA_NAMES
+ 
+    matrices = []
+    for cam_name in camera_names:
+        calib = loader.get_camera_calibration(cam_name)
+ 
+        if calib.image_size is None:
+            raise ValueError(
+                f"Camera {cam_name!r} has no resolution in calib.json. "
+                "KIT Scenes calibration files are expected to always include "
+                "a resolution field."
+            )
+ 
+        K_scaled = scale_intrinsic(calib.intrinsic, calib.image_size)
+ 
+        # invert calib.extrinsic to get T_ref_to_cam.
+        T_ref_to_cam = np.linalg.inv(calib.extrinsic)   # (4, 4)
+        P = K_scaled @ T_ref_to_cam[:3, :]              # (3, 4)
+        matrices.append(P)
+ 
+    return torch.tensor(np.stack(matrices, axis=0), dtype=torch.float32)  # (V, 3, 4)
+
 
 def load_camera_frame(
     loader: SensorDataLoader,

--- a/Model/data_parsing/kit_scenes/camera.py
+++ b/Model/data_parsing/kit_scenes/camera.py
@@ -11,7 +11,8 @@ Map tile (slot 7)
 KIT Scenes ships Lanelet2 HD maps, which are rasterised into a semantic RGB
 image by ``map.generate_bev_map_tile``. The resulting ``(H, W, 3)`` uint8 array
 is passed through the same backbone transform as the camera frames so that all
-8 views have identical shape and normalisation. If the map is unavailable for
+8 views have identical shape and normalisation. This is a pragmatic choice pending 
+a map-specific normalization pass. If the map is unavailable for
 a scene (missing ``maps/map.osm`` or lanelet2 not installed), slot 7 falls
 back to a zero tensor.
 """
@@ -43,47 +44,68 @@ CAMERA_NAMES: list[str] = [
 # Total views fed to the model = 7 cameras + 1 map tile.
 NUM_VIEWS = 8
 
-_BACKBONE_IMAGE_SIZE = 256
-
 def scale_intrinsic(
     K: np.ndarray,
     original_wh: tuple[int, int],
-    target_size: int = _BACKBONE_IMAGE_SIZE,
+    transform: Compose,
 ) -> np.ndarray:
-    """Return K rescaled for a square ``target_size`` output.
- 
-    Args:
-        K: (3, 3) pinhole camera matrix at the camera's native resolution.
-        original_wh: (width, height) of the native camera image.
-        target_size: Square side length after the backbone preprocessing
-            transform. Defaults to ``_BACKBONE_IMAGE_SIZE`` (256).
- 
-    Returns:
-        (3, 3) float64 array with ``fx``, ``fy``, ``cx``, ``cy`` scaled.
+    """Return K adjusted for the actual resize/crop steps in `transform`.
+
+    Walks the torchvision Compose pipeline and applies the geometric effect
+    of each Resize and CenterCrop step to K. Other steps (Normalize, ToTensor,
+    ColorJitter, etc.) don't touch pixel coordinates and are ignored.
     """
-    orig_w, orig_h = original_wh
-    sx = target_size / orig_w
-    sy = target_size / orig_h
-    K_scaled = K.copy()
-    K_scaled[0, 0] *= sx   # fx
-    K_scaled[1, 1] *= sy   # fy
-    K_scaled[0, 2] *= sx   # cx
-    K_scaled[1, 2] *= sy   # cy
-    return K_scaled
+    from torchvision.transforms import Resize, CenterCrop
+
+    K_out = K.copy().astype(np.float64)
+    cur_w, cur_h = original_wh
+
+    for t in transform.transforms:
+        if isinstance(t, Resize):
+            size = t.size
+            if isinstance(size, (list, tuple)):
+                if len(size) == 1:
+                    size = size[0]
+                else:
+                    # explicit (h, w)
+                    scale_x = size[1] / cur_w
+                    scale_y = size[0] / cur_h
+                    cur_w, cur_h = size[1], size[0]
+                    K_out[0, 0] *= scale_x
+                    K_out[1, 1] *= scale_y
+                    K_out[0, 2] *= scale_x
+                    K_out[1, 2] *= scale_y
+                    continue
+            # resize with shortest-edge mode (see timm.data.transforms)
+            scale = size / min(cur_h, cur_w)
+            cur_w = int(cur_w * scale + 0.5)
+            cur_h = int(cur_h * scale + 0.5)
+            K_out[0, 0] *= scale
+            K_out[1, 1] *= scale
+            K_out[0, 2] *= scale
+            K_out[1, 2] *= scale
+
+        elif isinstance(t, CenterCrop):
+            size = t.size
+            crop_h, crop_w = (size, size) if isinstance(size, int) else size
+            offset_x = (cur_w - crop_w) / 2.0
+            offset_y = (cur_h - crop_h) / 2.0
+            K_out[0, 2] -= offset_x
+            K_out[1, 2] -= offset_y
+            cur_w, cur_h = crop_w, crop_h
+
+    return K_out.astype(np.float64)
  
  
 def compute_camera_projection_matrices(
     loader: SensorDataLoader,
+    transform: Compose,
     camera_names: list[str] | None = None,
 ) -> torch.Tensor:
     """Compute ``(3, 4)`` projection matrices for each camera view.
  
     ``P = K_scaled @ T_ref_to_cam`` maps 3-D reference-frame points to
     pixel coordinates in the backbone-resized image.
- 
-    KIT Scenes ``calib.json`` always provides a ``resolution`` field, so
-    ``CameraCalibration.image_size`` is always populated and no image I/O
-    is required here.
  
     Args:
         loader: ``SensorDataLoader`` for the scene.
@@ -107,8 +129,7 @@ def compute_camera_projection_matrices(
                 "KIT Scenes calibration files are expected to always include "
                 "a resolution field."
             )
- 
-        K_scaled = scale_intrinsic(calib.intrinsic, calib.image_size)
+        K_scaled = scale_intrinsic(calib.intrinsic, calib.image_size, transform)
  
         # invert calib.extrinsic to get T_ref_to_cam.
         T_ref_to_cam = np.linalg.inv(calib.extrinsic)   # (4, 4)
@@ -127,9 +148,6 @@ def load_camera_frame(
     camera_names: list[str] | None = None,
 ) -> torch.Tensor:
     """Load and preprocess the camera views at a single reference frame.
-
-    KIT Scenes cameras and ego poses share the 10 Hz reference timeline, so
-    ``frame_idx`` indexes both directly.
 
     The 8th tile (slot 7) is a semantic BEV map rasterised from the scene's
     Lanelet2 HD map, centred on the ego vehicle and rotated so the ego heading

--- a/Model/data_parsing/kit_scenes/camera.py
+++ b/Model/data_parsing/kit_scenes/camera.py
@@ -1,0 +1,103 @@
+"""Camera frame loading for the KIT Scenes Multimodal dataset.
+
+KIT Scenes stores per-frame JPEGs on disk (not videos), already at the 10 Hz
+reference timeline, so a single ``frame_idx`` indexes every camera and the ego
+poses alike. The ``kitscenes`` SDK's ``SensorDataLoader`` decodes a frame to an
+RGB ``np.ndarray``; this module resizes/normalises it for the AutoE2E backbone
+and stacks the views into the tensor the model expects.
+
+Map tile (slot 7)
+-----------------
+KIT Scenes ships Lanelet2 HD maps, which are rasterised into a semantic RGB
+image by ``map.generate_bev_map_tile``. The resulting ``(H, W, 3)`` uint8 array
+is passed through the same backbone transform as the camera frames so that all
+8 views have identical shape and normalisation. If the map is unavailable for
+a scene (missing ``maps/map.osm`` or lanelet2 not installed), slot 7 falls
+back to a zero tensor.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from kitscenes.sensors import SensorDataLoader
+from PIL import Image
+from torchvision.transforms import Compose
+
+from .map import generate_bev_map_tile
+
+# Camera directories used as visual tiles for the KIT Scenes dataset.
+# Order: hi-res front, then the 6 surround ring cameras. The 2-camera stereo
+# pair (camera_base_front_left_rect/_right_rect) is intentionally dropped; it
+# duplicates forward coverage already given by the ring front camera.
+CAMERA_NAMES: list[str] = [
+    "camera_base_front_center",
+    "camera_ring_front",
+    "camera_ring_front_left",
+    "camera_ring_front_right",
+    "camera_ring_rear",
+    "camera_ring_rear_left",
+    "camera_ring_rear_right",
+]
+
+# Total views fed to the model = 7 cameras + 1 map tile.
+NUM_VIEWS = 8
+
+
+def load_camera_frame(
+    loader: SensorDataLoader,
+    frame_idx: int,
+    transform: Compose,
+    ego_xy: np.ndarray,
+    ego_yaw: float = 0.0,
+    camera_names: list[str] | None = None,
+) -> torch.Tensor:
+    """Load and preprocess the camera views at a single reference frame.
+
+    KIT Scenes cameras and ego poses share the 10 Hz reference timeline, so
+    ``frame_idx`` indexes both directly.
+
+    The 8th tile (slot 7) is a semantic BEV map rasterised from the scene's
+    Lanelet2 HD map, centred on the ego vehicle and rotated so the ego heading
+    always points straight up. It is passed through the same backbone transform
+    as the camera frames so all 8 views share the same shape and normalisation.
+
+    Args:
+        loader: ``SensorDataLoader`` for the scene, supplied by the dataset so
+            its per-scene caches are reused across __getitem__ calls.
+        frame_idx: Index into the scene's reference timeline.
+        transform: Backbone preprocessing transform (resize + normalise).
+        ego_xy: (2,) map-local position [x, y] in metres at this frame.
+        ego_yaw: Ego heading in map frame (radians, Z-up). Rotates the BEV tile
+            so the ego's heading always points straight up in the image.
+        camera_names: Ordered list of camera directory names to load.
+            Defaults to ``CAMERA_NAMES``.
+
+    Returns:
+        Float tensor of shape (8, 3, H, W):
+        7 camera views followed by 1 semantic BEV map tile.
+    """
+    if camera_names is None:
+        camera_names = CAMERA_NAMES
+
+    camera_tensors = []
+    for cam_name in camera_names:
+        rgb_frame = loader.get_camera_image(cam_name, frame_idx)  # (H, W, 3) RGB
+        camera_tensors.append(transform(Image.fromarray(rgb_frame)))  # (3, H, W)
+
+    # Slot 7: semantic BEV map. generate_bev_map_tile returns (H, W, 3).
+    # Passing through transform (PIL path) gives identical (3, H, W) float
+    # normalisation as the camera tiles. Falls back to zeros on failure.
+    bev_rgb = generate_bev_map_tile(
+        scene_path=loader.scene_path,
+        ego_x=float(ego_xy[0]),
+        ego_y=float(ego_xy[1]),
+        ego_yaw=float(ego_yaw),
+    )
+    if bev_rgb is None:
+        map_tile = torch.zeros_like(camera_tensors[0])  # (3, H, W)
+    else:
+        map_tile = transform(Image.fromarray(bev_rgb))  # (3, H, W)
+    camera_tensors.append(map_tile)
+
+    return torch.stack(camera_tensors, dim=0)  # (8, 3, H, W)

--- a/Model/data_parsing/kit_scenes/camera.py
+++ b/Model/data_parsing/kit_scenes/camera.py
@@ -4,17 +4,10 @@ KIT Scenes stores per-frame JPEGs on disk (not videos), already at the 10 Hz
 reference timeline, so a single ``frame_idx`` indexes every camera and the ego
 poses alike. The ``kitscenes`` SDK's ``SensorDataLoader`` decodes a frame to an
 RGB ``np.ndarray``; this module resizes/normalises it for the AutoE2E backbone
-and stacks the views into the tensor the model expects.
+and stacks the 7 camera views into the tensor the model expects.
 
-Map tile (slot 7)
------------------
-KIT Scenes ships Lanelet2 HD maps, which are rasterised into a semantic RGB
-image by ``map.generate_bev_map_tile``. The resulting ``(H, W, 3)`` uint8 array
-is passed through the same backbone transform as the camera frames so that all
-8 views have identical shape and normalisation. This is a pragmatic choice pending 
-a map-specific normalization pass. If the map is unavailable for
-a scene (missing ``maps/map.osm`` or lanelet2 not installed), slot 7 falls
-back to a zero tensor.
+Camera projection matrices are computed from KITScenes calibration files, with
+intrinsics scaled to match the backbone's actual resize/crop transform.
 """
 
 from __future__ import annotations
@@ -24,8 +17,6 @@ import torch
 from kitscenes.sensors import SensorDataLoader
 from PIL import Image
 from torchvision.transforms import Compose
-
-from .map import generate_bev_map_tile
 
 # Camera directories used as visual tiles for the KIT Scenes dataset.
 # Order: hi-res front, then the 6 surround ring cameras. The 2-camera stereo
@@ -41,8 +32,8 @@ CAMERA_NAMES: list[str] = [
     "camera_ring_rear_right",
 ]
 
-# Total views fed to the model = 7 cameras + 1 map tile.
-NUM_VIEWS = 8
+# Total views fed to the model = 7 cameras.
+NUM_VIEWS = 7
 
 def scale_intrinsic(
     K: np.ndarray,
@@ -54,11 +45,25 @@ def scale_intrinsic(
     Walks the torchvision Compose pipeline and applies the geometric effect
     of each Resize and CenterCrop step to K. Other steps (Normalize, ToTensor,
     ColorJitter, etc.) don't touch pixel coordinates and are ignored.
+
+    Args:
+        K: Camera intrinsic matrix, shape (3, 3).
+        original_wh: Original image dimensions as (width, height).
+        transform: Backbone preprocessing transform.
+
+    Returns:
+        Scaled intrinsic matrix K, shape (3, 3), as float64.
     """
     from torchvision.transforms import Resize, CenterCrop
 
-    K_out = K.copy().astype(np.float64)
+    if K.shape != (3, 3):
+        raise ValueError(f"K must have shape (3, 3), got {K.shape}")
+
     cur_w, cur_h = original_wh
+    if cur_w <= 0 or cur_h <= 0:
+        raise ValueError(f"Image dimensions must be positive, got ({cur_w}, {cur_h})")
+
+    K_out = K.copy().astype(np.float64)
 
     for t in transform.transforms:
         if isinstance(t, Resize):
@@ -143,31 +148,21 @@ def load_camera_frame(
     loader: SensorDataLoader,
     frame_idx: int,
     transform: Compose,
-    ego_xy: np.ndarray,
-    ego_yaw: float = 0.0,
     camera_names: list[str] | None = None,
 ) -> torch.Tensor:
     """Load and preprocess the camera views at a single reference frame.
-
-    The 8th tile (slot 7) is a semantic BEV map rasterised from the scene's
-    Lanelet2 HD map, centred on the ego vehicle and rotated so the ego heading
-    always points straight up. It is passed through the same backbone transform
-    as the camera frames so all 8 views share the same shape and normalisation.
 
     Args:
         loader: ``SensorDataLoader`` for the scene, supplied by the dataset so
             its per-scene caches are reused across __getitem__ calls.
         frame_idx: Index into the scene's reference timeline.
         transform: Backbone preprocessing transform (resize + normalise).
-        ego_xy: (2,) map-local position [x, y] in metres at this frame.
-        ego_yaw: Ego heading in map frame (radians, Z-up). Rotates the BEV tile
-            so the ego's heading always points straight up in the image.
         camera_names: Ordered list of camera directory names to load.
             Defaults to ``CAMERA_NAMES``.
 
     Returns:
-        Float tensor of shape (8, 3, H, W):
-        7 camera views followed by 1 semantic BEV map tile.
+        Float tensor of shape (7, 3, H, W):
+        7 camera views.
     """
     if camera_names is None:
         camera_names = CAMERA_NAMES
@@ -177,19 +172,4 @@ def load_camera_frame(
         rgb_frame = loader.get_camera_image(cam_name, frame_idx)  # (H, W, 3) RGB
         camera_tensors.append(transform(Image.fromarray(rgb_frame)))  # (3, H, W)
 
-    # Slot 7: semantic BEV map. generate_bev_map_tile returns (H, W, 3).
-    # Passing through transform (PIL path) gives identical (3, H, W) float
-    # normalisation as the camera tiles. Falls back to zeros on failure.
-    bev_rgb = generate_bev_map_tile(
-        scene_path=loader.scene_path,
-        ego_x=float(ego_xy[0]),
-        ego_y=float(ego_xy[1]),
-        ego_yaw=float(ego_yaw),
-    )
-    if bev_rgb is None:
-        map_tile = torch.zeros_like(camera_tensors[0])  # (3, H, W)
-    else:
-        map_tile = transform(Image.fromarray(bev_rgb))  # (3, H, W)
-    camera_tensors.append(map_tile)
-
-    return torch.stack(camera_tensors, dim=0)  # (8, 3, H, W)
+    return torch.stack(camera_tensors, dim=0)  # (7, 3, H, W)

--- a/Model/data_parsing/kit_scenes/dataset.py
+++ b/Model/data_parsing/kit_scenes/dataset.py
@@ -36,7 +36,7 @@ from kitscenes.dataset import KITScenesDataset as _KITScenesSDK
 from kitscenes.poses import load_ego_poses
 from torch.utils.data import Dataset
 
-from .camera import CAMERA_NAMES, load_camera_frame
+from .camera import CAMERA_NAMES, load_camera_frame, compute_camera_projection_matrices
 from .egomotion import (
     MIN_ROWS,
     _FUTURE_TIMESTEPS,
@@ -108,6 +108,7 @@ class KitScenesDataset(Dataset):
         # Per-scene caches populated during construction.
         self._scene_egomotion: dict[str, np.ndarray] = {}      # (T, 4) float32
         self._scene_positions: dict[str, np.ndarray] = {}      # (T, 2) float64
+        self._scene_camera_params: dict[str, torch.Tensor] = {}  # (7, 3, 4) float32
 
         # Build the flat sample index: list of (scene_id, frame_idx).
         # Precomputing this means __getitem__ never touches the SDK metadata.
@@ -171,6 +172,14 @@ class KitScenesDataset(Dataset):
         self._scene_egomotion[scene_id] = egomotion
         self._scene_positions[scene_id] = translations_local
 
+        # Projection matrices are frame-invariant; compute once per scene.
+        # min_idx is any valid frame; used only as fallback if calib.image_size
+        # is absent from calib.json (triggers a single image-header read).
+        self._scene_camera_params[scene_id] = compute_camera_projection_matrices(
+            loader,
+            camera_names=self.camera_names,
+        )
+
         return [(scene_id, frame_idx) for frame_idx in range(min_idx, max_idx + 1)]
 
     def __len__(self) -> int:
@@ -209,4 +218,5 @@ class KitScenesDataset(Dataset):
             trajectory_target=trajectory_target,
             scene_id=scene_id,
             frame_idx=frame_idx,
+            camera_params=self._scene_camera_params[scene_id],
         )

--- a/Model/data_parsing/kit_scenes/dataset.py
+++ b/Model/data_parsing/kit_scenes/dataset.py
@@ -20,6 +20,7 @@ Usage
     # sample["trajectory_target"]  (128,)
     # sample["scene_id"]           str
     # sample["frame_idx"]          int
+    # sample["camera_params"]      (7, 3, 4) — projection matrices for the 7 cameras
 """
 
 from __future__ import annotations
@@ -57,6 +58,7 @@ class ClipSample(TypedDict):
     trajectory_target: torch.Tensor   # (128,)
     scene_id: str
     frame_idx: int
+    camera_params: torch.Tensor       # (7, 3, 4) — projection matrices for the 7 cameras
 
 
 class KitScenesDataset(Dataset):
@@ -128,9 +130,10 @@ class KitScenesDataset(Dataset):
         """Return all valid (scene_id, frame_idx) for one scene.
 
         Validates camera presence and pose-stream length, then caches the
-        derived egomotion array and UTM translation array. A frame_idx is valid
-        when there are _HISTORY_TIMESTEPS frames behind it and _FUTURE_TIMESTEPS
-        ahead of it, within the span covered by both ego poses and camera frames.
+        derived egomotion array, scene-local position array, and camera
+        projection matrices. A frame_idx is valid when there are _HISTORY_TIMESTEPS 
+        frames behind it and _FUTURE_TIMESTEPS ahead of it, within the span 
+        covered by both ego poses and camera frames.
         """
         # Work off the sensor loader rather than get_scene. get_scene is
         # lru_cache(maxsize=None) and would pin every scene's raw ego poses in
@@ -173,10 +176,9 @@ class KitScenesDataset(Dataset):
         self._scene_positions[scene_id] = translations_local
 
         # Projection matrices are frame-invariant; compute once per scene.
-        # min_idx is any valid frame; used only as fallback if calib.image_size
-        # is absent from calib.json (triggers a single image-header read).
         self._scene_camera_params[scene_id] = compute_camera_projection_matrices(
             loader,
+            transform=self.transform,
             camera_names=self.camera_names,
         )
 

--- a/Model/data_parsing/kit_scenes/dataset.py
+++ b/Model/data_parsing/kit_scenes/dataset.py
@@ -14,7 +14,8 @@ Usage
     )
 
     sample = dataset[0]
-    # sample["visual_tiles"]       (8, 3, H, W)  — 7 cameras + BEV map tile
+    # sample["visual_tiles"]       (7, 3, H, W)  — 7 cameras 
+    # sample["map_tile"]          (3, H, W)     — semantic BEV map tile
     # sample["egomotion_history"]  (256,)
     # sample["visual_history"]     (896,)
     # sample["trajectory_target"]  (128,)
@@ -27,6 +28,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from PIL import Image
 from typing import TypedDict
 
 import numpy as np
@@ -36,6 +38,8 @@ import torch
 from kitscenes.dataset import KITScenesDataset as _KITScenesSDK
 from kitscenes.poses import load_ego_poses
 from torch.utils.data import Dataset
+
+from .map import generate_bev_map_tile
 
 from .camera import CAMERA_NAMES, load_camera_frame, compute_camera_projection_matrices
 from .egomotion import (
@@ -52,7 +56,8 @@ _VISUAL_HISTORY_DIM = 896
 
 
 class ClipSample(TypedDict):
-    visual_tiles: torch.Tensor        # (8, 3, H, W) — 7 cameras + BEV map tile
+    visual_tiles: torch.Tensor        # (7, 3, H, W) — 7 cameras
+    map_tile: torch.Tensor            # (3, H, W) — semantic BEV map tile
     egomotion_history: torch.Tensor   # (256,)
     visual_history: torch.Tensor      # (896,)
     trajectory_target: torch.Tensor   # (128,)
@@ -81,6 +86,11 @@ class KitScenesDataset(Dataset):
         scene_ids: Optional explicit list of scene IDs. If ``None``, all valid
             scenes in the split are used. Pass a single-element list for smoke
             tests or forward pass validation.
+        rasterize_map_at_runtime: If True (default), rasterize Lanelet2 map
+            tiles on-demand at runtime via generate_bev_map_tile. If False,
+            return zero tensor map tiles, representative of pre-rendered/cached
+            maps or datasets without HD maps. Use False for benchmarking to
+            measure map encoder impact independently from rendering cost.
     """
 
     def __init__(
@@ -90,8 +100,10 @@ class KitScenesDataset(Dataset):
         split: str | None = None,
         camera_names: list[str] | None = None,
         scene_ids: list[str] | None = None,
+        rasterize_map_at_runtime: bool = True,
     ) -> None:
         self.camera_names = camera_names or CAMERA_NAMES
+        self.rasterize_map_at_runtime = rasterize_map_at_runtime
 
         # Build the image transform from the backbone's own config so that
         # preprocessing always matches what the backbone expects.
@@ -201,10 +213,26 @@ class KitScenesDataset(Dataset):
             loader,
             frame_idx,
             transform=self.transform,
-            ego_xy=ego_xy,
-            ego_yaw=ego_yaw,
             camera_names=self.camera_names,
         )
+
+        # Load semantic BEV map. generate_bev_map_tile returns (H, W, 3).
+        # Passing through transform (PIL path) gives identical (3, H, W) float
+        # normalisation as the camera tiles. Falls back to zeros on failure or
+        # if rasterize_map_at_runtime is False.
+        if self.rasterize_map_at_runtime:
+            bev_map = generate_bev_map_tile(
+                scene_path=loader.scene_path,
+                ego_x=float(ego_xy[0]),
+                ego_y=float(ego_xy[1]),
+                ego_yaw=float(ego_yaw),
+            )
+            if bev_map is None:
+                map_tile = torch.zeros_like(visual_tiles[0])  # (3, H, W)
+            else:
+                map_tile = self.transform(Image.fromarray(bev_map))  # (3, H, W)
+        else:
+            map_tile = torch.zeros_like(visual_tiles[0])  # (3, H, W)
 
         egomotion_history, trajectory_target = load_egomotion(
             self._scene_egomotion[scene_id],
@@ -215,6 +243,7 @@ class KitScenesDataset(Dataset):
 
         return ClipSample(
             visual_tiles=visual_tiles,
+            map_tile=map_tile,
             egomotion_history=egomotion_history,
             visual_history=visual_history,
             trajectory_target=trajectory_target,

--- a/Model/data_parsing/kit_scenes/dataset.py
+++ b/Model/data_parsing/kit_scenes/dataset.py
@@ -1,0 +1,212 @@
+"""PyTorch Dataset for the KIT Scenes Multimodal dataset.
+
+Usage
+-----
+    from data_parsing.kit_scenes import KitScenesDataset
+
+    # All valid samples in a split (for training)
+    dataset = KitScenesDataset(data_root="/path/to/kitscenes", split="train")
+
+    # Single scene (for smoke tests / forward pass validation)
+    dataset = KitScenesDataset(
+        data_root="/path/to/kitscenes",
+        scene_ids=["<scene-uuid>"],
+    )
+
+    sample = dataset[0]
+    # sample["visual_tiles"]       (8, 3, H, W)  — 7 cameras + BEV map tile
+    # sample["egomotion_history"]  (256,)
+    # sample["visual_history"]     (896,)
+    # sample["trajectory_target"]  (128,)
+    # sample["scene_id"]           str
+    # sample["frame_idx"]          int
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TypedDict
+
+import numpy as np
+import timm
+import torch
+# Aliased to avoid confusion with our wrapper class below.
+from kitscenes.dataset import KITScenesDataset as _KITScenesSDK
+from kitscenes.poses import load_ego_poses
+from torch.utils.data import Dataset
+
+from .camera import CAMERA_NAMES, load_camera_frame
+from .egomotion import (
+    MIN_ROWS,
+    _FUTURE_TIMESTEPS,
+    _HISTORY_TIMESTEPS,
+    load_egomotion,
+    poses_to_arrays,
+)
+
+logger = logging.getLogger(__name__)
+
+_VISUAL_HISTORY_DIM = 896
+
+
+class ClipSample(TypedDict):
+    visual_tiles: torch.Tensor        # (8, 3, H, W) — 7 cameras + BEV map tile
+    egomotion_history: torch.Tensor   # (256,)
+    visual_history: torch.Tensor      # (896,)
+    trajectory_target: torch.Tensor   # (128,)
+    scene_id: str
+    frame_idx: int
+
+
+class KitScenesDataset(Dataset):
+    """Dataset where each item is one valid (scene_id, frame_idx) pair.
+
+    All valid frame indices across all scenes are enumerated at construction
+    time. __getitem__ does only I/O — derived egomotion quantities and UTM
+    translations are cached per scene during construction, and sensor loaders
+    are fetched on demand from the SDK's own (lru_cached) ``get_sensor_loader``.
+
+    Args:
+        data_root: Path to the dataset root (HuggingFace layout:
+            ``data/<split>/`` under this path). If ``None``, the SDK falls
+            back to ``$KITSCENES_ROOT``.
+        backbone_name: timm backbone whose preprocessing config drives the
+            image transform.
+        split: Restrict to one SDK split ('train', 'val', 'test', 'test_e2e',
+            'overlap_train_val'). If ``None``, all scenes are discovered.
+        camera_names: Camera views to load. Defaults to ``CAMERA_NAMES``.
+        scene_ids: Optional explicit list of scene IDs. If ``None``, all valid
+            scenes in the split are used. Pass a single-element list for smoke
+            tests or forward pass validation.
+    """
+
+    def __init__(
+        self,
+        data_root: Path | str | None = None,
+        backbone_name: str = "swinv2_tiny_window8_256",
+        split: str | None = None,
+        camera_names: list[str] | None = None,
+        scene_ids: list[str] | None = None,
+    ) -> None:
+        self.camera_names = camera_names or CAMERA_NAMES
+
+        # Build the image transform from the backbone's own config so that
+        # preprocessing always matches what the backbone expects.
+        # create_model loads config only — no pretrained weights downloaded here.
+        _backbone = timm.create_model(backbone_name, pretrained=False)
+        data_config = timm.data.resolve_model_data_config(_backbone)
+        self.transform = timm.data.create_transform(**data_config, is_training=False)
+        del _backbone
+
+        self._sdk = _KITScenesSDK(root=data_root, split=split)
+
+        scenes = scene_ids if scene_ids is not None else self._sdk.scene_ids
+        if not scenes:
+            raise ValueError(f"No scenes found under: {self._sdk.root}")
+
+        # Per-scene caches populated during construction.
+        self._scene_egomotion: dict[str, np.ndarray] = {}      # (T, 4) float32
+        self._scene_positions: dict[str, np.ndarray] = {}      # (T, 2) float64
+
+        # Build the flat sample index: list of (scene_id, frame_idx).
+        # Precomputing this means __getitem__ never touches the SDK metadata.
+        self._samples: list[tuple[str, int]] = []
+        for scene_id in scenes:
+            self._samples.extend(self._valid_samples_for_scene(scene_id))
+
+        if not self._samples:
+            raise ValueError("No valid samples found across all scenes.")
+
+        logger.info(
+            "KitScenesDataset: %d samples from %d scenes",
+            len(self._samples), len(self._scene_egomotion),
+        )
+
+    def _valid_samples_for_scene(self, scene_id: str) -> list[tuple[str, int]]:
+        """Return all valid (scene_id, frame_idx) for one scene.
+
+        Validates camera presence and pose-stream length, then caches the
+        derived egomotion array and UTM translation array. A frame_idx is valid
+        when there are _HISTORY_TIMESTEPS frames behind it and _FUTURE_TIMESTEPS
+        ahead of it, within the span covered by both ego poses and camera frames.
+        """
+        # Work off the sensor loader rather than get_scene. get_scene is
+        # lru_cache(maxsize=None) and would pin every scene's raw ego poses in
+        # the SDK cache for the dataset's lifetime. 
+        loader = self._sdk.get_sensor_loader(scene_id)
+
+        present = set(loader.get_camera_names())
+        missing = [c for c in self.camera_names if c not in present]
+        if missing:
+            logger.warning(
+                "Scene %s: missing cameras %s. Skipping.", scene_id, missing
+            )
+            return []
+
+        poses = load_ego_poses(loader.scene_path)
+        if len(poses) < MIN_ROWS:
+            logger.warning(
+                "Scene %s has only %d ego poses (need %d). Skipping.",
+                scene_id, len(poses), MIN_ROWS,
+            )
+            return []
+
+        egomotion, translations_local = poses_to_arrays(poses)
+
+        # Cameras and poses share the reference timeline but may differ in
+        # count at the tail; cap the valid range to the span both cover.
+        num_frames = len(loader.get_reference_timestamps())
+        usable = min(len(egomotion), num_frames)
+
+        min_idx = _HISTORY_TIMESTEPS
+        max_idx = usable - _FUTURE_TIMESTEPS - 1
+        if max_idx < min_idx:
+            logger.warning(
+                "Scene %s: usable span %d too short for a sample. Skipping.",
+                scene_id, usable,
+            )
+            return []
+
+        self._scene_egomotion[scene_id] = egomotion
+        self._scene_positions[scene_id] = translations_local
+
+        return [(scene_id, frame_idx) for frame_idx in range(min_idx, max_idx + 1)]
+
+    def __len__(self) -> int:
+        return len(self._samples)
+
+    def __getitem__(self, idx: int) -> ClipSample:
+        scene_id, frame_idx = self._samples[idx]
+
+        # get_sensor_loader is lru_cached on the SDK; safe to call in hot path.
+        loader = self._sdk.get_sensor_loader(scene_id)
+
+        # Map-local position and heading at this frame for BEV map tile.
+        ego_xy = self._scene_positions[scene_id][frame_idx]       # (2,) float64
+        ego_yaw = float(self._scene_egomotion[scene_id][frame_idx, 2])  # yaw, radians
+
+        visual_tiles = load_camera_frame(
+            loader,
+            frame_idx,
+            transform=self.transform,
+            ego_xy=ego_xy,
+            ego_yaw=ego_yaw,
+            camera_names=self.camera_names,
+        )
+
+        egomotion_history, trajectory_target = load_egomotion(
+            self._scene_egomotion[scene_id],
+            frame_idx=frame_idx,
+        )
+
+        visual_history = torch.zeros(_VISUAL_HISTORY_DIM, dtype=torch.float32)
+
+        return ClipSample(
+            visual_tiles=visual_tiles,
+            egomotion_history=egomotion_history,
+            visual_history=visual_history,
+            trajectory_target=trajectory_target,
+            scene_id=scene_id,
+            frame_idx=frame_idx,
+        )

--- a/Model/data_parsing/kit_scenes/egomotion.py
+++ b/Model/data_parsing/kit_scenes/egomotion.py
@@ -1,0 +1,129 @@
+"""Egomotion derivation for the KIT Scenes Multimodal dataset.
+
+KIT Scenes does not store velocity/acceleration/
+curvature columns. It provides only 6-DOF ego poses in ``poses.txt`` (TUM
+format, UTM frame) at the 10 Hz reference rate. The four model signals are
+therefore *derived* from the pose sequence by finite differencing:
+
+    egomotion_history  (256,) — 64 timesteps before the sample point x 4 signals
+                                [speed, acceleration, yaw_angle, curvature]
+
+    trajectory_target  (128,) — 64 timesteps after the sample point x 2 signals
+                                [acceleration, curvature]
+                                Matches DrivingPolicy's fc3 output exactly.
+
+The pose stream is already at 10 Hz, so there is no downsampling step.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from kitscenes.schema import EgoPose
+from scipy.spatial.transform import Rotation
+
+# Must match DrivingPolicy dimensions.
+_HISTORY_TIMESTEPS = 64         # 6.4 s of past context at 10 Hz
+_FUTURE_TIMESTEPS = 64          # 6.4 s of future prediction at 10 Hz
+_NUM_HISTORY_SIGNALS = 4        # speed, acceleration, yaw_angle, curvature
+_NUM_TARGET_SIGNALS = 2         # acceleration, curvature
+
+EGOMOTION_DIM = _HISTORY_TIMESTEPS * _NUM_HISTORY_SIGNALS   # 256
+TRAJECTORY_DIM = _FUTURE_TIMESTEPS * _NUM_TARGET_SIGNALS    # 128
+
+# Minimum number of ego poses for a scene to yield at least one valid sample.
+MIN_ROWS = _HISTORY_TIMESTEPS + _FUTURE_TIMESTEPS + 1  # 129
+
+# Indices for selecting target signals.
+_ACCELERATION_IDX = 1
+_CURVATURE_IDX = 3
+
+# Target signals selected from the derived array: [acceleration, curvature].
+_TARGET_IDX = [_ACCELERATION_IDX, _CURVATURE_IDX]
+
+# Speed floor (m/s) guarding the curvature = yaw_rate / speed division.
+_MIN_SPEED = 0.1
+
+
+def poses_to_arrays(
+    poses: tuple[EgoPose, ...],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Derive egomotion quantities and extract UTM translations from ego poses.
+
+    ``np.gradient`` uses the real (possibly uneven) timestamps and falls back
+    to one-sided differences at the boundaries.
+
+    Args:
+        poses: Ego poses for one scene, ordered along the reference timeline.
+
+    Returns:
+        egomotion: Float32 array of shape (T, 4):
+            [speed, acceleration, yaw_angle, curvature].
+            - speed: ground-plane (XY) world velocity magnitude, m/s.
+            - acceleration: time-derivative of speed (longitudinal), m/s^2.
+            - yaw_angle: heading about Z from the pose quaternion, rad.
+            - curvature: yaw_rate / speed, 1/m, with speed floored at
+              _MIN_SPEED.
+        translations_local: Float64 array of shape (T, 2): scene-local frame
+            coordinates [easting, northing] in metres per timestep. These match the
+            coordinate frame of the Lanelet2 HD map and the ``get_lanelets_in_roi``
+            query.
+    """
+    t_s = np.array([p.timestamp_ns for p in poses], dtype=np.float64) / 1e9
+    translations = np.array([p.translation for p in poses], dtype=np.float64)  # (T, 3)
+    quats = np.array([p.rotation for p in poses], dtype=np.float64)             # (T, 4) xyzw
+
+    velocity_xy = np.gradient(translations[:, :2], t_s, axis=0)  # (T, 2)
+    speed = np.linalg.norm(velocity_xy, axis=1)                   # (T,)
+
+    acceleration = np.gradient(speed, t_s)                        # (T,)
+
+    yaw_angle = Rotation.from_quat(quats).as_euler("ZYX")[:, 0]   # (T,)
+
+    yaw_rate = np.gradient(np.unwrap(yaw_angle), t_s)             # (T,)
+    speed_safe = np.where(speed < _MIN_SPEED, _MIN_SPEED, speed)
+    curvature = yaw_rate / speed_safe                              # (T,)
+
+    egomotion = np.stack(
+        [speed, acceleration, yaw_angle, curvature], axis=1
+    ).astype(np.float32)
+
+    translations_local = translations[:, :2].astype(np.float64)     # (T, 2) easting, northing
+    return egomotion, translations_local
+
+
+def load_egomotion(
+    egomotion_arr: np.ndarray,
+    frame_idx: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Slice egomotion history and trajectory target around a sample point.
+
+    Takes the 64 timesteps before ``frame_idx`` as the history and the 64
+    timesteps after it as the target. Ensure ``frame_idx`` is in the valid range:
+
+        _HISTORY_TIMESTEPS <= frame_idx <= len(egomotion_arr) - _FUTURE_TIMESTEPS - 1
+
+    Args:
+        egomotion_arr: Derived (T, 4) array from ``poses_to_arrays``.
+        frame_idx: Reference-timeline index treated as the current moment.
+
+    Returns:
+        egomotion_history: Float tensor of shape ``(256,)``.
+        trajectory_target: Float tensor of shape ``(128,)``.
+    """
+    min_idx = _HISTORY_TIMESTEPS
+    max_idx = len(egomotion_arr) - _FUTURE_TIMESTEPS - 1
+    if not (min_idx <= frame_idx <= max_idx):
+        raise ValueError(
+            f"frame_idx {frame_idx} out of valid range [{min_idx}, {max_idx}] "
+            f"for a {len(egomotion_arr)}-pose scene."
+        )
+
+    history = egomotion_arr[frame_idx - _HISTORY_TIMESTEPS:frame_idx]          # (64, 4)
+    future = egomotion_arr[frame_idx + 1:frame_idx + 1 + _FUTURE_TIMESTEPS]    # (64, 4)
+    target = future[:, _TARGET_IDX]                                         # (64, 2)
+
+    return (
+        torch.from_numpy(history.flatten()),   # (256,)
+        torch.from_numpy(target.flatten()),    # (128,)
+    )

--- a/Model/data_parsing/kit_scenes/egomotion.py
+++ b/Model/data_parsing/kit_scenes/egomotion.py
@@ -10,7 +10,6 @@ therefore *derived* from the pose sequence by finite differencing:
 
     trajectory_target  (128,) — 64 timesteps after the sample point x 2 signals
                                 [acceleration, curvature]
-                                Matches DrivingPolicy's fc3 output exactly.
 
 The pose stream is already at 10 Hz, so there is no downsampling step.
 """
@@ -22,7 +21,6 @@ import torch
 from kitscenes.schema import EgoPose
 from scipy.spatial.transform import Rotation
 
-# Must match DrivingPolicy dimensions.
 _HISTORY_TIMESTEPS = 64         # 6.4 s of past context at 10 Hz
 _FUTURE_TIMESTEPS = 64          # 6.4 s of future prediction at 10 Hz
 _NUM_HISTORY_SIGNALS = 4        # speed, acceleration, yaw_angle, curvature

--- a/Model/data_parsing/kit_scenes/forward_pass_test.py
+++ b/Model/data_parsing/kit_scenes/forward_pass_test.py
@@ -67,6 +67,7 @@ def main(
     visual_history = batch["visual_history"].to(device)       # (B, 896)
     egomotion_history = batch["egomotion_history"].to(device) # (B, 256)
     trajectory_target = batch["trajectory_target"].to(device) # (B, 128)
+    camera_params = batch["camera_params"].to(device)
     t_dataset = time.time() - t0
 
     print(f"Dataset creation: {t_dataset:.2f}s")
@@ -74,6 +75,7 @@ def main(
     print(f"visual_tiles: {tuple(visual_tiles.shape)}")
     print(f"egomotion_history: {tuple(egomotion_history.shape)}")
     print(f"trajectory_target: {tuple(trajectory_target.shape)}")
+    print(f"camera_params: {tuple(camera_params.shape)}")
 
     # --------------------
     # forward pass

--- a/Model/data_parsing/kit_scenes/forward_pass_test.py
+++ b/Model/data_parsing/kit_scenes/forward_pass_test.py
@@ -1,0 +1,117 @@
+"""
+Forward pass test for AutoE2E using the KIT Scenes Multimodal dataset.
+
+Loads a single scene (or split), runs one batch through the data pipeline, and
+optionally through the model. 
+
+Usage:
+    cd Model/data_parsing/kit_scenes
+    python forward_pass_test.py \
+        --dataset_root data \
+        --scene_id <scene-uuid>
+
+    # Whole split:
+    cd Model/data_parsing/kit_scenes
+    python forward_pass_test.py \
+        --dataset_root data \
+        --split test_e2e
+
+    # Offline / CI (no pretrained weights):
+    cd Model/data_parsing/kit_scenes
+    python forward_pass_test.py \
+        --dataset_root data \
+        --scene_id <scene-uuid> \
+        --no-pretrained
+"""
+
+import argparse
+import pathlib
+import sys
+import time
+
+import torch
+from torch.utils.data import DataLoader
+
+_MODEL_DIR = pathlib.Path(__file__).parent.parent.parent.resolve()
+sys.path.insert(0, str(_MODEL_DIR))
+
+from data_parsing.kit_scenes import KitScenesDataset  # noqa: E402
+from model_components.auto_e2e import AutoE2E # noqa: E402
+
+
+def main(
+    dataset_root: str,
+    scene_id: str | None,
+    split: str | None,
+    batch_size: int = 4,
+    pretrained_backbone: bool = True,
+) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+
+    scene_ids = [scene_id] if scene_id is not None else None
+
+    t0 = time.time()
+    dataset = KitScenesDataset(
+        data_root=dataset_root,
+        backbone_name="swinv2_tiny_window8_256",
+        split=split,
+        scene_ids=scene_ids,
+    )
+    print(f"Valid samples: {len(dataset)}")
+
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False, num_workers=0)
+
+    batch = next(iter(loader))
+    visual_tiles = batch["visual_tiles"].to(device)           # (B, 8, 3, H, W)
+    visual_history = batch["visual_history"].to(device)       # (B, 896)
+    egomotion_history = batch["egomotion_history"].to(device) # (B, 256)
+    trajectory_target = batch["trajectory_target"].to(device) # (B, 128)
+    t_dataset = time.time() - t0
+
+    print(f"Dataset creation: {t_dataset:.2f}s")
+
+    print(f"visual_tiles: {tuple(visual_tiles.shape)}")
+    print(f"egomotion_history: {tuple(egomotion_history.shape)}")
+    print(f"trajectory_target: {tuple(trajectory_target.shape)}")
+
+    # --------------------
+    # forward pass
+    model = AutoE2E(is_pretrained=pretrained_backbone).to(device)
+
+    t0 = time.time()
+    trajectory_, compressed_, future_ = model(visual_tiles, visual_history, egomotion_history)
+    t_forward = time.time() - t0
+    print(f"Forward pass: {t_forward:.2f}s")
+
+    print(f"trajectory output: {tuple(trajectory_.shape)}")
+    print(f"compressed visual feature output: {tuple(compressed_.shape)}")
+    print(f"future visual features: {[tuple(f.shape) for f in future_]}")
+    # --------------------
+
+    # TODO (training): wire in loss and backprop
+    # loss = F.mse_loss(trajectory, trajectory_target)
+    # loss.backward()
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset_root", type=str, required=True)
+    parser.add_argument("--scene_id", type=str, default=None,
+                    help="Single scene ID to test. Defaults to all scenes in the split.")
+    parser.add_argument("--split", type=str, default=None,
+                    help="SDK split to use (train, val, test, test_e2e, overlap_train_val).")
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--no-pretrained", action="store_true",
+                    help="Skip downloading pretrained weights for the backbone and initialize randomly.")
+    args = parser.parse_args()
+
+    main(
+        args.dataset_root,
+        args.scene_id,
+        args.split,
+        args.batch_size,
+        pretrained_backbone=not args.no_pretrained,
+    )

--- a/Model/data_parsing/kit_scenes/forward_pass_test.py
+++ b/Model/data_parsing/kit_scenes/forward_pass_test.py
@@ -74,22 +74,44 @@ def main(
 
     print(f"visual_tiles: {tuple(visual_tiles.shape)}")
     print(f"egomotion_history: {tuple(egomotion_history.shape)}")
-    print(f"trajectory_target: {tuple(trajectory_target.shape)}")
     print(f"camera_params: {tuple(camera_params.shape)}")
+    print(f"trajectory_target: {tuple(trajectory_target.shape)}")
+    
 
     # --------------------
-    # forward pass
+    # forward pass - Concat fusion path
+    print("Testing forward pass with Concat fusion...")
     model = AutoE2E(is_pretrained=pretrained_backbone).to(device)
 
     t0 = time.time()
-    trajectory_, compressed_, future_ = model(visual_tiles, visual_history, egomotion_history)
+    trajectory_, compressed_, future_ = model(visual_tiles, visual_history, egomotion_history, camera_params=camera_params)
     t_forward = time.time() - t0
-    print(f"Forward pass: {t_forward:.2f}s")
+    print(f"Forward pass (Concat fusion): {t_forward:.2f}s")
 
-    print(f"trajectory output: {tuple(trajectory_.shape)}")
+    print(f"trajectory output (Concat fusion): {tuple(trajectory_.shape)}")
     print(f"compressed visual feature output: {tuple(compressed_.shape)}")
     print(f"future visual features: {[tuple(f.shape) for f in future_]}")
     # --------------------
+
+    # forward pass - BEV fusion path
+    print("Testing forward pass with BEV fusion...")
+    model_bev = AutoE2E(
+        is_pretrained=pretrained_backbone,
+        fusion_mode="bev",
+    ).to(device)
+
+    t0 = time.time()
+    trajectory_bev, ego_hidden_bev, _ = model_bev(
+        visual_tiles,
+        visual_history,
+        egomotion_history,
+        camera_params=camera_params,
+        mode="infer",
+    )
+    t_forward_bev = time.time() - t0
+    print(f"Forward pass (BEV fusion): {t_forward_bev:.2f}s")
+    print(f"trajectory output (BEV fusion): {tuple(trajectory_bev.shape)}")
+    print(f"ego hidden (BEV fusion): {tuple(ego_hidden_bev.shape)}")
 
     # TODO (training): wire in loss and backprop
     # loss = F.mse_loss(trajectory, trajectory_target)

--- a/Model/data_parsing/kit_scenes/forward_pass_test.py
+++ b/Model/data_parsing/kit_scenes/forward_pass_test.py
@@ -1,8 +1,8 @@
 """
 Forward pass test for AutoE2E using the KIT Scenes Multimodal dataset.
 
-Loads a single scene (or split), runs one batch through the data pipeline, and
-optionally through the model. 
+Organizes tests into separate functions for loading the dataset, testing
+inference mode, and testing training mode.
 
 Usage:
     cd Model/data_parsing/kit_scenes
@@ -14,7 +14,7 @@ Usage:
     cd Model/data_parsing/kit_scenes
     python forward_pass_test.py \
         --dataset_root data \
-        --split test_e2e
+        --split train
 
     # Offline / CI (no pretrained weights):
     cd Model/data_parsing/kit_scenes
@@ -22,6 +22,13 @@ Usage:
         --dataset_root data \
         --scene_id <scene-uuid> \
         --no-pretrained
+
+    # Benchmark with zero tensor maps (no runtime rasterization):
+    cd Model/data_parsing/kit_scenes
+    python forward_pass_test.py \
+        --dataset_root data \
+        --scene_id <scene-uuid> \
+        --no-rasterize-maps
 """
 
 import argparse
@@ -36,18 +43,17 @@ _MODEL_DIR = pathlib.Path(__file__).parent.parent.parent.resolve()
 sys.path.insert(0, str(_MODEL_DIR))
 
 from data_parsing.kit_scenes import KitScenesDataset  # noqa: E402
-from model_components.auto_e2e import AutoE2E # noqa: E402
+from model_components.auto_e2e import AutoE2E  # noqa: E402
 
 
-def main(
+def load_dataset(
     dataset_root: str,
     scene_id: str | None,
     split: str | None,
-    batch_size: int = 4,
-    pretrained_backbone: bool = True,
-) -> None:
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"Device: {device}")
+    rasterize_map_at_runtime: bool = True,
+) -> tuple[KitScenesDataset, dict]:
+    """Load KITScenes dataset and return first batch."""
+    print("[dataset] Loading KITScenes dataset...")
 
     scene_ids = [scene_id] if scene_id is not None else None
 
@@ -57,67 +63,125 @@ def main(
         backbone_name="swinv2_tiny_window8_256",
         split=split,
         scene_ids=scene_ids,
+        rasterize_map_at_runtime=rasterize_map_at_runtime,
     )
-    print(f"Valid samples: {len(dataset)}")
+    print(f"[dataset] Valid samples: {len(dataset)}")
 
-    loader = DataLoader(dataset, batch_size=batch_size, shuffle=False, num_workers=0)
-
+    loader = DataLoader(dataset, batch_size=2, shuffle=False, num_workers=0)
     batch = next(iter(loader))
-    visual_tiles = batch["visual_tiles"].to(device)           # (B, 8, 3, H, W)
-    visual_history = batch["visual_history"].to(device)       # (B, 896)
-    egomotion_history = batch["egomotion_history"].to(device) # (B, 256)
-    trajectory_target = batch["trajectory_target"].to(device) # (B, 128)
-    camera_params = batch["camera_params"].to(device)
+
     t_dataset = time.time() - t0
+    print(f"[dataset] Creation time: {t_dataset:.2f}s")
 
-    print(f"Dataset creation: {t_dataset:.2f}s")
+    # Move batch to device
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    batch_device = {
+        "visual_tiles": batch["visual_tiles"].to(device),
+        "map_tile": batch["map_tile"].to(device),
+        "visual_history": batch["visual_history"].to(device),
+        "egomotion_history": batch["egomotion_history"].to(device),
+        "trajectory_target": batch["trajectory_target"].to(device),
+        "camera_params": batch["camera_params"].to(device),
+    }
 
-    print(f"visual_tiles: {tuple(visual_tiles.shape)}")
-    print(f"egomotion_history: {tuple(egomotion_history.shape)}")
-    print(f"camera_params: {tuple(camera_params.shape)}")
-    print(f"trajectory_target: {tuple(trajectory_target.shape)}")
-    
+    # Print shapes
+    print(f"[dataset] visual_tiles: {tuple(batch_device['visual_tiles'].shape)}")
+    print(f"[dataset] map_tile: {tuple(batch_device['map_tile'].shape)}")
+    print(f"[dataset] egomotion_history: {tuple(batch_device['egomotion_history'].shape)}")
+    print(f"[dataset] camera_params: {tuple(batch_device['camera_params'].shape)}")
+    print(f"[dataset] trajectory_target: {tuple(batch_device['trajectory_target'].shape)}")
 
-    # --------------------
-    # forward pass - Concat fusion path
-    print("Testing forward pass with Concat fusion...")
-    model = AutoE2E(is_pretrained=pretrained_backbone).to(device)
+    return dataset, batch_device
 
-    t0 = time.time()
-    trajectory_, compressed_, future_ = model(visual_tiles, visual_history, egomotion_history, camera_params=camera_params)
-    t_forward = time.time() - t0
-    print(f"Forward pass (Concat fusion): {t_forward:.2f}s")
 
-    print(f"trajectory output (Concat fusion): {tuple(trajectory_.shape)}")
-    print(f"compressed visual feature output: {tuple(compressed_.shape)}")
-    print(f"future visual features: {[tuple(f.shape) for f in future_]}")
-    # --------------------
+def test_bev_infer_mode(
+    batch: dict,
+    device: torch.device,
+    pretrained_backbone: bool,
+) -> None:
+    """Test forward pass with BEV fusion in inference mode."""
+    print("[bev_infer] Testing forward pass with BEV fusion in infer mode")
 
-    # forward pass - BEV fusion path
-    print("Testing forward pass with BEV fusion...")
-    model_bev = AutoE2E(
+    torch.cuda.empty_cache()
+    model = AutoE2E(
         is_pretrained=pretrained_backbone,
         fusion_mode="bev",
     ).to(device)
 
     t0 = time.time()
-    trajectory_bev, ego_hidden_bev, _ = model_bev(
-        visual_tiles,
-        visual_history,
-        egomotion_history,
-        camera_params=camera_params,
+    trajectory, ego_hidden, _ = model(
+        batch["visual_tiles"],
+        batch["map_tile"],
+        batch["visual_history"],
+        batch["egomotion_history"],
+        camera_params=batch["camera_params"],
         mode="infer",
     )
-    t_forward_bev = time.time() - t0
-    print(f"Forward pass (BEV fusion): {t_forward_bev:.2f}s")
-    print(f"trajectory output (BEV fusion): {tuple(trajectory_bev.shape)}")
-    print(f"ego hidden (BEV fusion): {tuple(ego_hidden_bev.shape)}")
+    t_forward = time.time() - t0
 
-    # TODO (training): wire in loss and backprop
-    # loss = F.mse_loss(trajectory, trajectory_target)
-    # loss.backward()
+    print(f"[bev_infer] Forward pass time: {t_forward:.2f}s")
+    print(f"[bev_infer] Trajectory shape: {trajectory.shape}")
+    print(f"[bev_infer] Ego Hidden shape: {tuple(ego_hidden.shape)}")
+    print("[bev_infer] PASSED")
 
-    print("Done.")
+
+def test_bev_train_mode(
+    batch: dict,
+    device: torch.device,
+    pretrained_backbone: bool,
+) -> None:
+    """Test forward pass with BEV fusion in training mode."""
+    print("[bev_train] Testing forward pass with BEV fusion in train mode")
+
+    torch.cuda.empty_cache()
+    model = AutoE2E(
+        is_pretrained=pretrained_backbone,
+        fusion_mode="bev",
+    ).to(device)
+
+    t0 = time.time()
+    planner_loss, ego_hidden, future_visual_features = model(
+        batch["visual_tiles"],
+        batch["map_tile"],
+        batch["visual_history"],
+        batch["egomotion_history"],
+        camera_params=batch["camera_params"],
+        trajectory_target=batch["trajectory_target"],
+        mode="train",
+    )
+    t_forward = time.time() - t0
+
+    print(f"[bev_train] Forward pass time: {t_forward:.2f}s")
+    print(f"[bev_train] Planner loss: {planner_loss.item():.4f}")
+    print(f"[bev_train] Ego Hidden shape: {tuple(ego_hidden.shape)}")
+    print(f"[bev_train] Future Visual Features shapes: {[tuple(f.shape) for f in future_visual_features]}")
+    print("[bev_train] PASSED")
+
+
+def main(
+    dataset_root: str,
+    scene_id: str | None,
+    split: str | None,
+    pretrained_backbone: bool = True,
+    rasterize_map_at_runtime: bool = True,
+) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+    print()
+
+    # Load dataset and get first batch
+    dataset, batch = load_dataset(dataset_root, scene_id, split, rasterize_map_at_runtime=rasterize_map_at_runtime)
+    print()
+
+    # Test inference mode
+    test_bev_infer_mode(batch, device, pretrained_backbone)
+    print()
+
+    # Test training mode
+    test_bev_train_mode(batch, device, pretrained_backbone)
+    print()
+
+    print("All tests passed.")
 
 
 if __name__ == "__main__":
@@ -127,15 +191,16 @@ if __name__ == "__main__":
                     help="Single scene ID to test. Defaults to all scenes in the split.")
     parser.add_argument("--split", type=str, default=None,
                     help="SDK split to use (train, val, test, test_e2e, overlap_train_val).")
-    parser.add_argument("--batch_size", type=int, default=4)
     parser.add_argument("--no-pretrained", action="store_true",
                     help="Skip downloading pretrained weights for the backbone and initialize randomly.")
+    parser.add_argument("--no-rasterize-maps", action="store_true",
+                    help="Disable runtime map rasterization; use zero tensor maps instead (for benchmarking).")
     args = parser.parse_args()
 
     main(
         args.dataset_root,
         args.scene_id,
         args.split,
-        args.batch_size,
         pretrained_backbone=not args.no_pretrained,
+        rasterize_map_at_runtime=not args.no_rasterize_maps,
     )

--- a/Model/data_parsing/kit_scenes/map.py
+++ b/Model/data_parsing/kit_scenes/map.py
@@ -1,0 +1,314 @@
+"""BEV map rasterisation for the KIT Scenes Multimodal dataset.
+
+Provides ``generate_bev_map_tile`` for rendering using OpenCV. `kitscenes` SDK has visualization utilities based on Matplotlib.
+
+Require only base ``lanelet2`` (no ``ml_converter`` wheel).
+
+Rendering mirrors ``kitscenes.visualization.ml_converter_vis_utils``:
+- White background.
+- Road borders (green), curbstones, fence, guard rail drawn thick.
+- Lane dividers: wide gray background stroke + thin coloured stroke on top.
+- Centerlines: dashed darkred.
+- Stop lines: red.
+- Pedestrian crossings: yellow.
+
+Coordinate frame
+----------------
+Poses are in the map-local frame (metres from map origin, axes aligned with
+UTM 32N). All boundary polylines from ``get_lanelets_in_roi`` are in the same
+frame. Tiles are ego-centric: forward (+X) → up, left (+Y) → left.
+
+Caching
+-------
+``_cached_scene_map`` wraps ``load_scene_map`` in ``lru_cache`` so map.osm is
+parsed once per scene per process.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Colour table (RGB) — mirrors ls_type_to_color in ml_converter_vis_utils
+# ---------------------------------------------------------------------------
+# Keys: (type_attr, subtype_attr). subtype=None matches any subtype.
+
+_RGB_TABLE: dict[tuple[str, str | None], tuple[int, int, int]] = {
+    ("road_border",        None):          (0,   200,   0),   # green
+    ("curbstone",          "high"):        (0,   100,   0),   # darkgreen
+    ("curbstone",          "low"):         (50,  205,  50),   # limegreen
+    ("fence",              None):          (165,  42,  42),   # brown
+    ("guard_rail",         None):          (139,  69,  19),   # saddlebrown
+    ("wall",               None):          (205, 133,  63),   # peru
+    ("building",           None):          (244, 164,  96),   # sandybrown
+    ("drivable_area",      None):          (173, 216, 230),   # lightblue
+    ("line_thin",          "dashed"):      (  0,   0, 255),   # blue
+    ("line_thick",         "dashed"):      (  0,   0, 255),   # blue
+    ("line_thin",          "solid"):       (  0,   0, 255),   # blue
+    ("line_thick",         "solid"):       (  0,   0, 139),   # darkblue
+    ("line_thin",          "solid_solid"): (  0,   0, 139),   # darkblue
+    ("line_thin",          "solid_dashed"):(  65, 105, 225),  # royalblue
+    ("line_thin",          "dashed_solid"):(100, 149, 237),   # cornflowerblue
+    ("virtual",            None):          (105, 105, 105),   # dimgrey
+    ("divider",            None):          (128, 128, 128),   # gray
+    ("line_thin",          "centerline"):  (139,   0,   0),   # darkred
+    ("bike_marking",       "dashed"):      (255, 140,   0),   # darkorange
+    ("bike_marking",       "solid"):       (255,  69,   0),   # orangered
+    ("stop_line",          None):          (255,   0,   0),   # red
+    ("pedestrian_marking", None):          (255, 255,   0),   # yellow
+    ("zig-zag",            None):          (255, 215,   0),   # gold
+}
+
+_FALLBACK_RGB: tuple[int, int, int] = (128, 0, 128)  # purple
+
+_BORDER_TYPES = {
+    "road_border", "curbstone", "fence", "guard_rail",
+    "wall", "building", "drivable_area",
+}
+_DIVIDER_TYPES = {"line_thin", "line_thick"}
+_DIVIDER_SUBTYPES = {"solid", "dashed", "solid_solid", "solid_dashed", "dashed_solid"}
+
+
+def _get_rgb(line_type: str, subtype: str) -> tuple[int, int, int]:
+    return _RGB_TABLE.get((line_type, subtype)) \
+        or _RGB_TABLE.get((line_type, None), _FALLBACK_RGB)
+
+
+def _attr(obj, key: str) -> str:
+    return obj.attributes[key] if key in obj.attributes else ""
+
+
+@functools.lru_cache(maxsize=None)
+def _cached_scene_map(scene_path: Path):
+    from kitscenes.map_api import load_scene_map
+    return load_scene_map(scene_path)
+
+
+def _to_px(pts: np.ndarray, ego: np.ndarray, yaw: float, scale: float, rs: int) -> np.ndarray:
+    """Map-local XY → canvas pixels.
+
+    Translates to ego-relative, rotates by -yaw so ego heading points up,
+    then maps to pixel coords: forward (+X_ego) → up, left (+Y_ego) → left.
+    """
+    cx = rs / 2.0
+    rel = pts[:, :2] - ego
+    c, s = np.cos(-yaw), np.sin(-yaw)
+    x_rot = c * rel[:, 0] - s * rel[:, 1]
+    y_rot = s * rel[:, 0] + c * rel[:, 1]
+    col = cx - y_rot * scale
+    row = cx - x_rot * scale
+    return np.stack([col, row], axis=1).astype(np.int32).reshape(-1, 1, 2)
+
+
+def _cv_line(canvas, pts, ego, yaw, scale, rs, rgb, thickness):
+    if len(pts) < 2:
+        return
+    bgr = (rgb[2], rgb[1], rgb[0])
+    cv2.polylines(canvas, [_to_px(pts, ego, yaw, scale, rs)],
+                  isClosed=False, color=bgr, thickness=thickness,
+                  lineType=cv2.LINE_AA)
+
+
+def _cv_divider(canvas, pts, ego, yaw, scale, rs, rgb):
+    """Gray background stroke then thin coloured stroke — mirrors _plot_lane_dividers."""
+    if len(pts) < 2:
+        return
+    px = _to_px(pts, ego, yaw, scale, rs)
+    cv2.polylines(canvas, [px], isClosed=False,
+                  color=(128, 128, 128), thickness=2, lineType=cv2.LINE_AA)
+    bgr = (rgb[2], rgb[1], rgb[0])
+    cv2.polylines(canvas, [px], isClosed=False,
+                  color=bgr, thickness=1, lineType=cv2.LINE_AA)
+
+
+def _cv_dashed(canvas, pts, ego, yaw, scale, rs, rgb, thickness, dash, gap):
+    """Dashed polyline (OpenCV has no native dash support)."""
+    if len(pts) < 2:
+        return
+    px = _to_px(pts, ego, yaw, scale, rs).reshape(-1, 2)
+    bgr = (rgb[2], rgb[1], rgb[0])
+    accum, drawing = 0.0, True
+    for i in range(len(px) - 1):
+        p0, p1 = px[i].astype(float), px[i + 1].astype(float)
+        seg = float(np.linalg.norm(p1 - p0))
+        if seg < 1e-3:
+            continue
+        d = (p1 - p0) / seg
+        pos = 0.0
+        while pos < seg:
+            budget = (dash if drawing else gap) - accum
+            step = min(budget, seg - pos)
+            if drawing:
+                cv2.line(canvas,
+                         tuple((p0 + d * pos).astype(int)),
+                         tuple((p0 + d * (pos + step)).astype(int)),
+                         bgr, thickness, lineType=cv2.LINE_AA)
+            pos += step
+            accum += step
+            if accum >= (dash if drawing else gap):
+                accum, drawing = 0.0, not drawing
+
+
+def generate_bev_map_tile(
+    scene_path: Path,
+    ego_x: float,
+    ego_y: float,
+    ego_yaw: float = 0.0,
+    canvas_size: int = 224,
+    radius_meters: float = 60.0,
+    supersample: int = 4,
+) -> np.ndarray | None:
+    """Rasterise a semantic BEV map tile centred on the ego vehicle (OpenCV).
+
+    Args:
+        scene_path: Scene directory path.
+        ego_local_x: Ego X in map-local frame (metres).
+        ego_local_y: Ego Y in map-local frame (metres).
+        ego_yaw: Ego heading in map frame (radians, Z-up convention). The tile
+            is rotated so the ego's heading always points straight up.
+        canvas_size: Output side length in pixels.
+        radius_meters: Half-width of the observation window in metres.
+        supersample: Render at N×canvas_size then downsample with INTER_AREA.
+
+    Returns:
+        uint8 RGB (canvas_size, canvas_size, 3). White if map unavailable.
+    """
+    scene_map = _cached_scene_map(scene_path)
+    if scene_map is None:
+        # Returning None to distinguish map load failure from an empty map (white).
+        return None
+
+    rs = canvas_size * supersample
+    canvas = np.full((rs, rs, 3), 255, dtype=np.uint8)
+    scale = rs / (radius_meters * 2.0)
+    ego = np.array([ego_x, ego_y], dtype=np.float64)
+    yaw = float(ego_yaw)
+    ss = supersample
+
+    try:
+        lanelets = scene_map.get_lanelets_in_roi(center=ego, radius=radius_meters)
+    except Exception:
+        logger.debug("get_lanelets_in_roi failed for %s", scene_path.name, exc_info=True)
+        lanelets = []
+
+    # Pass 1: road borders and lane dividers
+    for llt in lanelets:
+        for bound in (llt.leftBound, llt.rightBound):
+            pts = np.array([[p.x, p.y] for p in bound], dtype=np.float64)
+            b_type = _attr(bound, "type")
+            b_sub = _attr(bound, "subtype")
+            if b_type in _BORDER_TYPES:
+                _cv_line(canvas, pts, ego, yaw, scale, rs, _get_rgb(b_type, b_sub), 1)
+            elif b_type in _DIVIDER_TYPES and b_sub in _DIVIDER_SUBTYPES:
+                _cv_divider(canvas, pts, ego, yaw, scale, rs,
+                            _get_rgb(b_type, b_sub))
+            elif b_type == "virtual":
+                _cv_line(canvas, pts, ego, yaw, scale, rs, _get_rgb("virtual", ""), 1)
+
+    # Pass 2: centerlines — dashed darkred
+    for llt in lanelets:
+        if _attr(llt, "subtype") == "crosswalk":
+            continue
+        cl = np.array([[p.x, p.y] for p in llt.centerline], dtype=np.float64)
+        if len(cl) >= 2:
+            _cv_dashed(canvas, cl, ego, yaw, scale, rs,
+                       _get_rgb("line_thin", "centerline"),
+                       1, dash=8 * ss, gap=8 * ss)
+
+    # Pass 3: pedestrian crossings — yellow
+    for llt in lanelets:
+        if _attr(llt, "subtype") != "crosswalk":
+            continue
+        for bound in (llt.leftBound, llt.rightBound):
+            pts = np.array([[p.x, p.y] for p in bound], dtype=np.float64)
+            _cv_line(canvas, pts, ego, yaw, scale, rs,
+                     _get_rgb("pedestrian_marking", ""), 1)
+
+    # Pass 4: stop lines — red
+    try:
+        for line in scene_map.get_stop_lines():
+            pts = np.array(line, dtype=np.float64)
+            _cv_line(canvas, pts, ego, yaw, scale, rs, _get_rgb("stop_line", ""), 1)
+    except Exception:
+        pass
+
+    if supersample == 1:
+        return canvas
+    return cv2.resize(canvas, (canvas_size, canvas_size),
+                      interpolation=cv2.INTER_AREA)
+
+
+# ---------------------------------------------------------------------------
+# Visualization — legend + display
+# ---------------------------------------------------------------------------
+
+# Legend entries matching ls_type_to_color in ml_converter_vis_utils
+_LEGEND_ENTRIES: list[tuple[str, tuple[float, float, float]]] = [
+    ("Road Border",        (0,      200/255, 0)),
+    ("Curbstone High",     (0,      100/255, 0)),
+    ("Curbstone Low",      (50/255, 205/255, 50/255)),
+    ("Fence / Guard Rail", (139/255, 69/255, 19/255)),
+    ("Drivable Area",      (173/255, 216/255, 230/255)),
+    ("Dashed lane",        (0,      0,       1.0)),
+    ("Solid lane",         (0,      0,       139/255)),
+    ("Solid-Dashed",       (65/255, 105/255, 225/255)),
+    ("Virtual",            (105/255, 105/255, 105/255)),
+    ("Centerline",         (139/255, 0,       0)),
+    ("Stop Line",          (1.0,    0,       0)),
+    ("Ped. Crossing",      (1.0,    1.0,     0)),
+]
+
+
+def visualise_bev_tile(
+    bev_rgb: np.ndarray,
+    title: str = "BEV map tile",
+    save_path: str | Path | None = None,
+    figsize: tuple[int, int] = (9, 7),
+) -> None:
+    """Display a BEV map tile with a semantic legend.
+
+    Args:
+        bev_rgb: (H, W, 3) uint8 RGB array from either generate function.
+        title: Figure title.
+        save_path: If provided, saves to this path; otherwise calls plt.show().
+        figsize: Matplotlib figure size in inches.
+    """
+    import matplotlib.patches as mpatches
+    import matplotlib.pyplot as plt
+
+    fig, (ax_map, ax_leg) = plt.subplots(
+        1, 2, figsize=figsize,
+        gridspec_kw={"width_ratios": [4, 1]},
+    )
+
+    ax_map.imshow(bev_rgb)
+    ax_map.set_title(title, fontsize=11)
+    ax_map.axis("off")
+
+    h, w = bev_rgb.shape[:2]
+    ax_map.plot(w / 2, h / 2, marker="^", color="black",
+                markersize=8, markeredgecolor="white", markeredgewidth=1, zorder=10)
+    ax_map.annotate("N ↑ fwd", (w * 0.02, h * 0.04), color="black", fontsize=7)
+
+    patches = [
+        mpatches.Patch(facecolor=colour, edgecolor="grey", linewidth=0.5, label=label)
+        for label, colour in _LEGEND_ENTRIES
+    ]
+    ax_leg.legend(handles=patches, loc="center left", fontsize=8,
+                  frameon=False, handlelength=1.5, handleheight=1.2)
+    ax_leg.axis("off")
+
+    plt.tight_layout()
+    if save_path is not None:
+        plt.savefig(save_path, dpi=150, bbox_inches="tight")
+        print(f"Saved {save_path}")
+    else:
+        plt.show()
+    plt.close(fig)

--- a/Model/data_parsing/kit_scenes/map.py
+++ b/Model/data_parsing/kit_scenes/map.py
@@ -121,7 +121,7 @@ def _cv_divider(canvas, pts, ego, yaw, scale, rs, rgb, thickness):
         return
     px = _to_px(pts, ego, yaw, scale, rs)
     cv2.polylines(canvas, [px], isClosed=False,
-                  color=(128, 128, 128), thickness=thickness * 2, lineType=cv2.LINE_AA)
+                  color=(128, 128, 128), thickness=thickness * 3, lineType=cv2.LINE_AA)
     cv2.polylines(canvas, [px], isClosed=False,
                   color=rgb, thickness=thickness, lineType=cv2.LINE_AA)
 
@@ -246,16 +246,17 @@ def generate_bev_map_tile(
 
 # Legend entries matching ls_type_to_color in ml_converter_vis_utils
 _LEGEND_ENTRIES: list[tuple[str, tuple[float, float, float]]] = [
-    ("Road Border",        (0,      200/255, 0)),
-    ("Curbstone High",     (0,      100/255, 0)),
-    ("Curbstone Low",      (50/255, 205/255, 50/255)),
-    ("Fence / Guard Rail", (139/255, 69/255, 19/255)),
-    ("Dashed lane",        (0,      0,       1.0)),
-    ("Solid lane",         (0,      0,       139/255)),
-    ("Solid-Dashed",       (65/255, 105/255, 225/255)),
-    ("Centerline",         (139/255, 0,       0)),
-    ("Stop Line",          (1.0,    0,       0)),
-    ("Ped. Crossing",      (1.0,    1.0,     0)),
+    ("Road Border",                                      (0,       200/255, 0)),
+    ("Curbstone High",                                   (0,       100/255, 0)),
+    ("Curbstone Low",                                    (50/255,  205/255, 50/255)),
+    ("Fence / Guard Rail",                               (139/255, 69/255,  19/255)),
+    ("Virtual boundary",                                 (105/255, 105/255, 105/255)),
+    ("Dashed lane divider (blue + grey outline)",        (0,       0,       1.0)),
+    ("Solid lane divider (darkblue + grey outline)",     (0,       0,       139/255)),
+    ("Solid-Dashed divider (royalblue + grey outline)",  (65/255,  105/255, 225/255)),
+    ("Centerline",                                       (139/255, 0,       0)),
+    ("Stop Line",                                        (1.0,     0,       0)),
+    ("Ped. Crossing",                                    (1.0,     1.0,     0)),
 ]
 
 def visualise_bev_tile(

--- a/Model/data_parsing/kit_scenes/map.py
+++ b/Model/data_parsing/kit_scenes/map.py
@@ -1,8 +1,7 @@
-"""BEV map rasterisation for the KIT Scenes Multimodal dataset.
+"""BEV map rasterization for the KIT Scenes Multimodal dataset.
 
-Provides ``generate_bev_map_tile`` for rendering using OpenCV. `kitscenes` SDK has visualization utilities based on Matplotlib.
-
-Require only base ``lanelet2`` (no ``ml_converter`` wheel).
+Provides ``generate_bev_map_tile`` for rendering using OpenCV. Requires only
+base ``lanelet2`` (no ``lanelet2_ml_converter`` wheel).
 
 Rendering mirrors ``kitscenes.visualization.ml_converter_vis_utils``:
 - White background.

--- a/Model/data_parsing/kit_scenes/map.py
+++ b/Model/data_parsing/kit_scenes/map.py
@@ -157,7 +157,7 @@ def generate_bev_map_tile(
     ego_x: float,
     ego_y: float,
     ego_yaw: float = 0.0,
-    canvas_size: int = 224,
+    canvas_size: int = 256,
     radius_meters: float = 60.0,
     linewidths: float = 1.5,
 ) -> np.ndarray | None:

--- a/Model/data_parsing/kit_scenes/map.py
+++ b/Model/data_parsing/kit_scenes/map.py
@@ -48,7 +48,6 @@ _RGB_TABLE: dict[tuple[str, str | None], tuple[int, int, int]] = {
     ("guard_rail",         None):          (139,  69,  19),   # saddlebrown
     ("wall",               None):          (205, 133,  63),   # peru
     ("building",           None):          (244, 164,  96),   # sandybrown
-    ("drivable_area",      None):          (173, 216, 230),   # lightblue
     ("line_thin",          "dashed"):      (  0,   0, 255),   # blue
     ("line_thick",         "dashed"):      (  0,   0, 255),   # blue
     ("line_thin",          "solid"):       (  0,   0, 255),   # blue
@@ -70,10 +69,13 @@ _FALLBACK_RGB: tuple[int, int, int] = (128, 0, 128)  # purple
 
 _BORDER_TYPES = {
     "road_border", "curbstone", "fence", "guard_rail",
-    "wall", "building", "drivable_area",
+    "wall", "building"
 }
 _DIVIDER_TYPES = {"line_thin", "line_thick"}
 _DIVIDER_SUBTYPES = {"solid", "dashed", "solid_solid", "solid_dashed", "dashed_solid"}
+
+_RENDER_SIZE = 2048  # fixed internal resolution for rendering map
+
 
 
 def _get_rgb(line_type: str, subtype: str) -> tuple[int, int, int]:
@@ -110,30 +112,24 @@ def _to_px(pts: np.ndarray, ego: np.ndarray, yaw: float, scale: float, rs: int) 
 def _cv_line(canvas, pts, ego, yaw, scale, rs, rgb, thickness):
     if len(pts) < 2:
         return
-    bgr = (rgb[2], rgb[1], rgb[0])
     cv2.polylines(canvas, [_to_px(pts, ego, yaw, scale, rs)],
-                  isClosed=False, color=bgr, thickness=thickness,
+                  isClosed=False, color=rgb, thickness=thickness,
                   lineType=cv2.LINE_AA)
 
-
-def _cv_divider(canvas, pts, ego, yaw, scale, rs, rgb):
-    """Gray background stroke then thin coloured stroke — mirrors _plot_lane_dividers."""
+def _cv_divider(canvas, pts, ego, yaw, scale, rs, rgb, thickness):
     if len(pts) < 2:
         return
     px = _to_px(pts, ego, yaw, scale, rs)
     cv2.polylines(canvas, [px], isClosed=False,
-                  color=(128, 128, 128), thickness=2, lineType=cv2.LINE_AA)
-    bgr = (rgb[2], rgb[1], rgb[0])
+                  color=(128, 128, 128), thickness=thickness * 2, lineType=cv2.LINE_AA)
     cv2.polylines(canvas, [px], isClosed=False,
-                  color=bgr, thickness=1, lineType=cv2.LINE_AA)
-
+                  color=rgb, thickness=thickness, lineType=cv2.LINE_AA)
 
 def _cv_dashed(canvas, pts, ego, yaw, scale, rs, rgb, thickness, dash, gap):
-    """Dashed polyline (OpenCV has no native dash support)."""
     if len(pts) < 2:
         return
     px = _to_px(pts, ego, yaw, scale, rs).reshape(-1, 2)
-    bgr = (rgb[2], rgb[1], rgb[0])
+    # remove bgr swap — use rgb directly
     accum, drawing = 0.0, True
     for i in range(len(px) - 1):
         p0, p1 = px[i].astype(float), px[i + 1].astype(float)
@@ -149,7 +145,7 @@ def _cv_dashed(canvas, pts, ego, yaw, scale, rs, rgb, thickness, dash, gap):
                 cv2.line(canvas,
                          tuple((p0 + d * pos).astype(int)),
                          tuple((p0 + d * (pos + step)).astype(int)),
-                         bgr, thickness, lineType=cv2.LINE_AA)
+                         rgb, thickness, lineType=cv2.LINE_AA)
             pos += step
             accum += step
             if accum >= (dash if drawing else gap):
@@ -163,34 +159,29 @@ def generate_bev_map_tile(
     ego_yaw: float = 0.0,
     canvas_size: int = 224,
     radius_meters: float = 60.0,
-    supersample: int = 4,
+    linewidths: float = 1.5,
 ) -> np.ndarray | None:
-    """Rasterise a semantic BEV map tile centred on the ego vehicle (OpenCV).
-
+    """
     Args:
         scene_path: Scene directory path.
-        ego_local_x: Ego X in map-local frame (metres).
-        ego_local_y: Ego Y in map-local frame (metres).
-        ego_yaw: Ego heading in map frame (radians, Z-up convention). The tile
-            is rotated so the ego's heading always points straight up.
-        canvas_size: Output side length in pixels.
+        ego_x: Ego X in map-local frame (metres).
+        ego_y: Ego Y in map-local frame (metres).
+        ego_yaw: Ego heading in map frame (radians, Z-up convention).
+        canvas_size: Output size in pixels. Rendered internally at
+            _RENDER_SIZE and resized to this.
         radius_meters: Half-width of the observation window in metres.
-        supersample: Render at N×canvas_size then downsample with INTER_AREA.
-
-    Returns:
-        uint8 RGB (canvas_size, canvas_size, 3). White if map unavailable.
+        linewidths: Base line weight; scaled internally to the render size.
     """
     scene_map = _cached_scene_map(scene_path)
     if scene_map is None:
-        # Returning None to distinguish map load failure from an empty map (white).
         return None
 
-    rs = canvas_size * supersample
+    rs = _RENDER_SIZE
     canvas = np.full((rs, rs, 3), 255, dtype=np.uint8)
     scale = rs / (radius_meters * 2.0)
     ego = np.array([ego_x, ego_y], dtype=np.float64)
     yaw = float(ego_yaw)
-    ss = supersample
+    lw = max(1, round(linewidths * rs / 1000))  # scale line weight to render size; linewidths is in "units per 1000px"
 
     try:
         lanelets = scene_map.get_lanelets_in_roi(center=ego, radius=radius_meters)
@@ -205,12 +196,12 @@ def generate_bev_map_tile(
             b_type = _attr(bound, "type")
             b_sub = _attr(bound, "subtype")
             if b_type in _BORDER_TYPES:
-                _cv_line(canvas, pts, ego, yaw, scale, rs, _get_rgb(b_type, b_sub), 1)
+                _cv_line(canvas, pts, ego, yaw, scale, rs, _get_rgb(b_type, b_sub), lw)
             elif b_type in _DIVIDER_TYPES and b_sub in _DIVIDER_SUBTYPES:
                 _cv_divider(canvas, pts, ego, yaw, scale, rs,
-                            _get_rgb(b_type, b_sub))
+                            _get_rgb(b_type, b_sub), lw)
             elif b_type == "virtual":
-                _cv_line(canvas, pts, ego, yaw, scale, rs, _get_rgb("virtual", ""), 1)
+                _cv_line(canvas, pts, ego, yaw, scale, rs, _get_rgb("virtual", ""), lw)
 
     # Pass 2: centerlines — dashed darkred
     for llt in lanelets:
@@ -220,29 +211,33 @@ def generate_bev_map_tile(
         if len(cl) >= 2:
             _cv_dashed(canvas, cl, ego, yaw, scale, rs,
                        _get_rgb("line_thin", "centerline"),
-                       1, dash=8 * ss, gap=8 * ss)
+                       thickness=lw, dash=4 * lw, gap=4 * lw)
 
-    # Pass 3: pedestrian crossings — yellow
+    # Pass 3: pedestrian crossings
     for llt in lanelets:
         if _attr(llt, "subtype") != "crosswalk":
             continue
         for bound in (llt.leftBound, llt.rightBound):
             pts = np.array([[p.x, p.y] for p in bound], dtype=np.float64)
-            _cv_line(canvas, pts, ego, yaw, scale, rs,
-                     _get_rgb("pedestrian_marking", ""), 1)
+            b_type = _attr(bound, "type")
+            b_sub = _attr(bound, "subtype")
+            color = _get_rgb(b_type, b_sub)
+            if color == _FALLBACK_RGB:
+                color = _get_rgb("pedestrian_marking", None)
+            _cv_line(canvas, pts, ego, yaw, scale, rs, color, lw)
 
-    # Pass 4: stop lines — red
+    # Pass 4: stop lines
     try:
         for line in scene_map.get_stop_lines():
             pts = np.array(line, dtype=np.float64)
-            _cv_line(canvas, pts, ego, yaw, scale, rs, _get_rgb("stop_line", ""), 1)
+            _cv_line(canvas, pts, ego, yaw, scale, rs, _get_rgb("stop_line", ""), lw)
     except Exception:
         pass
 
-    if supersample == 1:
+    if canvas_size == rs:
         return canvas
-    return cv2.resize(canvas, (canvas_size, canvas_size),
-                      interpolation=cv2.INTER_AREA)
+    interp = cv2.INTER_AREA if canvas_size < rs else cv2.INTER_LINEAR
+    return cv2.resize(canvas, (canvas_size, canvas_size), interpolation=interp)
 
 
 # ---------------------------------------------------------------------------
@@ -255,16 +250,13 @@ _LEGEND_ENTRIES: list[tuple[str, tuple[float, float, float]]] = [
     ("Curbstone High",     (0,      100/255, 0)),
     ("Curbstone Low",      (50/255, 205/255, 50/255)),
     ("Fence / Guard Rail", (139/255, 69/255, 19/255)),
-    ("Drivable Area",      (173/255, 216/255, 230/255)),
     ("Dashed lane",        (0,      0,       1.0)),
     ("Solid lane",         (0,      0,       139/255)),
     ("Solid-Dashed",       (65/255, 105/255, 225/255)),
-    ("Virtual",            (105/255, 105/255, 105/255)),
     ("Centerline",         (139/255, 0,       0)),
     ("Stop Line",          (1.0,    0,       0)),
     ("Ped. Crossing",      (1.0,    1.0,     0)),
 ]
-
 
 def visualise_bev_tile(
     bev_rgb: np.ndarray,


### PR DESCRIPTION
## Key difference: Vectorized HD maps
 
Unlike NVIDIA, KIT Scenes ships production-grade Lanelet2 HD maps as the primary map representation. This raises the question: how to feed vectorized road geometry into a vision model backbone?
 
**Solution: `map.py` — rasterize maps to semantic RGB tiles.** Each scene's Lanelet2 map is queried for lanelets in an ego-centric region, then rasterized using OpenCV into a `(H, W, 3)` uint8 RGB image. The tile includes:
- Road borders (green), curbstones (dark/light green), guard rails, fences, walls (browns)
- Lane dividers (gray background + coloured stroke)
- Centerlines (dashed darkred)
- Stop lines (red)
- Pedestrian crossings (yellow)
The tile is ego-centric (forward → up, left → left) and rotated so the ego's heading always points straight up. It's then passed through the same backbone transform (resize + ImageNet normalisation) as the camera frames, so all 8 views share identical shape and normalisation.

## Design tradeoff: Rasterization vs. alternative representations
 
Rasterizing is not free. At scale, the per-tile cost adds up. Three directions to consider:
 
**1. Keep current approach (rasterize → backbone image encoder)**
- Pros: Consistent with camera pipeline; maps are just "another view" to the model
- Cons: Lanelet2 is inherently vectorized; rasterization loses graph structure (lane topology, connectivity)

**2. Vectorized map encoder with spatial output (not v1)**
- Keep maps as polylines/graphs; encode via GNN/transformer on lanelet graph, output `(3, H, W)` directly
- Lanelet graph (nodes, edges, lane adjacency) → GNN → decoder projects to spatial → `(3, H, W)` → stacks as view 8
- The 3 channels encode learned semantics (e.g., drivable area, lane boundaries, regulatory elements) instead of rasterized RGB
- Pros: No rasterization cost; preserves graph structure; model contract stays clean (still `visual_tiles (B, 8, 3, H, W)`)
- Cons: Encoder complexity (variable-size graphs → fixed spatial output); need to design lanelet featurization and channel semantics
- This is **data parsing + encoder design**, still clean separation from AutoE2E. Viable for v2 if rasterization bottleneck is confirmed.

## Current choice & next steps
 
Current: rasterize to RGB, apply backbone transform, feed as slot 7 to the same CNN backbone. This is simple and works. 
 
For v2, we could collect profiling data on the rasterization bottleneck during training. If rasterization becomes a bottleneck after the first training run, pivot to option 2 (vectorized encoder).
 
## Map Transforms
 
Currently using `timm.data.create_transform` (backbone-driven ImageNet normalization). Alternatives:
- **Task-specific transforms:** Histogram equalization or CLAHE (contrast) for map clarity (maps are simpler than camera images; might benefit from different preprocessing)
- **Non-ImageNet normalization:** ImageNet statistics may not make sense for raster maps. 

Keeping ImageNet norm for now (simple, well-studied), but this is tunable.
 
## Testing
 
`forward_pass_test.py` validates: dataset → batch → forward pass. 
 
Example smoke test on one scene:
```bash
python forward_pass_test.py --dataset_root $KITSCENES_ROOT --scene_id <uuid> --no-pretrained
```