### PR TITLE
ci: run pytest from repo root without redundant marker flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         run: ruff check
 
       - name: Run unit tests
-        run: cd Model/tests && python -m pytest -v -m "not integration"
+        run: python -m pytest Model/tests -v


### PR DESCRIPTION
Simplifies the unit-test invocation in `ci.yml`.

Both parts of the old command were redundant:

- **`cd Model/tests`** — pytest discovers `Model/pytest.ini` by walking up from the
  given test path, and test imports resolve via pytest's rootdir logic, not the
  working directory. Running from the repo root selects the exact same tests.
- **`-m "not integration"`** — this policy already lives in `Model/pytest.ini`
  (`addopts = -m "not integration"`). Duplicating it in the workflow means two
  places own the same rule and can drift apart; after this change the ini file is
  the single owner.

