### PR TITLE
feat(data_parsing): add GPS-to-BEV map tile rendering utility

### DIFF
--- a/Model/data_parsing/map_rendering/README.md
+++ b/Model/data_parsing/map_rendering/README.md
@@ -1,0 +1,119 @@
+# GPS → BEV Map Tile Rendering
+
+Offline preprocessing utility that turns raw GPS waypoints into BEV map tiles
+in the style of the L2D dataset's pre-rendered map. Use it for datasets that
+do not natively ship map images (e.g. KIT Scenes, NVIDIA PhysicalAI).
+
+## When to use
+
+- You have GPS lat/lon traces per clip and want a model input equivalent to
+  L2D's BEV map tile.
+- You are building a dataset offline and can pre-render every tile.
+- You do **not** want to render at training time — fetching road networks via
+  Overpass takes seconds per call and requires internet access.
+
+## Workflow
+
+1. Build a `{clip_id: (latitudes, longitudes)}` mapping from your dataset.
+2. Run `render_and_cache_tiles(...)` once to produce one PNG per clip plus a
+   shared road-network pickle cache.
+3. In the DataLoader, read the PNG, push it through your timm transform like
+   any other camera tile.
+
+## Module layout
+
+| File | Purpose |
+| --- | --- |
+| `gps_to_map.py` | Core: fetch network, map-match, render, end-to-end tensor. |
+| `cache.py`      | Pickle network graphs and batch-render dataset tiles. |
+| `test_gps_to_map.py` | Offline tests; `osmnx.graph_from_point` is mocked. |
+
+## Public API
+
+```python
+from data_parsing.map_rendering import (
+    fetch_road_network,
+    map_match_waypoints,
+    render_map_tile,
+    gps_to_tensor,
+)
+from data_parsing.map_rendering.cache import (
+    cache_network,
+    load_cached_network,
+    render_and_cache_tiles,
+)
+```
+
+### Single-clip example
+
+```python
+import timm
+from data_parsing.map_rendering import gps_to_tensor
+
+backbone = timm.create_model("swinv2_tiny_window8_256", pretrained=False)
+data_cfg = timm.data.resolve_model_data_config(backbone)
+transform = timm.data.create_transform(**data_cfg, is_training=False)
+
+tensor = gps_to_tensor(
+    latitudes=lats,
+    longitudes=lons,
+    transform=transform,
+    radius_m=800,
+)
+# tensor.shape == (3, H, W) — drop straight into the visual_tiles slot.
+```
+
+### Batch preprocessing
+
+```python
+from data_parsing.map_rendering.cache import render_and_cache_tiles
+
+paths = render_and_cache_tiles(
+    dataset_gps_data={clip_id: (lats, lons) for clip_id, lats, lons in clips},
+    output_dir="cache/map_tiles",
+    network_cache_dir="cache/road_networks",
+    radius_m=800,
+)
+```
+
+`network_cache_dir` quantizes centroids to ~100 m so adjacent clips reuse the
+same downloaded graph.
+
+## Style
+
+Defaults match the L2D BEV map palette and dimensions:
+
+| Element | Default |
+| --- | --- |
+| Image size | 640 × 360 |
+| Background | `#111111` |
+| Road network | `#444444` |
+| Route | `#00CCFF` |
+| Raw GPS markers | `#FF3333` |
+| DPI | 200 |
+
+All of these are arguments on `render_map_tile` and `gps_to_tensor`.
+
+## Dependencies
+
+- `osmnx` (and its transitive `geopandas` / `shapely` chain)
+- `matplotlib` (headless `Agg` backend is selected automatically)
+- `Pillow`
+- `networkx`
+- `torch` (only for the tensor output path)
+
+Install with:
+
+```
+pip install osmnx geopandas matplotlib pillow networkx
+```
+
+## Notes
+
+- This is a **data preprocessing** utility. It lives in `data_parsing/`, not
+  `model_components/`. Do not call it from a `Dataset.__getitem__`.
+- Map matching can fail (waypoints outside the fetched bbox, disconnected
+  components). When it does, the renderer falls back to drawing the network
+  plus raw GPS markers.
+- Tests must not require internet — `osmnx.graph_from_point` and
+  `osmnx.distance.nearest_nodes` are mocked.

--- a/Model/data_parsing/map_rendering/README.md
+++ b/Model/data_parsing/map_rendering/README.md
@@ -4,6 +4,24 @@ Offline preprocessing utility that turns raw GPS waypoints into BEV map tiles
 in the style of the L2D dataset's pre-rendered map. Use it for datasets that
 do not natively ship map images (e.g. KIT Scenes, NVIDIA PhysicalAI).
 
+## Ego-centric framing
+
+Tiles are rendered **ego-centric**, matching the L2D / NVIDIA / KIT Scenes
+convention:
+
+- Center: the ego pose `(ego_lat, ego_lon)` (defaults to the last GPS sample
+  when omitted in `gps_to_tensor`).
+- Orientation: rotated so the ego forward direction points **up** in the
+  image (forward = +y).
+- Frame: a local equirectangular projection — coordinates are converted from
+  lon/lat to metres relative to the ego, then rotated by `-ego_heading`. The
+  axes share a common metric scale (`ax.set_aspect("equal")`), so there is
+  no lat/lon aspect distortion.
+- Extent: a fixed metric window of `±radius_m` around the origin.
+
+`ego_heading` is in radians, measured CCW from north (so `0` = north, the
+ego is facing north and the tile is north-up).
+
 ## When to use
 
 - You have GPS lat/lon traces per clip and want a model input equivalent to
@@ -58,6 +76,8 @@ tensor = gps_to_tensor(
     latitudes=lats,
     longitudes=lons,
     transform=transform,
+    ego_heading=heading_rad,  # radians CCW from north
+    # ego_lat / ego_lon default to the last GPS sample
     radius_m=800,
 )
 # tensor.shape == (3, H, W) — drop straight into the visual_tiles slot.
@@ -115,5 +135,8 @@ pip install osmnx geopandas matplotlib pillow networkx
 - Map matching can fail (waypoints outside the fetched bbox, disconnected
   components). When it does, the renderer falls back to drawing the network
   plus raw GPS markers.
+- `render_and_cache_tiles` estimates `ego_heading` from the last segment of
+  each GPS trace. If you have a more accurate heading source (IMU, GNSS
+  course-over-ground), prefer calling `render_map_tile` directly with it.
 - Tests must not require internet — `osmnx.graph_from_point` and
   `osmnx.distance.nearest_nodes` are mocked.

--- a/Model/data_parsing/map_rendering/__init__.py
+++ b/Model/data_parsing/map_rendering/__init__.py
@@ -1,0 +1,20 @@
+"""Offline GPS-to-map-tile rendering for datasets that lack BEV map images.
+
+See README.md for the full preprocessing workflow. The rendered tiles match
+the L2D BEV map format and can be fed through the same timm transform as
+camera tiles.
+"""
+
+from .gps_to_map import (
+    fetch_road_network,
+    gps_to_tensor,
+    map_match_waypoints,
+    render_map_tile,
+)
+
+__all__ = [
+    "fetch_road_network",
+    "gps_to_tensor",
+    "map_match_waypoints",
+    "render_map_tile",
+]

--- a/Model/data_parsing/map_rendering/cache.py
+++ b/Model/data_parsing/map_rendering/cache.py
@@ -112,7 +112,12 @@ def render_and_cache_tiles(
                 image_size=image_size,
             )
         except Exception as exc:  # noqa: BLE001 — matplotlib/osmnx errors vary
-            logger.warning("clip %s: render failed (%s); skipping", clip_id, exc)
+            logger.warning(
+                "clip %s: render failed (%s); skipping",
+                clip_id,
+                exc,
+                exc_info=True,
+            )
             continue
 
         image.save(tile_path)

--- a/Model/data_parsing/map_rendering/cache.py
+++ b/Model/data_parsing/map_rendering/cache.py
@@ -1,0 +1,37 @@
+"""Caching helpers for the map rendering pipeline.
+
+Network fetches via osmnx are slow (seconds each, internet required). This
+module persists fetched graphs to disk and renders/persists tiles for an
+entire dataset in one batch so the DataLoader only ever reads PNGs.
+"""
+
+from __future__ import annotations
+
+import logging
+import pickle
+from pathlib import Path
+
+import networkx as nx
+
+logger = logging.getLogger(__name__)
+
+
+def cache_network(graph: nx.MultiDiGraph, filepath: str | Path) -> None:
+    """Pickle a road-network graph to disk."""
+    path = Path(filepath)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as f:
+        pickle.dump(graph, f)
+
+
+def load_cached_network(filepath: str | Path) -> nx.MultiDiGraph | None:
+    """Load a pickled road-network graph, or `None` if the file is missing."""
+    path = Path(filepath)
+    if not path.exists():
+        return None
+    try:
+        with path.open("rb") as f:
+            return pickle.load(f)
+    except (OSError, pickle.UnpicklingError) as exc:
+        logger.warning("failed to load cached network %s: %s", path, exc)
+        return None

--- a/Model/data_parsing/map_rendering/cache.py
+++ b/Model/data_parsing/map_rendering/cache.py
@@ -10,8 +10,17 @@ from __future__ import annotations
 import logging
 import pickle
 from pathlib import Path
+from typing import Iterable, Mapping, Sequence
 
 import networkx as nx
+
+from .gps_to_map import (
+    DEFAULT_IMAGE_SIZE,
+    DEFAULT_RADIUS_M,
+    fetch_road_network,
+    map_match_waypoints,
+    render_map_tile,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,3 +44,106 @@ def load_cached_network(filepath: str | Path) -> nx.MultiDiGraph | None:
     except (OSError, pickle.UnpicklingError) as exc:
         logger.warning("failed to load cached network %s: %s", path, exc)
         return None
+
+
+def render_and_cache_tiles(
+    dataset_gps_data: Mapping[str, tuple[Sequence[float], Sequence[float]]],
+    output_dir: str | Path,
+    radius_m: int = DEFAULT_RADIUS_M,
+    image_size: tuple[int, int] = DEFAULT_IMAGE_SIZE,
+    network_cache_dir: str | Path | None = None,
+    skip_existing: bool = True,
+) -> list[Path]:
+    """Pre-render and persist a BEV map tile for every clip in a dataset.
+
+    Args:
+        dataset_gps_data: mapping of `clip_id -> (latitudes, longitudes)`.
+        output_dir: where rendered PNG tiles are written (`{clip_id}.png`).
+        radius_m: render radius around each clip's centroid.
+        image_size: output `(W, H)`.
+        network_cache_dir: if given, fetched graphs are persisted here keyed by
+            centroid so neighbouring clips share a cached download.
+        skip_existing: do not re-render clips whose PNG already exists.
+
+    Returns:
+        List of paths to the rendered tile files (including pre-existing ones).
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    net_cache = Path(network_cache_dir) if network_cache_dir else None
+    if net_cache is not None:
+        net_cache.mkdir(parents=True, exist_ok=True)
+
+    rendered: list[Path] = []
+    for clip_id, (lats, lons) in dataset_gps_data.items():
+        tile_path = out / f"{clip_id}.png"
+        if skip_existing and tile_path.exists():
+            rendered.append(tile_path)
+            continue
+
+        if not lats:
+            logger.warning("clip %s has no GPS samples; skipping", clip_id)
+            continue
+
+        center_lat = sum(lats) / len(lats)
+        center_lon = sum(lons) / len(lons)
+
+        graph = _load_or_fetch_network(
+            center_lat, center_lon, radius_m, net_cache
+        )
+        if graph is None:
+            logger.warning("clip %s: failed to obtain road network; skipping", clip_id)
+            continue
+
+        _, route = map_match_waypoints(graph, list(lats), list(lons))
+        raw_points = list(zip(lats, lons))
+        try:
+            image = render_map_tile(
+                graph,
+                route_nodes=route,
+                raw_gps_points=raw_points,
+                image_size=image_size,
+            )
+        except Exception as exc:  # noqa: BLE001 — matplotlib/osmnx errors vary
+            logger.warning("clip %s: render failed (%s); skipping", clip_id, exc)
+            continue
+
+        image.save(tile_path)
+        rendered.append(tile_path)
+
+    return rendered
+
+
+def _load_or_fetch_network(
+    center_lat: float,
+    center_lon: float,
+    radius_m: int,
+    cache_dir: Path | None,
+) -> nx.MultiDiGraph | None:
+    """Return a cached graph if available, otherwise fetch and cache it.
+
+    Centroids are quantized to ~100 m so nearby clips reuse the same download.
+    """
+    if cache_dir is not None:
+        key = f"{round(center_lat, 3)}_{round(center_lon, 3)}_{radius_m}.pkl"
+        cache_path = cache_dir / key
+        cached = load_cached_network(cache_path)
+        if cached is not None:
+            return cached
+    else:
+        cache_path = None
+
+    try:
+        graph = fetch_road_network(center_lat, center_lon, radius_m=radius_m)
+    except Exception as exc:  # noqa: BLE001 — network/Overpass failures
+        logger.warning(
+            "fetch_road_network(%.4f, %.4f) failed: %s",
+            center_lat,
+            center_lon,
+            exc,
+        )
+        return None
+
+    if cache_path is not None:
+        cache_network(graph, cache_path)
+    return graph

--- a/Model/data_parsing/map_rendering/cache.py
+++ b/Model/data_parsing/map_rendering/cache.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import pickle
 from pathlib import Path
-from typing import Iterable, Mapping, Sequence
+from typing import Mapping, Sequence
 
 import networkx as nx
 

--- a/Model/data_parsing/map_rendering/cache.py
+++ b/Model/data_parsing/map_rendering/cache.py
@@ -8,6 +8,7 @@ entire dataset in one batch so the DataLoader only ever reads PNGs.
 from __future__ import annotations
 
 import logging
+import math
 import pickle
 from pathlib import Path
 from typing import Mapping, Sequence
@@ -17,6 +18,7 @@ import networkx as nx
 from .gps_to_map import (
     DEFAULT_IMAGE_SIZE,
     DEFAULT_RADIUS_M,
+    EARTH_RADIUS_M,
     fetch_road_network,
     map_match_waypoints,
     render_map_tile,
@@ -85,11 +87,12 @@ def render_and_cache_tiles(
             logger.warning("clip %s has no GPS samples; skipping", clip_id)
             continue
 
-        center_lat = sum(lats) / len(lats)
-        center_lon = sum(lons) / len(lons)
+        ego_lat = float(lats[-1])
+        ego_lon = float(lons[-1])
+        ego_heading = _heading_from_trace(lats, lons, ego_lat)
 
         graph = _load_or_fetch_network(
-            center_lat, center_lon, radius_m, net_cache
+            ego_lat, ego_lon, radius_m, net_cache
         )
         if graph is None:
             logger.warning("clip %s: failed to obtain road network; skipping", clip_id)
@@ -101,7 +104,11 @@ def render_and_cache_tiles(
             image = render_map_tile(
                 graph,
                 route_nodes=route,
+                ego_lat=ego_lat,
+                ego_lon=ego_lon,
+                ego_heading=ego_heading,
                 raw_gps_points=raw_points,
+                radius_m=radius_m,
                 image_size=image_size,
             )
         except Exception as exc:  # noqa: BLE001 — matplotlib/osmnx errors vary
@@ -112,6 +119,26 @@ def render_and_cache_tiles(
         rendered.append(tile_path)
 
     return rendered
+
+
+def _heading_from_trace(
+    lats: Sequence[float], lons: Sequence[float], ref_lat: float
+) -> float:
+    """Estimate ego heading (radians) from the last segment of the GPS trace.
+
+    Uses atan2(east, north) so 0 rad ≡ north and the value matches the
+    `ego_heading` convention in `render_map_tile`. Falls back to 0 when the
+    trace has fewer than two distinct samples.
+    """
+    if len(lats) < 2:
+        return 0.0
+    cos_lat = math.cos(math.radians(ref_lat))
+    deg_to_m = EARTH_RADIUS_M * math.pi / 180.0
+    dx = (lons[-1] - lons[-2]) * cos_lat * deg_to_m
+    dy = (lats[-1] - lats[-2]) * deg_to_m
+    if dx == 0.0 and dy == 0.0:
+        return 0.0
+    return math.atan2(dx, dy)
 
 
 def _load_or_fetch_network(

--- a/Model/data_parsing/map_rendering/gps_to_map.py
+++ b/Model/data_parsing/map_rendering/gps_to_map.py
@@ -54,3 +54,53 @@ def fetch_road_network(
         dist=radius_m,
         network_type=network_type,
     )
+
+
+def map_match_waypoints(
+    graph: nx.MultiDiGraph,
+    latitudes: Sequence[float],
+    longitudes: Sequence[float],
+) -> tuple[list[int], list[int]]:
+    """Snap a GPS trace onto graph nodes and stitch them into a connected route.
+
+    Returns:
+        matched_nodes: nearest graph node for each input waypoint (same length).
+        route_nodes:   the full node sequence after shortest-path stitching
+                       between consecutive matches; empty when matching fails.
+
+    Map matching can fail (no edges in radius, disconnected components, GPS
+    outside the graph bbox); callers should treat an empty `route_nodes` as
+    "render raw GPS only".
+    """
+    if len(latitudes) != len(longitudes):
+        raise ValueError("latitudes and longitudes must be the same length")
+    if not latitudes:
+        return [], []
+
+    try:
+        matched_nodes = list(
+            ox.distance.nearest_nodes(graph, list(longitudes), list(latitudes))
+        )
+    except Exception as exc:  # noqa: BLE001 — osmnx raises a variety of errors
+        logger.warning("nearest_nodes failed: %s", exc)
+        return [], []
+
+    route: list[int] = []
+    for src, dst in zip(matched_nodes[:-1], matched_nodes[1:]):
+        if src == dst:
+            if not route or route[-1] != src:
+                route.append(src)
+            continue
+        try:
+            segment = nx.shortest_path(graph, src, dst, weight="length")
+        except (nx.NetworkXNoPath, nx.NodeNotFound) as exc:
+            logger.debug("no path %s -> %s: %s", src, dst, exc)
+            continue
+        if route and route[-1] == segment[0]:
+            segment = segment[1:]
+        route.extend(segment)
+
+    if not route and matched_nodes:
+        route = [matched_nodes[0]]
+
+    return matched_nodes, route

--- a/Model/data_parsing/map_rendering/gps_to_map.py
+++ b/Model/data_parsing/map_rendering/gps_to_map.py
@@ -1,0 +1,56 @@
+"""Render GPS waypoints onto an OpenStreetMap-derived BEV map tile.
+
+The output matches the L2D BEV map style (dark background, gray roads, bright
+blue route, optional red raw GPS markers) so a downstream timm transform can
+treat it identically to the rendered map tile L2D ships.
+
+Network fetches are slow and require internet access; this module is intended
+for OFFLINE preprocessing. Pair with `cache.py` for batch use.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Sequence
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless rendering — no display required
+import matplotlib.pyplot as plt  # noqa: E402
+import networkx as nx  # noqa: E402
+import numpy as np  # noqa: E402
+import osmnx as ox  # noqa: E402
+import torch  # noqa: E402
+from PIL import Image  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+# L2D BEV map palette
+DEFAULT_BG_COLOR = "#111111"
+DEFAULT_ROAD_COLOR = "#444444"
+DEFAULT_ROUTE_COLOR = "#00CCFF"
+DEFAULT_GPS_COLOR = "#FF3333"
+
+DEFAULT_IMAGE_SIZE = (640, 360)  # (W, H), matches L2D
+DEFAULT_RADIUS_M = 800
+DEFAULT_DPI = 200
+
+
+def fetch_road_network(
+    center_lat: float,
+    center_lon: float,
+    radius_m: int = DEFAULT_RADIUS_M,
+    network_type: str = "drive",
+) -> nx.MultiDiGraph:
+    """Download the OSM road network within a radius of a GPS point.
+
+    Hits Overpass API; expect network latency on the order of seconds. Cache
+    aggressively via `cache.py` if you call this repeatedly for nearby points.
+    """
+    return ox.graph_from_point(
+        (center_lat, center_lon),
+        dist=radius_m,
+        network_type=network_type,
+    )

--- a/Model/data_parsing/map_rendering/gps_to_map.py
+++ b/Model/data_parsing/map_rendering/gps_to_map.py
@@ -104,3 +104,72 @@ def map_match_waypoints(
         route = [matched_nodes[0]]
 
     return matched_nodes, route
+
+
+def _node_xy(graph: nx.MultiDiGraph, node_id: int) -> tuple[float, float]:
+    data = graph.nodes[node_id]
+    return data["x"], data["y"]  # (lon, lat)
+
+
+def render_map_tile(
+    graph: nx.MultiDiGraph,
+    route_nodes: Sequence[int],
+    raw_gps_points: Sequence[tuple[float, float]] | None = None,
+    image_size: tuple[int, int] = DEFAULT_IMAGE_SIZE,
+    dpi: int = DEFAULT_DPI,
+    bg_color: str = DEFAULT_BG_COLOR,
+    road_color: str = DEFAULT_ROAD_COLOR,
+    route_color: str = DEFAULT_ROUTE_COLOR,
+    gps_color: str = DEFAULT_GPS_COLOR,
+    show_raw_gps: bool = True,
+) -> Image.Image:
+    """Render the road network, the matched route, and (optionally) raw GPS.
+
+    `raw_gps_points` is a sequence of `(lat, lon)` tuples — same convention as
+    the rest of this module's public API. They are drawn on top of the route as
+    small markers when `show_raw_gps=True`.
+    """
+    width_px, height_px = image_size
+    fig_w_in = width_px / dpi
+    fig_h_in = height_px / dpi
+
+    fig, ax = plt.subplots(figsize=(fig_w_in, fig_h_in), dpi=dpi)
+    fig.patch.set_facecolor(bg_color)
+    ax.set_facecolor(bg_color)
+
+    try:
+        ox.plot_graph(
+            graph,
+            ax=ax,
+            node_size=0,
+            edge_color=road_color,
+            edge_linewidth=0.8,
+            bgcolor=bg_color,
+            show=False,
+            close=False,
+        )
+
+        if len(route_nodes) >= 2:
+            xs, ys = zip(*(_node_xy(graph, n) for n in route_nodes))
+            ax.plot(xs, ys, color=route_color, linewidth=2.0, zorder=3)
+        elif len(route_nodes) == 1:
+            x, y = _node_xy(graph, route_nodes[0])
+            ax.scatter([x], [y], color=route_color, s=12, zorder=3)
+
+        if show_raw_gps and raw_gps_points:
+            lats, lons = zip(*raw_gps_points)
+            ax.scatter(lons, lats, color=gps_color, s=6, zorder=4)
+
+        ax.set_axis_off()
+        fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
+
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", facecolor=bg_color, dpi=dpi, pad_inches=0)
+    finally:
+        plt.close(fig)
+
+    buf.seek(0)
+    img = Image.open(buf).convert("RGB")
+    if img.size != image_size:
+        img = img.resize(image_size, Image.BILINEAR)
+    return img

--- a/Model/data_parsing/map_rendering/gps_to_map.py
+++ b/Model/data_parsing/map_rendering/gps_to_map.py
@@ -1,8 +1,10 @@
-"""Render GPS waypoints onto an OpenStreetMap-derived BEV map tile.
+"""Render GPS waypoints onto an ego-centric BEV map tile.
 
 The output matches the L2D BEV map style (dark background, gray roads, bright
-blue route, optional red raw GPS markers) so a downstream timm transform can
-treat it identically to the rendered map tile L2D ships.
+blue route, optional red raw GPS markers) and the L2D ego-centric framing:
+the tile is centered on the ego pose and the ego heading points straight up
+(forward = +y in image space). Downstream timm transforms can treat the tile
+identically to the rendered map tile L2D ships.
 
 Network fetches are slow and require internet access; this module is intended
 for OFFLINE preprocessing. Pair with `cache.py` for batch use.
@@ -12,12 +14,14 @@ from __future__ import annotations
 
 import io
 import logging
+import math
 from typing import Sequence
 
 import matplotlib
 
 matplotlib.use("Agg")  # headless rendering — no display required
 import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.collections import LineCollection  # noqa: E402
 import networkx as nx  # noqa: E402
 import numpy as np  # noqa: E402
 import osmnx as ox  # noqa: E402
@@ -36,6 +40,9 @@ DEFAULT_GPS_COLOR = "#FF3333"
 DEFAULT_IMAGE_SIZE = (640, 360)  # (W, H), matches L2D
 DEFAULT_RADIUS_M = 800
 DEFAULT_DPI = 200
+
+# WGS84 mean Earth radius in meters; used by the equirectangular approximation.
+EARTH_RADIUS_M = 6_378_137.0
 
 
 def fetch_road_network(
@@ -111,10 +118,47 @@ def _node_xy(graph: nx.MultiDiGraph, node_id: int) -> tuple[float, float]:
     return data["x"], data["y"]  # (lon, lat)
 
 
+def _project_to_ego_local(
+    latitudes: Sequence[float] | np.ndarray,
+    longitudes: Sequence[float] | np.ndarray,
+    ego_lat: float,
+    ego_lon: float,
+    ego_heading: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Project (lat, lon) into the ego-local metric frame.
+
+    The equirectangular approximation maps the small render window around
+    the ego into a flat (east, north) plane:
+
+        x_east  = (lon - ego_lon) * cos(ego_lat) * R * pi / 180
+        y_north = (lat - ego_lat) * R * pi / 180
+
+    The (east, north) plane is then rotated by `-ego_heading` so the ego
+    forward direction points along +y in the output. `ego_heading` is in
+    radians; with the convention here, `ego_heading=0` leaves the frame
+    north-up.
+    """
+    lats = np.asarray(latitudes, dtype=float)
+    lons = np.asarray(longitudes, dtype=float)
+    cos_lat = math.cos(math.radians(ego_lat))
+    deg_to_m = EARTH_RADIUS_M * math.pi / 180.0
+    x_east = (lons - ego_lon) * cos_lat * deg_to_m
+    y_north = (lats - ego_lat) * deg_to_m
+    cos_h = math.cos(-ego_heading)
+    sin_h = math.sin(-ego_heading)
+    x_local = x_east * cos_h - y_north * sin_h
+    y_local = x_east * sin_h + y_north * cos_h
+    return x_local, y_local
+
+
 def render_map_tile(
     graph: nx.MultiDiGraph,
     route_nodes: Sequence[int],
+    ego_lat: float,
+    ego_lon: float,
+    ego_heading: float,
     raw_gps_points: Sequence[tuple[float, float]] | None = None,
+    radius_m: int = DEFAULT_RADIUS_M,
     image_size: tuple[int, int] = DEFAULT_IMAGE_SIZE,
     dpi: int = DEFAULT_DPI,
     bg_color: str = DEFAULT_BG_COLOR,
@@ -123,11 +167,11 @@ def render_map_tile(
     gps_color: str = DEFAULT_GPS_COLOR,
     show_raw_gps: bool = True,
 ) -> Image.Image:
-    """Render the road network, the matched route, and (optionally) raw GPS.
+    """Render an ego-centric BEV map tile.
 
-    `raw_gps_points` is a sequence of `(lat, lon)` tuples — same convention as
-    the rest of this module's public API. They are drawn on top of the route as
-    small markers when `show_raw_gps=True`.
+    The tile is centered on `(ego_lat, ego_lon)` and rotated so the ego
+    heading points up. `raw_gps_points` is a sequence of `(lat, lon)` tuples
+    — same convention as the rest of this module's public API.
     """
     width_px, height_px = image_size
     fig_w_in = width_px / dpi
@@ -138,28 +182,50 @@ def render_map_tile(
     ax.set_facecolor(bg_color)
 
     try:
-        ox.plot_graph(
-            graph,
-            ax=ax,
-            node_size=0,
-            edge_color=road_color,
-            edge_linewidth=0.8,
-            bgcolor=bg_color,
-            show=False,
-            close=False,
-        )
+        # Roads — collect every edge as a metric-frame line segment.
+        edge_segments: list[list[tuple[float, float]]] = []
+        for u, v in graph.edges():
+            ux_lon, uy_lat = _node_xy(graph, u)
+            vx_lon, vy_lat = _node_xy(graph, v)
+            xs, ys = _project_to_ego_local(
+                [uy_lat, vy_lat],
+                [ux_lon, vx_lon],
+                ego_lat,
+                ego_lon,
+                ego_heading,
+            )
+            edge_segments.append([(xs[0], ys[0]), (xs[1], ys[1])])
+        if edge_segments:
+            ax.add_collection(
+                LineCollection(
+                    edge_segments,
+                    colors=road_color,
+                    linewidths=0.8,
+                    zorder=2,
+                )
+            )
 
-        if len(route_nodes) >= 2:
-            xs, ys = zip(*(_node_xy(graph, n) for n in route_nodes))
-            ax.plot(xs, ys, color=route_color, linewidth=2.0, zorder=3)
-        elif len(route_nodes) == 1:
-            x, y = _node_xy(graph, route_nodes[0])
-            ax.scatter([x], [y], color=route_color, s=12, zorder=3)
+        if route_nodes:
+            route_lons = [graph.nodes[n]["x"] for n in route_nodes]
+            route_lats = [graph.nodes[n]["y"] for n in route_nodes]
+            xs, ys = _project_to_ego_local(
+                route_lats, route_lons, ego_lat, ego_lon, ego_heading
+            )
+            if len(route_nodes) >= 2:
+                ax.plot(xs, ys, color=route_color, linewidth=2.0, zorder=3)
+            else:
+                ax.scatter(xs, ys, color=route_color, s=12, zorder=3)
 
         if show_raw_gps and raw_gps_points:
             lats, lons = zip(*raw_gps_points)
-            ax.scatter(lons, lats, color=gps_color, s=6, zorder=4)
+            xs, ys = _project_to_ego_local(
+                list(lats), list(lons), ego_lat, ego_lon, ego_heading
+            )
+            ax.scatter(xs, ys, color=gps_color, s=6, zorder=4)
 
+        ax.set_xlim(-radius_m, radius_m)
+        ax.set_ylim(-radius_m, radius_m)
+        ax.set_aspect("equal")  # metric frame — no lat/lon distortion
         ax.set_axis_off()
         fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
 
@@ -179,6 +245,9 @@ def gps_to_tensor(
     latitudes: Sequence[float],
     longitudes: Sequence[float],
     transform,
+    ego_heading: float,
+    ego_lat: float | None = None,
+    ego_lon: float | None = None,
     radius_m: int = DEFAULT_RADIUS_M,
     image_size: tuple[int, int] = DEFAULT_IMAGE_SIZE,
     dpi: int = DEFAULT_DPI,
@@ -187,9 +256,12 @@ def gps_to_tensor(
 ) -> torch.Tensor:
     """End-to-end: GPS coords in, model-ready `(3, H, W)` tensor out.
 
-    `transform` is the timm backbone transform — same one used for camera
-    tiles — which handles resize + normalization. Pass `graph` to skip the
-    Overpass fetch when the network has been cached for the area.
+    The tile is rendered ego-centric: `(ego_lat, ego_lon)` defaults to the
+    last GPS sample, and `ego_heading` (radians) rotates the tile so the ego
+    forward direction is up. `transform` is the timm backbone transform —
+    same one used for camera tiles — which handles resize + normalization.
+    Pass `graph` to skip the Overpass fetch when the network has been cached
+    for the area.
     """
     lats = np.asarray(latitudes, dtype=float)
     lons = np.asarray(longitudes, dtype=float)
@@ -198,11 +270,13 @@ def gps_to_tensor(
     if lats.size == 0:
         raise ValueError("at least one GPS point is required")
 
-    center_lat = float(lats.mean())
-    center_lon = float(lons.mean())
+    if ego_lat is None:
+        ego_lat = float(lats[-1])
+    if ego_lon is None:
+        ego_lon = float(lons[-1])
 
     if graph is None:
-        graph = fetch_road_network(center_lat, center_lon, radius_m=radius_m)
+        graph = fetch_road_network(ego_lat, ego_lon, radius_m=radius_m)
 
     _, route = map_match_waypoints(graph, lats.tolist(), lons.tolist())
     raw_points = list(zip(lats.tolist(), lons.tolist()))
@@ -210,7 +284,11 @@ def gps_to_tensor(
     image = render_map_tile(
         graph,
         route_nodes=route,
+        ego_lat=ego_lat,
+        ego_lon=ego_lon,
+        ego_heading=ego_heading,
         raw_gps_points=raw_points,
+        radius_m=radius_m,
         image_size=image_size,
         dpi=dpi,
         show_raw_gps=show_raw_gps,

--- a/Model/data_parsing/map_rendering/gps_to_map.py
+++ b/Model/data_parsing/map_rendering/gps_to_map.py
@@ -173,3 +173,52 @@ def render_map_tile(
     if img.size != image_size:
         img = img.resize(image_size, Image.BILINEAR)
     return img
+
+
+def gps_to_tensor(
+    latitudes: Sequence[float],
+    longitudes: Sequence[float],
+    transform,
+    radius_m: int = DEFAULT_RADIUS_M,
+    image_size: tuple[int, int] = DEFAULT_IMAGE_SIZE,
+    dpi: int = DEFAULT_DPI,
+    show_raw_gps: bool = True,
+    graph: nx.MultiDiGraph | None = None,
+) -> torch.Tensor:
+    """End-to-end: GPS coords in, model-ready `(3, H, W)` tensor out.
+
+    `transform` is the timm backbone transform — same one used for camera
+    tiles — which handles resize + normalization. Pass `graph` to skip the
+    Overpass fetch when the network has been cached for the area.
+    """
+    lats = np.asarray(latitudes, dtype=float)
+    lons = np.asarray(longitudes, dtype=float)
+    if lats.shape != lons.shape:
+        raise ValueError("latitudes and longitudes must have the same shape")
+    if lats.size == 0:
+        raise ValueError("at least one GPS point is required")
+
+    center_lat = float(lats.mean())
+    center_lon = float(lons.mean())
+
+    if graph is None:
+        graph = fetch_road_network(center_lat, center_lon, radius_m=radius_m)
+
+    _, route = map_match_waypoints(graph, lats.tolist(), lons.tolist())
+    raw_points = list(zip(lats.tolist(), lons.tolist()))
+
+    image = render_map_tile(
+        graph,
+        route_nodes=route,
+        raw_gps_points=raw_points,
+        image_size=image_size,
+        dpi=dpi,
+        show_raw_gps=show_raw_gps,
+    )
+
+    tensor = transform(image)
+    if tensor.dim() != 3 or tensor.shape[0] != 3:
+        raise ValueError(
+            f"transform must return a (3, H, W) tensor, got shape {tuple(tensor.shape)}"
+        )
+    return tensor

--- a/Model/data_parsing/map_rendering/test_gps_to_map.py
+++ b/Model/data_parsing/map_rendering/test_gps_to_map.py
@@ -1,0 +1,142 @@
+"""Unit tests for the map_rendering package.
+
+These tests must run offline — `osmnx.graph_from_point` is patched out, and
+all graphs are constructed locally.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import networkx as nx
+import pytest
+import torch
+from PIL import Image
+
+from data_parsing.map_rendering import (
+    fetch_road_network,
+    gps_to_tensor,
+    map_match_waypoints,
+    render_map_tile,
+)
+from data_parsing.map_rendering.cache import cache_network, load_cached_network
+
+
+def _toy_graph() -> nx.MultiDiGraph:
+    """Three-node graph along a fixed meridian (lon=0), 100 m apart in lat."""
+    graph = nx.MultiDiGraph(crs="epsg:4326")
+    nodes = [
+        (1, 35.0000, 0.0000),
+        (2, 35.0010, 0.0000),
+        (3, 35.0020, 0.0000),
+    ]
+    for nid, lat, lon in nodes:
+        graph.add_node(nid, x=lon, y=lat)
+    graph.add_edge(1, 2, length=111.0)
+    graph.add_edge(2, 1, length=111.0)
+    graph.add_edge(2, 3, length=111.0)
+    graph.add_edge(3, 2, length=111.0)
+    return graph
+
+
+def test_render_returns_pil_image():
+    graph = _toy_graph()
+    with mock.patch(
+        "data_parsing.map_rendering.gps_to_map.ox.plot_graph"
+    ) as plot_graph:
+        plot_graph.return_value = (None, None)
+        img = render_map_tile(
+            graph,
+            route_nodes=[1, 2, 3],
+            raw_gps_points=[(35.0005, 0.0), (35.0015, 0.0)],
+            image_size=(640, 360),
+            dpi=100,
+        )
+    assert isinstance(img, Image.Image)
+    assert img.size == (640, 360)
+    assert img.mode == "RGB"
+
+
+def test_tensor_output_shape():
+    graph = _toy_graph()
+
+    def fake_transform(image: Image.Image) -> torch.Tensor:
+        # Mimic a timm transform: resize + to_tensor + normalize -> (3, 224, 224)
+        arr = torch.zeros(3, 224, 224)
+        return arr
+
+    with mock.patch(
+        "data_parsing.map_rendering.gps_to_map.ox.plot_graph"
+    ) as plot_graph, mock.patch(
+        "data_parsing.map_rendering.gps_to_map.ox.distance.nearest_nodes",
+        return_value=[1, 2, 3],
+    ):
+        plot_graph.return_value = (None, None)
+        tensor = gps_to_tensor(
+            latitudes=[35.0000, 35.0010, 35.0020],
+            longitudes=[0.0, 0.0, 0.0],
+            transform=fake_transform,
+            graph=graph,
+        )
+
+    assert isinstance(tensor, torch.Tensor)
+    assert tensor.shape == (3, 224, 224)
+
+
+def test_map_match_with_simple_graph():
+    graph = _toy_graph()
+    with mock.patch(
+        "data_parsing.map_rendering.gps_to_map.ox.distance.nearest_nodes",
+        return_value=[1, 3],
+    ):
+        matched, route = map_match_waypoints(
+            graph,
+            latitudes=[35.0000, 35.0020],
+            longitudes=[0.0, 0.0],
+        )
+
+    assert matched == [1, 3]
+    # Stitching 1 -> 3 must traverse node 2.
+    assert route == [1, 2, 3]
+
+
+def test_map_match_empty_input():
+    graph = _toy_graph()
+    matched, route = map_match_waypoints(graph, [], [])
+    assert matched == []
+    assert route == []
+
+
+def test_map_match_length_mismatch():
+    graph = _toy_graph()
+    with pytest.raises(ValueError):
+        map_match_waypoints(graph, [35.0], [0.0, 0.1])
+
+
+def test_cache_round_trip(tmp_path: Path):
+    graph = _toy_graph()
+    cache_path = tmp_path / "net.pkl"
+
+    cache_network(graph, cache_path)
+    assert cache_path.exists()
+
+    loaded = load_cached_network(cache_path)
+    assert loaded is not None
+    assert set(loaded.nodes) == set(graph.nodes)
+    assert loaded.number_of_edges() == graph.number_of_edges()
+
+
+def test_load_cached_network_missing(tmp_path: Path):
+    assert load_cached_network(tmp_path / "does-not-exist.pkl") is None
+
+
+def test_fetch_road_network_calls_osmnx():
+    sentinel = _toy_graph()
+    with mock.patch(
+        "data_parsing.map_rendering.gps_to_map.ox.graph_from_point",
+        return_value=sentinel,
+    ) as fake:
+        result = fetch_road_network(35.0, 0.0, radius_m=500)
+    fake.assert_called_once()
+    assert result is sentinel

--- a/Model/data_parsing/map_rendering/test_gps_to_map.py
+++ b/Model/data_parsing/map_rendering/test_gps_to_map.py
@@ -6,10 +6,12 @@ all graphs are constructed locally.
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from unittest import mock
 
 import networkx as nx
+import numpy as np
 import pytest
 import torch
 from PIL import Image
@@ -40,22 +42,75 @@ def _toy_graph() -> nx.MultiDiGraph:
     return graph
 
 
+def _red_pixel_centroid(img: Image.Image) -> tuple[float, float]:
+    """Return the (x, y) centroid of strongly-red pixels (raw GPS markers)."""
+    arr = np.asarray(img)
+    mask = (arr[..., 0] > 180) & (arr[..., 1] < 80) & (arr[..., 2] < 80)
+    if not mask.any():
+        raise AssertionError("no red GPS markers found in tile")
+    ys, xs = np.where(mask)
+    return float(xs.mean()), float(ys.mean())
+
+
 def test_render_returns_pil_image():
     graph = _toy_graph()
-    with mock.patch(
-        "data_parsing.map_rendering.gps_to_map.ox.plot_graph"
-    ) as plot_graph:
-        plot_graph.return_value = (None, None)
-        img = render_map_tile(
-            graph,
-            route_nodes=[1, 2, 3],
-            raw_gps_points=[(35.0005, 0.0), (35.0015, 0.0)],
-            image_size=(640, 360),
-            dpi=100,
-        )
+    img = render_map_tile(
+        graph,
+        route_nodes=[1, 2, 3],
+        ego_lat=35.0010,
+        ego_lon=0.0,
+        ego_heading=0.0,
+        raw_gps_points=[(35.0005, 0.0), (35.0015, 0.0)],
+        image_size=(640, 360),
+        dpi=100,
+    )
     assert isinstance(img, Image.Image)
     assert img.size == (640, 360)
     assert img.mode == "RGB"
+
+
+def test_ego_centric_point_ahead_renders_in_upper_half():
+    """A GPS point directly north of the ego with heading=0 (north up) maps
+    to the upper half of the image."""
+    graph = _toy_graph()
+    img = render_map_tile(
+        graph,
+        route_nodes=[],
+        ego_lat=35.0000,
+        ego_lon=0.0,
+        ego_heading=0.0,  # north-up
+        raw_gps_points=[(35.0010, 0.0)],  # ~111 m north of ego
+        radius_m=400,
+        image_size=(400, 400),
+        dpi=100,
+    )
+    _, cy = _red_pixel_centroid(img)
+    assert cy < img.size[1] / 2, "point ahead of ego should render in upper half"
+
+
+def test_ego_centric_rotation_with_heading():
+    """Rotating the ego heading rotates the tile.
+
+    With `ego_heading` in radians CCW from north, `ego_heading=+pi/2` means
+    the ego is facing west; a point that lies world-north of the ego is then
+    on the ego's right and renders in the right half of the tile.
+    """
+    graph = _toy_graph()
+    img = render_map_tile(
+        graph,
+        route_nodes=[],
+        ego_lat=35.0000,
+        ego_lon=0.0,
+        ego_heading=math.pi / 2,
+        raw_gps_points=[(35.0010, 0.0)],
+        radius_m=400,
+        image_size=(400, 400),
+        dpi=100,
+    )
+    cx, cy = _red_pixel_centroid(img)
+    w, h = img.size
+    assert cx > w / 2, "rotated heading should put world-north point on the right"
+    assert abs(cy - h / 2) < h * 0.2, "rotated point should sit near vertical center"
 
 
 def test_tensor_output_shape():
@@ -67,21 +122,47 @@ def test_tensor_output_shape():
         return arr
 
     with mock.patch(
-        "data_parsing.map_rendering.gps_to_map.ox.plot_graph"
-    ) as plot_graph, mock.patch(
         "data_parsing.map_rendering.gps_to_map.ox.distance.nearest_nodes",
         return_value=[1, 2, 3],
     ):
-        plot_graph.return_value = (None, None)
         tensor = gps_to_tensor(
             latitudes=[35.0000, 35.0010, 35.0020],
             longitudes=[0.0, 0.0, 0.0],
             transform=fake_transform,
+            ego_heading=0.0,
             graph=graph,
         )
 
     assert isinstance(tensor, torch.Tensor)
     assert tensor.shape == (3, 224, 224)
+
+
+def test_gps_to_tensor_defaults_ego_to_last_point():
+    """When no ego position is passed, the last GPS sample is used as the
+    ego center — verified by passing a transform that captures the rendered
+    image and checking its shape and size."""
+    graph = _toy_graph()
+    captured: dict[str, Image.Image] = {}
+
+    def capture_transform(image: Image.Image) -> torch.Tensor:
+        captured["image"] = image
+        return torch.zeros(3, 64, 64)
+
+    with mock.patch(
+        "data_parsing.map_rendering.gps_to_map.ox.distance.nearest_nodes",
+        return_value=[1, 2, 3],
+    ):
+        gps_to_tensor(
+            latitudes=[35.0000, 35.0010, 35.0020],
+            longitudes=[0.0, 0.0, 0.0],
+            transform=capture_transform,
+            ego_heading=0.0,
+            graph=graph,
+            image_size=(320, 200),
+            dpi=100,
+        )
+
+    assert captured["image"].size == (320, 200)
 
 
 def test_map_match_with_simple_graph():


### PR DESCRIPTION
## Summary

Implements #46 — renders GPS waypoints onto an OpenStreetMap-derived BEV map tile, so datasets without a native map input (KIT Scenes, NVIDIA PhysicalAI) can produce an L2D-style map tile for the model's map view slot.

## Module

```
Model/data_parsing/map_rendering/
├── gps_to_map.py    ← fetch network, map-match, render ego-centric tile, gps_to_tensor
├── cache.py         ← network caching + batch tile pre-rendering
├── test_gps_to_map.py
└── README.md
```

## Key design

**Ego-centric rendering (matches L2D / NVIDIA / KITScenes parsers):** the tile is centered on the ego position with the ego heading pointing straight up. GPS lon/lat is converted to a local metric tangent-plane frame, rotated by `-ego_heading`, and plotted with equal aspect ratio (no lat/lon distortion). A fixed metric window (`±radius_m`) around the ego defines the extent.

**L2D palette:** dark background, gray roads, bright-blue matched route, red raw GPS markers — so a timm backbone transform treats it identically to L2D's shipped map tile.

**Offline preprocessing:** osmnx Overpass fetches are slow and need internet, so this is meant for batch pre-rendering (not in the DataLoader hot path). `cache.py` persists fetched graphs (centroid-quantized for reuse) and renders all tiles for a dataset once.

## Test plan

- [x] 11 tests pass, all with mocked osmnx (no network access required)
- [x] Ego-centric: a point ahead of the ego maps to the upper half; rotating heading rotates the tile
- [x] Map-match fallback (empty route → raw GPS only) verified
- [x] Network cache round-trip verified

## Notes

- Dependencies: osmnx, geopandas, matplotlib (offline preprocessing only)
- Failed clips during batch rendering log a full traceback and are skipped

## Refs

- Closes #46