### PR TITLE
ci: run all test files instead of only test_auto_e2e.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         run: ruff check
 
       - name: Run unit tests
-        run: cd Model/tests && python -m pytest test_auto_e2e.py -v -m "not integration"
+        run: cd Model/tests && python -m pytest -v -m "not integration"


### PR DESCRIPTION
The CI workflow pins pytest to a single file:

  ```yaml
  run: cd Model/tests && python -m pytest test_auto_e2e.py -v -m "not integration"
  ```

  As a result, `test_trajectory_loss.py` (added in #39) has never been executed in CI, and any future test file would be silently skipped as well.
