### PR TITLE
feat(map_encoder): add raster map encoder and map-image feature fusion

### DIFF
--- a/Model/README.md
+++ b/Model/README.md
@@ -1,11 +1,13 @@
 # AutoE2E Architecture
 
 ## Architecture Diagram
+> **Note:** The architecture diagram is outdated and does not reflect the current implementation (separate map encoder branch, BEV fusion as default, residual map fusion). It will be updated in a follow-up PR.
+
 <img src="../Media/auto_e2e_architecture.jpg" width="100%">
 
 ## Inputs and Predictions
 **AutoE2E consumes as input:**
-- 7 camera images at 224x224 resolution (providing a surround view of the vehicle alongside a telephoto front and rear camera for long range viewing)
+- 7 camera images at 256x256 resolution (providing a surround view of the vehicle)
 - Rendered map tile (indicating the high level road network layout and future route of the vehicle)
 - Egomotion history (speed, acceleration, yaw angle and yaw angle rate for the previous 6.4s at 10Hz sampling rate)
 - Visual history (`(896,)` = 64 frames × 14-dim compressed scene memory; provides frame-to-frame visual context, distinct from the planner GRU's intra-trajectory temporal coherence)
@@ -20,7 +22,8 @@
 **Forward signature:**
 ```python
 trajectory, ego_hidden, future_visual_features = model(
-    visual_tiles,        # (B, V, 3, H, W) — 7 cameras + 1 map tile
+    visual_tiles,        # (B, V, 3, H, W) — 7 cameras
+    map_tile,            # (B, 3, H_map, W_map) — BEV nav-map image
     visual_history,      # (B, 896) — frame-to-frame visual memory
     egomotion_history,   # (B, 256)
     camera_params=None,  # (B, V, 3, 4) optional, used by BEV fusion
@@ -29,6 +32,6 @@ trajectory, ego_hidden, future_visual_features = model(
 ```
 
 **To learn the driving policy:**
-- Imitaiton Learning is used to penalize trajectory prediciton as well as World Model Simulation based Reinforcement Learning
+- Imitation Learning is used to penalize trajectory prediction as well as World Model Simulation based Reinforcement Learning
 
 

--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -13,8 +13,12 @@ class AutoE2E(nn.Module):
                  num_timesteps=64, num_signals=2, egomotion_dim=256,
                  visual_history_dim=896,
                  map_type="rasterized", map_in_channels=3,
+<<<<<<< HEAD
                  map_fusion_mode="residual", map_fusion_kwargs=None,
                  planner_mode="gru", planner_kwargs=None):
+=======
+                 map_fusion_mode="residual", map_fusion_kwargs=None):
+>>>>>>> d33638d (feat(map_encoder): update fusion modes to use 'bev' and 'residual'; set default BEV dimensions)
         super(AutoE2E, self).__init__()
 
         # Camera backbone feature extractor

--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -13,12 +13,8 @@ class AutoE2E(nn.Module):
                  num_timesteps=64, num_signals=2, egomotion_dim=256,
                  visual_history_dim=896,
                  map_type="rasterized", map_in_channels=3,
-<<<<<<< HEAD
                  map_fusion_mode="residual", map_fusion_kwargs=None,
                  planner_mode="gru", planner_kwargs=None):
-=======
-                 map_fusion_mode="residual", map_fusion_kwargs=None):
->>>>>>> d33638d (feat(map_encoder): update fusion modes to use 'bev' and 'residual'; set default BEV dimensions)
         super(AutoE2E, self).__init__()
 
         # Camera backbone feature extractor

--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -3,18 +3,21 @@ from .backbone import Backbone
 from .feature_fusion import FeatureFusion
 from .trajectory_planning import build_planner
 from .future_state import FutureState
+from .map_encoder import build_map_encoder, build_map_bev_fusion
 
 
 class AutoE2E(nn.Module):
-    def __init__(self, backbone="swin_v2_tiny", num_views=8, embed_dim=256,
-                 fusion_mode="concat", is_pretrained=True,
+    def __init__(self, backbone="swin_v2_tiny", num_views=7, embed_dim=256,
+                 fusion_mode="bev", is_pretrained=True,
                  image_feature_size=8, view_fusion_kwargs=None,
                  num_timesteps=64, num_signals=2, egomotion_dim=256,
-                 visual_history_dim=896, planner_mode="gru",
-                 planner_kwargs=None):
+                 visual_history_dim=896,
+                 map_type="rasterized", map_in_channels=3,
+                 map_fusion_mode="residual", map_fusion_kwargs=None,
+                 planner_mode="gru", planner_kwargs=None):
         super(AutoE2E, self).__init__()
 
-        # Backbone feature extractor
+        # Camera backbone feature extractor
         self.Backbone = Backbone(backbone=backbone, is_pretrained=is_pretrained)
 
         # Multi-scale feature fusion with view unification.
@@ -28,9 +31,35 @@ class AutoE2E(nn.Module):
             view_fusion_kwargs=view_fusion_kwargs,
         )
 
+        # For BEV fusion mode the spatial size is bev_h × bev_w (potentially non-square).
+        # For concat/cross_attn it is image_feature_size × image_feature_size.
+        if fusion_mode == "bev":
+            vfk = view_fusion_kwargs or {"bev_h": 450, "bev_w": 300}
+            map_output_h = vfk["bev_h"]
+            map_output_w = vfk["bev_w"]
+        else:
+            map_output_h = image_feature_size
+            map_output_w = image_feature_size
+ 
+        # Map encoder: encodes the BEV nav-map image into spatial map features
+        self.MapEncoder = build_map_encoder(
+            map_type,
+            in_channels=map_in_channels,
+            embed_dim=embed_dim,
+            output_h=map_output_h,
+            output_w=map_output_w,
+        )
+ 
+        # Map BEV fusion: combines image BEV features with map BEV features
+        self.MapBEVFusion = build_map_bev_fusion(
+            map_fusion_mode,
+            embed_dim=embed_dim,
+            **(map_fusion_kwargs or {}),
+        )
+
         # Trajectory decoder — swappable via planner_mode (gru, flow_matching).
         self.TrajectoryPlanner = build_planner(
-            planner_mode,
+            planner_mode,        
             embed_dim=embed_dim,
             num_timesteps=num_timesteps,
             num_signals=num_signals,
@@ -42,9 +71,10 @@ class AutoE2E(nn.Module):
         # Future visual state prediction conditioned on planner ego_hidden
         self.FutureState = FutureState(embed_dim=embed_dim, ego_hidden_dim=embed_dim)
 
-    def forward(self, x, visual_history, egomotion_history, camera_params=None,
-                mode="train", trajectory_target=None, **kwargs):
-        """Run the full autonomous-driving pipeline.
+    def forward(self, camera_tiles, map_input, visual_history, egomotion_history,
+                camera_params=None, mode="train", trajectory_target=None, **kwargs):
+        """
+        Run the full autonomous-driving pipeline.
 
         The first return value's meaning depends on ``mode`` but is uniform
         across all planners (GRU, Flow Matching, ...):
@@ -58,15 +88,32 @@ class AutoE2E(nn.Module):
         * any other ``mode`` (e.g. ``"infer"``): returns
           ``(trajectory, ego_hidden, None)`` where ``trajectory`` is
           ``[B, num_timesteps * num_signals]``.
+
+        Args:
+            camera_tiles: (B, V, 3, H, W) — V camera images (V=7 by default).
+            map_input: (B, 3, H_map, W_map) — BEV nav-map image.
+            visual_history: (B, visual_history_dim).
+            egomotion_history: (B, egomotion_dim).
+            camera_params: Optional (B, V, 3, 4) ego-to-pixel projection matrices.
+            mode: "train" to produce future_visual_features; anything else skips it.
+
+        Returns:
+            trajectory: (B, num_timesteps * num_signals)
+            ego_hidden: (B, embed_dim)
+            future_visual_features: list of 4 × (B, embed_dim, H, W), or None
         """
-        B, V, C, H, W = x.shape
+        B, V, C, H, W = camera_tiles.shape
 
-        # Merge batch and views for backbone processing
-        x = x.reshape(B * V, C, H, W)
+        # --- Camera branch ---
+        x = camera_tiles.reshape(B * V, C, H, W)
         features = self.Backbone(x)
+        image_bev = self.FeatureFusion(features, B, V, camera_params=camera_params)
 
-        # Fuse multi-scale features and unify across views
-        fused_features = self.FeatureFusion(features, B, V, camera_params=camera_params)
+        # --- Map branch ---
+        map_bev = self.MapEncoder(map_input)
+
+        # --- Fuse image BEV + map BEV ---
+        fused_features = self.MapBEVFusion(image_bev, map_bev)
 
         if mode == "train":
             if trajectory_target is None:
@@ -79,6 +126,7 @@ class AutoE2E(nn.Module):
             )
             future_visual_features = self.FutureState(fused_features, ego_hidden)
             return planner_loss, ego_hidden, future_visual_features
+
 
         trajectory, ego_hidden = self.TrajectoryPlanner(
             fused_features, visual_history, egomotion_history, **kwargs,

--- a/Model/model_components/map_encoder/__init__.py
+++ b/Model/model_components/map_encoder/__init__.py
@@ -1,0 +1,34 @@
+import torch.nn as nn
+from .raster_map_encoder import RasterizedMapEncoder
+from .map_bev_fusion import MAP_FUSION_REGISTRY, build_map_bev_fusion
+
+MAP_ENCODER_REGISTRY = {
+    "rasterized": RasterizedMapEncoder,
+}
+
+
+def build_map_encoder(map_type: str, **kwargs) -> nn.Module:
+    """Construct a map encoder by registry name.
+
+    Args:
+        map_type: One of the keys in ``MAP_ENCODER_REGISTRY``
+            (currently only ``"rasterized"``).
+        **kwargs: Forwarded to the selected encoder constructor
+            (``embed_dim``, ``output_size``, ``in_channels``).
+
+    """
+    if map_type not in MAP_ENCODER_REGISTRY:
+        raise ValueError(
+            f"Unknown map_type '{map_type}'. "
+            f"Available: {list(MAP_ENCODER_REGISTRY.keys())}"
+        )
+    return MAP_ENCODER_REGISTRY[map_type](**kwargs)
+
+
+__all__ = [
+    "MAP_ENCODER_REGISTRY",
+    "MAP_FUSION_REGISTRY",
+    "build_map_encoder",
+    "build_map_bev_fusion",
+    "RasterizedMapEncoder",
+]

--- a/Model/model_components/map_encoder/map_bev_fusion/__init__.py
+++ b/Model/model_components/map_encoder/map_bev_fusion/__init__.py
@@ -1,0 +1,22 @@
+from .residual_fusion import ResidualMapFusion
+from .cross_attention_fusion import MapCrossAttentionFusion
+
+MAP_FUSION_REGISTRY = {
+    "residual": ResidualMapFusion,
+    "cross_attn": MapCrossAttentionFusion,
+}
+
+
+def build_map_bev_fusion(fusion_mode: str, embed_dim: int = 256, **kwargs):
+    """Construct a map BEV fusion module.
+
+    Args:
+        fusion_mode: One of ``"residual"`` or ``"cross_attn"``.
+        embed_dim: Channel dimension shared by image and map BEV features.
+    """
+    if fusion_mode not in MAP_FUSION_REGISTRY:
+        raise ValueError(
+            f"Unknown map_fusion_mode '{fusion_mode}'. "
+            f"Available: {list(MAP_FUSION_REGISTRY.keys())}"
+        )
+    return MAP_FUSION_REGISTRY[fusion_mode](embed_dim=embed_dim, **kwargs)

--- a/Model/model_components/map_encoder/map_bev_fusion/cross_attention_fusion.py
+++ b/Model/model_components/map_encoder/map_bev_fusion/cross_attention_fusion.py
@@ -1,0 +1,78 @@
+"""
+Cross-attention map BEV fusion. Fuses image BEV features with map BEV features using spatial cross-attention.
+
+"""
+
+import torch
+import torch.nn as nn
+
+
+class MapCrossAttentionFusion(nn.Module):
+    """Fuse image BEV and map BEV via spatial cross-attention.
+
+    Args:
+        embed_dim: Channel dimension of both input feature maps.
+        num_heads: Number of attention heads.
+        dropout: Dropout applied inside attention and the FFN.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int = 256,
+        num_heads: int = 8,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+
+        self.embed_dim = embed_dim
+
+        self.norm_query = nn.LayerNorm(embed_dim)
+        self.norm_kv = nn.LayerNorm(embed_dim)
+
+        self.cross_attn = nn.MultiheadAttention(
+            embed_dim=embed_dim,
+            num_heads=num_heads,
+            dropout=dropout,
+            batch_first=True,
+        )
+
+        self.ffn = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim * 2),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(embed_dim * 2, embed_dim),
+            nn.Dropout(dropout),
+        )
+        self.norm_ffn = nn.LayerNorm(embed_dim)
+
+    def forward(
+        self,
+        image_bev: torch.Tensor,
+        map_bev: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Args:
+            image_bev: (B, embed_dim, H, W) image BEV features — queries.
+            map_bev:   (B, embed_dim, H, W) map BEV features — keys and values.
+                       Must have the same spatial size as image_bev.
+
+        Returns:
+            (B, embed_dim, H, W) image BEV updated with map context.
+        """
+        B, C, H, W = image_bev.shape
+
+        # Flatten spatial dims: (B, H*W, C)
+        q = image_bev.permute(0, 2, 3, 1).reshape(B, H * W, C)
+        kv = map_bev.permute(0, 2, 3, 1).reshape(B, H * W, C)
+
+        # Pre-norm cross-attention with residual
+        kv_norm = self.norm_kv(kv)
+        attn_out, _ = self.cross_attn(self.norm_query(q), kv_norm, kv_norm)
+        q = q + attn_out
+
+        # FFN with residual
+        q = q + self.ffn(self.norm_ffn(q))
+
+        # Reshape back to spatial: (B, C, H, W)
+        return q.reshape(B, H, W, C).permute(0, 3, 1, 2).contiguous()
+    

--- a/Model/model_components/map_encoder/map_bev_fusion/residual_fusion.py
+++ b/Model/model_components/map_encoder/map_bev_fusion/residual_fusion.py
@@ -4,10 +4,11 @@ Fuses image BEV features with map BEV features via a learned residual gate:
 
     output = image_bev + alpha * map_bev
 
-where ``alpha`` is a per-channel learnable parameter vector, initialized to
-zero. At the start of training the map branch contributes nothing, so the
-model behaves identically to training without a map encoder. As training
-progresses, ``alpha`` grows to weight whichever map channels are useful.
+where ``alpha`` is a per-channel learnable parameter vector (shape: ``embed_dim``),
+initialized to zero and reshaped to ``(1, embed_dim, 1, 1)`` for broadcasting.
+At the start of training the map branch contributes nothing, so the model behaves
+identically to training without a map encoder. As training progresses, ``alpha``
+grows to weight whichever map channels are useful.
 
 """
 

--- a/Model/model_components/map_encoder/map_bev_fusion/residual_fusion.py
+++ b/Model/model_components/map_encoder/map_bev_fusion/residual_fusion.py
@@ -1,0 +1,49 @@
+"""Residual map BEV fusion.
+
+Fuses image BEV features with map BEV features via a learned residual gate:
+
+    output = image_bev + alpha * map_bev
+
+where ``alpha`` is a per-channel learnable parameter vector, initialized to
+zero. At the start of training the map branch contributes nothing, so the
+model behaves identically to training without a map encoder. As training
+progresses, ``alpha`` grows to weight whichever map channels are useful.
+
+"""
+
+import torch
+import torch.nn as nn
+
+
+class ResidualMapFusion(nn.Module):
+    """Add map BEV features to image BEV features via a per-channel gate.
+
+    Args:
+        embed_dim: Channel dimension of both input feature maps. Must match.
+    """
+
+    def __init__(self, embed_dim: int = 256) -> None:
+        super().__init__()
+
+        # Per-channel gate initialized to zero.
+        # Shape (embed_dim,) so each channel of map_bev is weighted
+        # independently.
+        self.alpha = nn.Parameter(torch.zeros(embed_dim))
+
+    def forward(
+        self,
+        image_bev: torch.Tensor,
+        map_bev: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Args:
+            image_bev: (B, embed_dim, H, W) image BEV features.
+            map_bev:   (B, embed_dim, H, W) map BEV features.
+                       Must have the same spatial size as image_bev.
+
+        Returns:
+            (B, embed_dim, H, W) fused BEV features.
+        """
+        # Reshape alpha for broadcast: (1, embed_dim, 1, 1)
+        gate = self.alpha.view(1, -1, 1, 1)
+        return image_bev + gate * map_bev

--- a/Model/model_components/map_encoder/raster_map_encoder.py
+++ b/Model/model_components/map_encoder/raster_map_encoder.py
@@ -1,0 +1,77 @@
+"""Rasterized navigation map encoder.
+
+Takes a BEV-space RGB map image and produces a spatial feature map at the same resolution as the image BEV
+features, so the two can be fused directly.
+"""
+
+import torch
+import torch.nn as nn
+import timm
+
+
+class RasterizedMapEncoder(nn.Module):
+    """Encode a BEV nav-map image into a spatial feature map.
+ 
+    Args:
+        in_channels: Number of input channels. Default 3 (RGB map).
+        embed_dim: Output channel dimension. Must match the image BEV
+            embed_dim so MapBEVFusion can combine them directly.
+        output_h: Height of the output feature map.
+        output_w: Width of the output feature map.
+    """
+ 
+    def __init__(
+        self,
+        in_channels: int = 3,
+        embed_dim: int = 256,
+        output_h: int = 8,
+        output_w: int = 8,
+    ) -> None:
+        super().__init__()
+ 
+        self.output_h = output_h
+        self.output_w = output_w
+ 
+        # SwinV2-Tiny backbone, randomly initialized.
+        self._backbone = timm.create_model(
+            "swinv2_tiny_window8_256",
+            pretrained=False,
+            features_only=True,
+            in_chans=in_channels,
+        )
+ 
+        self._feature_channels = [
+            stage["num_chs"] for stage in self._backbone.feature_info
+        ]
+        backbone_channels = sum(self._feature_channels)
+ 
+        self.pool = nn.AdaptiveMaxPool2d((output_h, output_w))
+ 
+        self.channel_proj = nn.Sequential(
+            nn.Conv2d(backbone_channels, embed_dim, kernel_size=1),
+            nn.GELU(),
+        )
+ 
+    def forward(self, map_image: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            map_image: (B, 3, H, W) BEV nav-map image. H and W must be 256
+                (required by swinv2_tiny_window8_256's patch embedding).
+ 
+        Returns:
+            (B, embed_dim, output_h, output_w)
+        """
+        features = self._backbone(map_image)
+ 
+        # Permute to channels-first. 
+        permuted = []
+        for f, expected_c in zip(features, self._feature_channels):
+            if f.dim() == 4 and f.shape[1] != expected_c and f.shape[-1] == expected_c:
+                permuted.append(f.permute(0, 3, 1, 2).contiguous())
+            else:
+                permuted.append(f)
+ 
+        pooled = [self.pool(f) for f in permuted]
+        x = torch.cat(pooled, dim=1)   # (B, backbone_channels, output_h, output_w)
+        return self.channel_proj(x)    # (B, embed_dim, output_h, output_w)
+ 

--- a/Model/tests/conftest.py
+++ b/Model/tests/conftest.py
@@ -77,8 +77,8 @@ class MockBackbone(nn.Module):
 
 
 def _build_model_with_mock_backbone(num_views, fusion_mode, device,
-                                    num_timesteps=64, planner_mode="gru",
-                                    planner_kwargs=None):
+                                    num_timesteps=64, map_fusion_mode="residual",
+                                    planner_mode="gru", planner_kwargs=None):
     """Construct AutoE2E with the mock backbone injected.
 
     Patches Backbone at the module level during construction to avoid
@@ -99,6 +99,7 @@ def _build_model_with_mock_backbone(num_views, fusion_mode, device,
             num_timesteps=num_timesteps,
             planner_mode=planner_mode,
             planner_kwargs=planner_kwargs,
+            map_fusion_mode=map_fusion_mode,
         )
     return model.to(device)
 
@@ -123,7 +124,7 @@ def model(request, device):
     _reset_model_grads fixture below.
     """
     return _build_model_with_mock_backbone(
-        num_views=8, fusion_mode=request.param, device=device
+        num_views=7, fusion_mode=request.param, device=device
     )
 
 
@@ -145,7 +146,7 @@ def full_model(request, device):
     view_fusion_kwargs = {"bev_h": 8, "bev_w": 8} if request.param == "bev" else None
     try:
         model = AutoE2E(
-            num_views=8, fusion_mode=request.param,
+            num_views=7, fusion_mode=request.param,
             view_fusion_kwargs=view_fusion_kwargs,
         )
     except (FileNotFoundError, OSError) as e:

--- a/Model/tests/conftest.py
+++ b/Model/tests/conftest.py
@@ -77,12 +77,8 @@ class MockBackbone(nn.Module):
 
 
 def _build_model_with_mock_backbone(num_views, fusion_mode, device,
-<<<<<<< HEAD
                                     num_timesteps=64, map_fusion_mode="residual",
                                     planner_mode="gru", planner_kwargs=None):
-=======
-                                    num_timesteps=64, map_fusion_mode="residual"):
->>>>>>> f6da161 (feat(map_encoder): update default map fusion mode in tests to 'residual'; add test for gradient testing with non-zero alpha)
     """Construct AutoE2E with the mock backbone injected.
 
     Patches Backbone at the module level during construction to avoid

--- a/Model/tests/conftest.py
+++ b/Model/tests/conftest.py
@@ -77,8 +77,12 @@ class MockBackbone(nn.Module):
 
 
 def _build_model_with_mock_backbone(num_views, fusion_mode, device,
+<<<<<<< HEAD
                                     num_timesteps=64, map_fusion_mode="residual",
                                     planner_mode="gru", planner_kwargs=None):
+=======
+                                    num_timesteps=64, map_fusion_mode="residual"):
+>>>>>>> f6da161 (feat(map_encoder): update default map fusion mode in tests to 'residual'; add test for gradient testing with non-zero alpha)
     """Construct AutoE2E with the mock backbone injected.
 
     Patches Backbone at the module level during construction to avoid

--- a/Model/tests/test_auto_e2e.py
+++ b/Model/tests/test_auto_e2e.py
@@ -19,12 +19,13 @@ from model_components.view_fusion.bev_fusion import BEVViewFusion
 
 def make_inputs(batch_size, num_views, device, include_camera_params=False):
     visual = torch.randn(batch_size, num_views, 3, 256, 256, device=device)
+    map_input = torch.randn(batch_size, 3, 256, 256, device=device)
     visual_history = torch.randn(batch_size, 896, device=device)
     egomotion = torch.randn(batch_size, 256, device=device)
     if include_camera_params:
         camera_params = torch.randn(batch_size, num_views, 3, 4, device=device)
-        return visual, visual_history, egomotion, camera_params
-    return visual, visual_history, egomotion
+        return visual, map_input, visual_history, egomotion, camera_params
+    return visual, map_input, visual_history, egomotion
 
 
 # ---------------------------------------------------------------------------
@@ -34,21 +35,21 @@ def make_inputs(batch_size, num_views, device, include_camera_params=False):
 class TestOutputShapes:
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     def test_trajectory_shape(self, model, device, batch_size):
-        visual, vis_hist, ego = make_inputs(batch_size, 8, device)
-        traj, _, _ = model(visual, vis_hist, ego, mode="infer")
+        visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
+        traj, _, _ = model(visual, map_input, vis_hist, ego)
         assert traj.shape == (batch_size, 128)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     def test_ego_hidden_shape(self, model, device, batch_size):
-        visual, vis_hist, ego = make_inputs(batch_size, 8, device)
-        _, ego_hidden, _ = model(visual, vis_hist, ego, mode="infer")
+        visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
+        _, ego_hidden, _ = model(visual, map_input, vis_hist, ego)
         assert ego_hidden.shape == (batch_size, 256)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     def test_future_features_shape(self, model, device, batch_size):
-        visual, vis_hist, ego = make_inputs(batch_size, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
         target = torch.randn(batch_size, 128, device=device)
-        _, _, future = model(visual, vis_hist, ego, mode="train",
+        _, _, future = model(visual, map_input, vis_hist, ego, mode="train",
                              trajectory_target=target)
         assert len(future) == 4
         for f in future:
@@ -63,13 +64,13 @@ class TestBatchIndependence:
     def test_samples_do_not_interfere(self, model, device):
         model.eval()
         torch.manual_seed(42)
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
 
         # Full batch forward
-        traj_both, _, _ = model(visual, vis_hist, ego, mode="infer")
+        traj_both, _, _ = model(visual, map_input, vis_hist, ego, mode="infer")
 
         # Single sample forward (sample 0)
-        traj_single, _, _ = model(visual[0:1], vis_hist[0:1], ego[0:1],
+        traj_single, _, _ = model(visual[0:1], map_input[0:1], vis_hist[0:1], ego[0:1], 
                                   mode="infer")
 
         # Sample 0's output must be identical regardless of what sample 1 contains
@@ -79,15 +80,15 @@ class TestBatchIndependence:
     def test_different_batch_neighbor_no_effect(self, model, device):
         model.eval()
         torch.manual_seed(42)
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
 
-        traj_a, _, _ = model(visual, vis_hist, ego, mode="infer")
+        traj_a, _, _ = model(visual, map_input, vis_hist, ego, mode="infer")
 
         # Change sample 1 completely
         visual_modified = visual.clone()
         visual_modified[1] = torch.randn_like(visual_modified[1])
 
-        traj_b, _, _ = model(visual_modified, vis_hist, ego, mode="infer")
+        traj_b, _, _ = model(visual_modified, map_input, vis_hist, ego, mode="infer")
 
         # Sample 0 output must remain unchanged
         assert torch.allclose(traj_a[0], traj_b[0], atol=1e-5), \
@@ -111,7 +112,7 @@ class TestViewFusion:
         """
         model.eval()
         torch.manual_seed(42)
-        visual, vis_hist, ego = make_inputs(1, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(1, 7, device)
         B, V, C, H, W = visual.shape
 
         def fused_features(x):
@@ -142,7 +143,7 @@ class TestViewFusion:
         """
         model.eval()
         torch.manual_seed(42)
-        visual, vis_hist, ego = make_inputs(1, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(1, 7, device)
         B, V, C, H, W = visual.shape
 
         def fused_features(x):
@@ -171,7 +172,7 @@ class TestViewFusion:
         model = build_mock_model(num_views=4, fusion_mode="bev", device=device)
         model.eval()
         torch.manual_seed(42)
-        visual, vis_hist, ego = make_inputs(1, 4, device)
+        visual, map_input, vis_hist, ego = make_inputs(1, 4, device)
         B, V, C, H, W = visual.shape
 
         # Identity-like ego-to-pixel projection that places every BEV reference
@@ -208,21 +209,19 @@ class TestViewFusion:
 
 class TestGradientFlow:
     def test_backward_succeeds(self, model, device):
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
         target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+        loss, ego_hidden, future = model(visual, map_input, vis_hist, ego, 
+                                         mode="train", trajectory_target=target)
 
         total = loss + ego_hidden.sum() + sum(f.sum() for f in future)
         total.backward()
 
     def test_all_parameters_have_gradients(self, model, device):
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
         target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+        loss, ego_hidden, future = model(visual, map_input, vis_hist, ego, 
+                                         mode="train", trajectory_target=target)
 
         total = loss + ego_hidden.sum() + sum(f.sum() for f in future)
         total.backward()
@@ -236,11 +235,11 @@ class TestGradientFlow:
             f"Parameters with no gradient: {params_without_grad}"
 
     def test_no_vanishing_gradients(self, model, device):
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
         target = torch.randn(2, 128, device=device)
         loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+             visual, map_input, vis_hist, ego, 
+            mode="train", trajectory_target=target)
 
         total = loss + ego_hidden.sum() + sum(f.sum() for f in future)
         total.backward()
@@ -249,6 +248,14 @@ class TestGradientFlow:
         for name, param in model.named_parameters():
             if param.requires_grad and param.grad is not None:
                 if param.grad.abs().max() == 0:
+                    # MapEncoder parameters legitimately receive zero gradient
+                    # at init because ResidualMapFusion uses alpha=0, which
+                    # zeroes out ∂loss/∂map_bev entirely (chain rule:
+                    # ∂fused/∂map_bev = alpha = 0). This is intentional: the
+                    # zero-init scheme ensures the map branch doesn't destabilise
+                    # early training. Gradient will flow once alpha grows > 0.
+                    if name.startswith("MapEncoder."):
+                        continue
                     zero_grad_params.append(name)
 
         assert len(zero_grad_params) == 0, \
@@ -267,11 +274,11 @@ class TestNumViewsFlexibility:
     ])
     def test_various_num_views(self, build_mock_model, device, num_views, fusion_mode):
         model = build_mock_model(num_views, fusion_mode, device)
-        visual, vis_hist, ego = make_inputs(2, num_views, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, num_views, device)
         target = torch.randn(2, 128, device=device)
         loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+             visual, map_input, vis_hist, ego, 
+            mode="train", trajectory_target=target)
 
         assert loss.dim() == 0
         assert ego_hidden.shape == (2, 256)
@@ -284,11 +291,11 @@ class TestNumViewsFlexibility:
 
 class TestNumericalStability:
     def test_no_nan_in_outputs(self, model, device):
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
         target = torch.randn(2, 128, device=device)
         loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+             visual, map_input, vis_hist, ego, 
+            mode="train", trajectory_target=target)
 
         assert not torch.isnan(loss), "NaN in planner loss"
         assert not torch.isnan(ego_hidden).any(), "NaN in ego_hidden"
@@ -296,11 +303,11 @@ class TestNumericalStability:
             assert not torch.isnan(f).any(), f"NaN in future feature {i}"
 
     def test_no_inf_in_outputs(self, model, device):
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
         target = torch.randn(2, 128, device=device)
         loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+             visual, map_input, vis_hist, ego, 
+            mode="train", trajectory_target=target)
 
         assert not torch.isinf(loss), "Inf in planner loss"
         assert not torch.isinf(ego_hidden).any(), "Inf in ego_hidden"
@@ -309,10 +316,11 @@ class TestNumericalStability:
 
     def test_large_input_values(self, model, device):
         """Model should not produce NaN/Inf even with large inputs."""
-        visual = torch.randn(1, 8, 3, 256, 256, device=device) * 100
+        visual = torch.randn(1, 7, 3, 256, 256, device=device) * 100
+        map_input = torch.randn(1, 3, 256, 256, device=device) * 100
         vis_hist = torch.randn(1, 896, device=device) * 100
         ego = torch.randn(1, 256, device=device) * 100
-        traj, ego_hidden, _ = model(visual, vis_hist, ego, mode="infer")
+        traj, _, _ = model(visual, map_input, vis_hist, ego, mode="infer")
 
         assert not torch.isnan(traj).any(), "NaN with large inputs"
         assert not torch.isinf(traj).any(), "Inf with large inputs"
@@ -830,11 +838,11 @@ class TestFullBackboneIntegration:
 
     def test_full_forward_pass(self, full_model, device):
         """Smoke test: full model forward produces expected output shapes."""
-        visual, vis_hist, ego = make_inputs(1, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(1, 7, device)
         target = torch.randn(1, 128, device=device)
         loss, ego_hidden, future = full_model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+             visual, map_input, vis_hist, ego, 
+            mode="train", trajectory_target=target)
 
         assert loss.dim() == 0
         assert ego_hidden.shape == (1, 256)
@@ -847,11 +855,10 @@ class TestFullBackboneIntegration:
 
     def test_full_forward_no_nan(self, full_model, device):
         """Full pipeline must not produce NaN with real backbone weights."""
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
         target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = full_model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+        loss, ego_hidden, future = full_model(visual, map_input, vis_hist, ego,
+                                              mode="train", trajectory_target=target)
 
         assert not torch.isnan(loss)
         assert not torch.isnan(ego_hidden).any()
@@ -869,7 +876,7 @@ class TestResNet50Backbone:
         from model_components.auto_e2e import AutoE2E
         try:
             model = AutoE2E(
-                backbone="res_net_50", num_views=8, fusion_mode="concat",
+                backbone="res_net_50", num_views=7, fusion_mode="concat",
                 is_pretrained=False,
             ).to(device)
         except (FileNotFoundError, OSError) as e:
@@ -878,11 +885,10 @@ class TestResNet50Backbone:
         # Dynamic backbone_channels = sum of all 5 ResNet50 stages = 3904
         assert model.Backbone.backbone_channels == 64 + 256 + 512 + 1024 + 2048
 
-        visual, vis_hist, ego = make_inputs(1, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(1, 7, device)
         target = torch.randn(1, 128, device=device)
         loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+            visual, map_input, vis_hist, ego, mode="train", trajectory_target=target)
 
         assert loss.dim() == 0
         assert ego_hidden.shape == (1, 256)
@@ -915,7 +921,7 @@ class TestTrainingLoop:
           - TrajectoryPlanner: outputs trajectory + ego_hidden
           - FutureState: produces future feature pyramid (consumed below)
         """
-        model = build_mock_model(num_views=8, fusion_mode="concat", device=device)
+        model = build_mock_model(num_views=7, fusion_mode="concat", device=device)
         model.train()
 
         optimizer = torch.optim.SGD(model.parameters(), lr=1e-2)
@@ -923,11 +929,10 @@ class TestTrainingLoop:
         before = {n: p.detach().clone() for n, p in model.named_parameters()
                   if p.requires_grad}
 
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
         target = torch.randn(2, 128, device=device)
         planner_loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+            visual, map_input, vis_hist, ego, mode="train", trajectory_target=target)
         loss = planner_loss + ego_hidden.sum() + sum(f.sum() for f in future)
 
         optimizer.zero_grad()
@@ -950,16 +955,14 @@ class TestTrainingLoop:
             f"optimizer.step() did not update any parameter in: {unchanged}"
 
     def test_model_to_loss_backward_integration(self, build_mock_model, device):
-        """The uniform planner-loss contract: forward(mode="train") returns a
-        scalar loss, and backward propagates grads end-to-end."""
-        model = build_mock_model(num_views=8, fusion_mode="concat", device=device)
+        """Pipe trajectory output into TrajectoryImitationLoss and run backward."""
+        model = build_mock_model(num_views=7, fusion_mode="bev", device=device)
         model.train()
 
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
         target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
-        )
+        loss, _, _ = model(visual, map_input, vis_hist, ego,
+                           mode="train", trajectory_target=target)
 
         assert loss.dim() == 0, "planner loss must be a scalar in train mode"
         assert loss.requires_grad
@@ -1140,14 +1143,15 @@ class TestVisualHistoryNonZeroDifference:
 class TestFullPipelineRobustness:
     def test_all_zero_inputs_produce_finite_outputs(self, build_mock_model, device):
         """Zero inputs across all paths must not cause NaN/Inf anywhere downstream."""
-        model = build_mock_model(num_views=8, fusion_mode="concat", device=device)
+        model = build_mock_model(num_views=7, fusion_mode="concat", device=device)
         model.eval()
 
-        visual = torch.zeros(2, 8, 3, 256, 256, device=device)
+        visual = torch.zeros(2, 7, 3, 256, 256, device=device)
+        map_input = torch.zeros(2, 3, 256, 256, device=device)
         vis_hist = torch.zeros(2, 896, device=device)
         ego = torch.zeros(2, 256, device=device)
 
-        traj, ego_hidden, _ = model(visual, vis_hist, ego, mode="infer")
+        traj, ego_hidden, _ = model(visual, map_input, vis_hist, ego, mode="infer")
 
         assert torch.isfinite(traj).all(), "NaN/Inf in trajectory with zero inputs"
         assert torch.isfinite(ego_hidden).all(), "NaN/Inf in ego_hidden with zero inputs"
@@ -1155,16 +1159,16 @@ class TestFullPipelineRobustness:
     def test_camera_params_none_then_valid_switching(self, build_mock_model, device):
         """A BEV-fusion model must accept both None and valid camera_params on the
         same instance, producing finite and distinct outputs."""
-        model = build_mock_model(num_views=8, fusion_mode="bev", device=device)
+        model = build_mock_model(num_views=7, fusion_mode="bev", device=device)
         model.eval()
 
-        visual, vis_hist, ego = make_inputs(1, 8, device, include_camera_params=False)
+        visual, map_input, vis_hist, ego = make_inputs(1, 7, device, include_camera_params=False)
 
-        traj_none, _, _ = model(visual, vis_hist, ego, mode="infer",
+        traj_none, _, _ = model(visual, map_input, vis_hist, ego, mode="infer",
                                 camera_params=None)
-        cam_params = torch.randn(1, 8, 3, 4, device=device)
-        traj_cam, _, _ = model(visual, vis_hist, ego, mode="infer",
-                               camera_params=cam_params)
+        cam_params = torch.randn(1, 7, 3, 4, device=device)
+        traj_cam, _, _ = model(visual, map_input, vis_hist, ego, mode="infer",
+                                camera_params=cam_params)
 
         assert torch.isfinite(traj_none).all(), "NaN/Inf with camera_params=None"
         assert torch.isfinite(traj_cam).all(), "NaN/Inf with valid camera_params"
@@ -1173,10 +1177,10 @@ class TestFullPipelineRobustness:
 
     def test_batch_size_one_smoke(self, build_mock_model, device):
         """End-to-end forward must work at batch_size=1 with correct shapes and no NaN."""
-        model = build_mock_model(num_views=8, fusion_mode="concat", device=device)
+        model = build_mock_model(num_views=7, fusion_mode="concat", device=device)
         model.eval()
-        visual, vis_hist, ego = make_inputs(1, 8, device)
-        traj, ego_hidden, _ = model(visual, vis_hist, ego, mode="infer")
+        visual, map_input, vis_hist, ego = make_inputs(1, 7, device)
+        traj, ego_hidden, _ = model(visual, map_input, vis_hist, ego, mode="infer")
 
         assert traj.shape == (1, 128)
         assert ego_hidden.shape == (1, 256)
@@ -1638,7 +1642,7 @@ class TestAutoE2EWithFlowMatching:
     @staticmethod
     def _fm_model(build_mock_model, device):
         return build_mock_model(
-            num_views=8, fusion_mode="concat", device=device,
+            num_views=8, fusion_mode="bev", device=device,
             planner_mode="flow_matching",
             planner_kwargs={"num_inference_steps": 4},
         )
@@ -1649,10 +1653,10 @@ class TestAutoE2EWithFlowMatching:
         This documents that the velocity-vs-target footgun is gone."""
         model = self._fm_model(build_mock_model, device)
         model.train()
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 8, device)
         target = torch.randn(2, 128, device=device)
         loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
+            visual, map_input, vis_hist, ego, mode="train", trajectory_target=target,
         )
         assert loss.dim() == 0, \
             "FM train mode must expose a scalar loss, not a [B, T*S] velocity"
@@ -1663,8 +1667,8 @@ class TestAutoE2EWithFlowMatching:
     def test_infer_mode_returns_trajectory(self, build_mock_model, device):
         model = self._fm_model(build_mock_model, device)
         model.eval()
-        visual, vis_hist, ego = make_inputs(1, 8, device)
-        traj, ego_hidden, future = model(visual, vis_hist, ego, mode="infer")
+        visual, map_input, vis_hist, ego = make_inputs(1, 8, device)
+        traj, ego_hidden, future = model(visual, map_input, vis_hist, ego, mode="infer")
         assert traj.shape == (1, 128)
         assert ego_hidden.shape == (1, 256)
         assert future is None
@@ -1673,10 +1677,10 @@ class TestAutoE2EWithFlowMatching:
     def test_backward_flows_through_planner_loss(self, build_mock_model, device):
         model = self._fm_model(build_mock_model, device)
         model.train()
-        visual, vis_hist, ego = make_inputs(2, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(2, 8, device)
         target = torch.randn(2, 128, device=device)
         loss, ego_hidden, future = model(
-            visual, vis_hist, ego, mode="train", trajectory_target=target,
+            visual, map_input, vis_hist, ego, mode="train", trajectory_target=target,
         )
         total = loss + ego_hidden.sum() + sum(f.sum() for f in future)
         total.backward()
@@ -1694,9 +1698,9 @@ class TestAutoE2EWithFlowMatching:
 
     def test_train_mode_requires_target(self, build_mock_model, device):
         model = self._fm_model(build_mock_model, device)
-        visual, vis_hist, ego = make_inputs(1, 8, device)
+        visual, map_input, vis_hist, ego = make_inputs(1, 8, device)
         with pytest.raises(ValueError, match="trajectory_target"):
-            model(visual, vis_hist, ego, mode="train")
+            model(visual, map_input, vis_hist, ego, mode="train")
 
     def test_gru_and_fm_interchangeable_at_inference(self, build_mock_model, device):
         """GRU and FM both produce a [B, T*S] trajectory in inference mode —
@@ -1707,7 +1711,7 @@ class TestAutoE2EWithFlowMatching:
         gru_model.eval()
         fm_model.eval()
 
-        visual, vis_hist, ego = make_inputs(2, 8, device)
-        gru_traj, _, _ = gru_model(visual, vis_hist, ego, mode="infer")
-        fm_traj, _, _ = fm_model(visual, vis_hist, ego, mode="infer")
+        visual, map_input, vis_hist, ego = make_inputs(2, 8, device)
+        gru_traj, _, _ = gru_model(visual, map_input, vis_hist, ego, mode="infer")
+        fm_traj, _, _ = fm_model(visual, map_input, vis_hist, ego, mode="infer")
         assert gru_traj.shape == fm_traj.shape == (2, 128)

--- a/Model/tests/test_auto_e2e.py
+++ b/Model/tests/test_auto_e2e.py
@@ -229,6 +229,14 @@ class TestGradientFlow:
         params_without_grad = []
         for name, param in model.named_parameters():
             if param.requires_grad and param.grad is None:
+                # MapEncoder parameters legitimately receive zero gradient
+                # at init because ResidualMapFusion uses alpha=0, which
+                # zeroes out ∂loss/∂map_bev entirely (chain rule:
+                # ∂fused/∂map_bev = alpha = 0). This is intentional: the
+                # zero-init scheme ensures the map branch doesn't destabilise
+                # early training. Gradient will flow once alpha grows > 0.
+                if name.startswith("MapEncoder."):
+                    continue
                 params_without_grad.append(name)
 
         assert len(params_without_grad) == 0, \
@@ -248,12 +256,6 @@ class TestGradientFlow:
         for name, param in model.named_parameters():
             if param.requires_grad and param.grad is not None:
                 if param.grad.abs().max() == 0:
-                    # MapEncoder parameters legitimately receive zero gradient
-                    # at init because ResidualMapFusion uses alpha=0, which
-                    # zeroes out ∂loss/∂map_bev entirely (chain rule:
-                    # ∂fused/∂map_bev = alpha = 0). This is intentional: the
-                    # zero-init scheme ensures the map branch doesn't destabilise
-                    # early training. Gradient will flow once alpha grows > 0.
                     if name.startswith("MapEncoder."):
                         continue
                     zero_grad_params.append(name)

--- a/Model/tests/test_auto_e2e.py
+++ b/Model/tests/test_auto_e2e.py
@@ -36,13 +36,13 @@ class TestOutputShapes:
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     def test_trajectory_shape(self, model, device, batch_size):
         visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
-        traj, _, _ = model(visual, map_input, vis_hist, ego)
+        traj, _, _ = model(visual, map_input, vis_hist, ego, mode="infer")
         assert traj.shape == (batch_size, 128)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     def test_ego_hidden_shape(self, model, device, batch_size):
         visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
-        _, ego_hidden, _ = model(visual, map_input, vis_hist, ego)
+        _, ego_hidden, _ = model(visual, map_input, vis_hist, ego, mode="infer")
         assert ego_hidden.shape == (batch_size, 256)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
@@ -229,7 +229,7 @@ class TestGradientFlow:
         params_without_grad = []
         for name, param in model.named_parameters():
             if param.requires_grad and param.grad is None:
-                # MapEncoder parameters legitimately receive zero gradient
+            # MapEncoder parameters legitimately receive zero gradient
                 # at init because ResidualMapFusion uses alpha=0, which
                 # zeroes out ∂loss/∂map_bev entirely (chain rule:
                 # ∂fused/∂map_bev = alpha = 0). This is intentional: the
@@ -823,6 +823,7 @@ class TestBEVFusion:
         # has_observation mask zeroes output after FFN
         assert out.abs().max() < 1e-6, \
             "No visible camera should produce zero BEV features"
+
 
 
 # ---------------------------------------------------------------------------

--- a/Model/tests/test_map_encoder.py
+++ b/Model/tests/test_map_encoder.py
@@ -1,0 +1,333 @@
+"""Tests for the map encoder and map BEV fusion modules.
+
+Covers:
+  - RasterizedMapEncoder: output shape, channel layout, gradient flow
+  - ResidualMapFusion: zero-alpha init, output shape, alpha learns, gradient flow
+  - MapCrossAttentionFusion: output shape, map influences output, gradient flow
+  - MAP_ENCODER_REGISTRY and MAP_FUSION_REGISTRY
+  - AutoE2E map integration: zero map produces same output as alpha=0 baseline,
+    map_input influences trajectory once alpha is non-zero, MapEncoder and
+    MapBEVFusion parameters receive gradients
+"""
+
+import pytest
+import torch
+import sys
+sys.path.append('..')
+
+from model_components.map_encoder import (
+    MAP_ENCODER_REGISTRY,
+    MAP_FUSION_REGISTRY,
+    build_map_encoder,
+    build_map_bev_fusion,
+    RasterizedMapEncoder,
+)
+from model_components.map_encoder.map_bev_fusion.residual_fusion import ResidualMapFusion
+from model_components.map_encoder.map_bev_fusion.cross_attention_fusion import MapCrossAttentionFusion
+
+
+_MAP_H = 256
+_MAP_W = 256
+
+
+def _make_bev_pair(batch_size, embed_dim, spatial, device):
+    image_bev = torch.randn(batch_size, embed_dim, spatial, spatial, device=device)
+    map_bev = torch.randn(batch_size, embed_dim, spatial, spatial, device=device)
+    return image_bev, map_bev
+
+
+class TestRasterizedMapEncoder:
+    def test_output_shape(self, device):
+        enc = RasterizedMapEncoder(in_channels=3, embed_dim=256, output_h=8, output_w=8).to(device)
+        x = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
+        out = enc(x)
+        assert out.shape == (2, 256, 8, 8), f"Expected (2, 256, 8, 8), got {tuple(out.shape)}"
+
+    def test_output_is_channels_first(self, device):
+        enc = RasterizedMapEncoder(embed_dim=64, output_h=4, output_w=4).to(device)
+        x = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
+        out = enc(x)
+        assert out.dim() == 4
+        assert out.shape[1] == 64, "Channel dim should be at position 1"
+
+    def test_output_size_is_honoured(self, device):
+        for h, w in [(4, 4), (8, 8), (8, 16), (16, 8)]:
+            enc = RasterizedMapEncoder(embed_dim=32, output_h=h, output_w=w).to(device)
+            x = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
+            out = enc(x)
+            assert out.shape[-2:] == (h, w), \
+                f"Expected spatial ({h}, {w}), got {tuple(out.shape[-2:])}"
+
+    def test_no_nan_on_zero_input(self, device):
+        enc = RasterizedMapEncoder(embed_dim=256, output_h=8, output_w=8).to(device)
+        x = torch.zeros(2, 3, _MAP_H, _MAP_W, device=device)
+        out = enc(x)
+        assert torch.isfinite(out).all(), "NaN/Inf with zero map input"
+
+    def test_different_inputs_produce_different_outputs(self, device):
+        enc = RasterizedMapEncoder(embed_dim=256, output_h=8, output_w=8).to(device)
+        enc.eval()
+        a = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
+        b = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
+        assert not torch.allclose(enc(a), enc(b), atol=1e-5), \
+            "Different map inputs produced identical features"
+
+    def test_gradient_flows_through_encoder(self, device):
+        enc = RasterizedMapEncoder(embed_dim=64, output_h=4, output_w=4).to(device)
+        x = torch.randn(1, 3, _MAP_H, _MAP_W, device=device, requires_grad=True)
+        enc(x).sum().backward()
+        assert x.grad is not None and x.grad.abs().max() > 0
+
+    def test_all_parameters_receive_gradients(self, device):
+        enc = RasterizedMapEncoder(embed_dim=64, output_h=4, output_w=4).to(device)
+        x = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
+        enc(x).sum().backward()
+        no_grad = [n for n, p in enc.named_parameters()
+                   if p.requires_grad and p.grad is None]
+        assert not no_grad, f"Parameters without grad: {no_grad}"
+
+    def test_is_randomly_initialized(self):
+        """Two independently constructed encoders must have different weights."""
+        enc_a = RasterizedMapEncoder(embed_dim=64, output_h=4, output_w=4)
+        enc_b = RasterizedMapEncoder(embed_dim=64, output_h=4, output_w=4)
+        w_a = next(enc_a._backbone.parameters())
+        w_b = next(enc_b._backbone.parameters())
+        assert not torch.equal(w_a, w_b), \
+            "Two encoders have identical weights — random init may not be working"
+
+
+class TestResidualMapFusion:
+    def test_output_shape(self, device):
+        fusion = ResidualMapFusion(embed_dim=256).to(device)
+        image_bev, map_bev = _make_bev_pair(2, 256, 8, device)
+        out = fusion(image_bev, map_bev)
+        assert out.shape == (2, 256, 8, 8)
+
+    def test_alpha_initialized_to_zero(self):
+        fusion = ResidualMapFusion(embed_dim=256)
+        assert torch.all(fusion.alpha == 0), \
+            "alpha must be zero-initialized so map has no effect at training start"
+
+    def test_zero_alpha_returns_image_bev_unchanged(self, device):
+        fusion = ResidualMapFusion(embed_dim=256).to(device)
+        image_bev, map_bev = _make_bev_pair(1, 256, 8, device)
+        out = fusion(image_bev, map_bev)
+        assert torch.allclose(out, image_bev), \
+            "With alpha=0 the output should equal image_bev exactly"
+
+    def test_nonzero_alpha_changes_output(self, device):
+        fusion = ResidualMapFusion(embed_dim=256).to(device)
+        with torch.no_grad():
+            fusion.alpha.fill_(1.0)
+        image_bev, map_bev = _make_bev_pair(1, 256, 8, device)
+        out = fusion(image_bev, map_bev)
+        assert not torch.allclose(out, image_bev, atol=1e-5), \
+            "With alpha=1 the output should differ from image_bev"
+
+    def test_alpha_is_per_channel(self, device):
+        embed_dim = 64
+        fusion = ResidualMapFusion(embed_dim=embed_dim).to(device)
+        assert fusion.alpha.shape == (embed_dim,), \
+            f"alpha should have shape ({embed_dim},), got {tuple(fusion.alpha.shape)}"
+
+    def test_alpha_receives_gradient(self, device):
+        fusion = ResidualMapFusion(embed_dim=256).to(device)
+        image_bev, map_bev = _make_bev_pair(2, 256, 8, device)
+        with torch.no_grad():
+            fusion.alpha.fill_(0.1)
+        fusion(image_bev, map_bev).sum().backward()
+        assert fusion.alpha.grad is not None, "alpha has no gradient"
+        assert fusion.alpha.grad.abs().max() > 0, "alpha gradient is all-zero"
+
+    def test_no_nan_with_zero_inputs(self, device):
+        fusion = ResidualMapFusion(embed_dim=256).to(device)
+        with torch.no_grad():
+            fusion.alpha.fill_(1.0)
+        out = fusion(
+            torch.zeros(1, 256, 8, 8, device=device),
+            torch.zeros(1, 256, 8, 8, device=device),
+        )
+        assert torch.isfinite(out).all()
+
+
+class TestMapCrossAttentionFusion:
+    def test_output_shape(self, device):
+        fusion = MapCrossAttentionFusion(embed_dim=256).to(device)
+        image_bev, map_bev = _make_bev_pair(2, 256, 8, device)
+        out = fusion(image_bev, map_bev)
+        assert out.shape == (2, 256, 8, 8)
+
+    def test_map_influences_output(self, device):
+        fusion = MapCrossAttentionFusion(embed_dim=256).to(device)
+        fusion.eval()
+        image_bev = torch.randn(1, 256, 8, 8, device=device)
+        map_a = torch.randn(1, 256, 8, 8, device=device)
+        map_b = torch.randn(1, 256, 8, 8, device=device)
+        out_a = fusion(image_bev, map_a)
+        out_b = fusion(image_bev, map_b)
+        assert not torch.allclose(out_a, out_b, atol=1e-5), \
+            "Different map inputs produced identical output — cross-attention has no effect"
+
+    def test_gradient_flows_through_fusion(self, device):
+        fusion = MapCrossAttentionFusion(embed_dim=64).to(device)
+        image_bev = torch.randn(1, 64, 4, 4, device=device, requires_grad=True)
+        map_bev = torch.randn(1, 64, 4, 4, device=device, requires_grad=True)
+        fusion(image_bev, map_bev).sum().backward()
+        assert image_bev.grad is not None and image_bev.grad.abs().max() > 0
+        assert map_bev.grad is not None and map_bev.grad.abs().max() > 0
+
+    def test_no_nan_with_zero_inputs(self, device):
+        fusion = MapCrossAttentionFusion(embed_dim=64).to(device)
+        out = fusion(
+            torch.zeros(1, 64, 4, 4, device=device),
+            torch.zeros(1, 64, 4, 4, device=device),
+        )
+        assert torch.isfinite(out).all()
+
+    def test_output_matches_input_spatial_size(self, device):
+        for h, w in [(4, 4), (8, 8), (7, 7)]:
+            fusion = MapCrossAttentionFusion(embed_dim=32).to(device)
+            image_bev = torch.randn(1, 32, h, w, device=device)
+            map_bev = torch.randn(1, 32, h, w, device=device)
+            out = fusion(image_bev, map_bev)
+            assert out.shape == (1, 32, h, w), \
+                f"Expected (1, 32, {h}, {w}), got {tuple(out.shape)}"
+
+
+
+class TestMapRegistries:
+    def test_rasterized_in_encoder_registry(self):
+        assert "rasterized" in MAP_ENCODER_REGISTRY
+
+    def test_unknown_encoder_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown map_type"):
+            build_map_encoder("vectorized")
+
+    def test_residual_and_cross_attn_in_fusion_registry(self):
+        assert "residual" in MAP_FUSION_REGISTRY
+        assert "cross_attn" in MAP_FUSION_REGISTRY
+
+    def test_unknown_fusion_mode_raises(self):
+        with pytest.raises(ValueError, match="Unknown map_fusion_mode"):
+            build_map_bev_fusion("nonexistent")
+
+    def test_build_map_encoder_returns_correct_type(self):
+        enc = build_map_encoder("rasterized", embed_dim=32, output_h=4, output_w=4)
+        assert isinstance(enc, RasterizedMapEncoder)
+
+    def test_build_map_bev_fusion_residual(self, device):
+        fusion = build_map_bev_fusion("residual", embed_dim=64).to(device)
+        assert isinstance(fusion, ResidualMapFusion)
+
+    def test_build_map_bev_fusion_cross_attn(self, device):
+        fusion = build_map_bev_fusion("cross_attn", embed_dim=64).to(device)
+        assert isinstance(fusion, MapCrossAttentionFusion)
+
+
+class TestAutoE2EMapIntegration:
+    """End-to-end tests verifying the map branch is correctly wired into AutoE2E.
+
+    Uses the build_mock_model fixture from conftest — it already handles patching
+    Backbone with MockBackbone internally, so there's no need to import conftest
+    directly (pytest makes conftest a plugin, not an importable module).
+    """
+
+    def _make_model(self, build_mock_model, device, map_fusion_mode="cross_attn"):
+        return build_mock_model(
+            num_views=7,
+            fusion_mode="concat",
+            device=device,
+            map_fusion_mode=map_fusion_mode,
+        )
+
+    def test_zero_map_with_zero_alpha_equals_no_map(self, build_mock_model, device):
+        """Only for residual fusion: With alpha=0 (init) and zero map input, output must equal a forward pass
+        using the same camera inputs but a random map — proving the gate is closed."""
+        model = self._make_model(build_mock_model, device, map_fusion_mode="residual")
+        model.eval()
+
+        visual = torch.randn(1, 7, 3, 256, 256, device=device)
+        map_zero = torch.zeros(1, 3, _MAP_H, _MAP_W, device=device)
+        map_rand = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
+        vis_hist = torch.randn(1, 896, device=device)
+        ego = torch.randn(1, 256, device=device)
+
+        traj_zero, _, _ = model(visual, map_zero, vis_hist, ego)
+        traj_rand, _, _ = model(visual, map_rand, vis_hist, ego)
+
+        assert torch.allclose(traj_zero, traj_rand, atol=1e-5), \
+            "With alpha=0, different map inputs should produce identical trajectories"
+
+    def test_nonzero_alpha_makes_map_influence_trajectory(self, build_mock_model, device):
+        """Only for residual fusion: Once alpha is non-zero, different map inputs must produce different trajectories."""
+        model = self._make_model(build_mock_model, device, map_fusion_mode="residual")
+        model.eval()
+        with torch.no_grad():
+            model.MapBEVFusion.alpha.fill_(1.0)
+
+        visual = torch.randn(1, 7, 3, 256, 256, device=device)
+        vis_hist = torch.randn(1, 896, device=device)
+        ego = torch.randn(1, 256, device=device)
+
+        traj_a, _, _ = model(visual, torch.randn(1, 3, _MAP_H, _MAP_W, device=device), vis_hist, ego)
+        traj_b, _, _ = model(visual, torch.randn(1, 3, _MAP_H, _MAP_W, device=device), vis_hist, ego)
+
+        assert not torch.allclose(traj_a, traj_b, atol=1e-5), \
+            "With alpha=1, different map inputs should produce different trajectories"
+
+    def test_map_encoder_parameters_receive_gradients(self, build_mock_model, device):
+        model = self._make_model(build_mock_model, device)
+        model.train()
+
+        visual = torch.randn(2, 7, 3, 256, 256, device=device)
+        map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
+        vis_hist = torch.randn(2, 896, device=device)
+        ego = torch.randn(2, 256, device=device)
+
+        traj, ego_hidden, future = model(visual, map_input, vis_hist, ego)
+        (traj.sum() + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
+
+        no_grad = [n for n, p in model.MapEncoder.named_parameters()
+                   if p.requires_grad and p.grad is None]
+        assert not no_grad, f"MapEncoder params without grad: {no_grad}"
+
+    def test_alpha_receives_gradient(self, build_mock_model, device):
+        model = self._make_model(build_mock_model, device, map_fusion_mode="residual")
+        model.train()
+        with torch.no_grad():
+            model.MapBEVFusion.alpha.fill_(0.1)
+
+        visual = torch.randn(1, 7, 3, 256, 256, device=device)
+        map_input = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
+        vis_hist = torch.randn(1, 896, device=device)
+        ego = torch.randn(1, 256, device=device)
+
+        model(visual, map_input, vis_hist, ego)[0].sum().backward()
+
+        assert model.MapBEVFusion.alpha.grad is not None, "alpha has no gradient"
+        assert model.MapBEVFusion.alpha.grad.abs().max() > 0, "alpha gradient is all-zero"
+
+    def test_cross_attn_fusion_mode_forward_succeeds(self, build_mock_model, device):
+        model = self._make_model(build_mock_model, device, map_fusion_mode="cross_attn")
+        visual = torch.randn(1, 7, 3, 256, 256, device=device)
+        map_input = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
+        vis_hist = torch.randn(1, 896, device=device)
+        ego = torch.randn(1, 256, device=device)
+        traj, ego_hidden, _ = model(visual, map_input, vis_hist, ego)
+        assert traj.shape == (1, 128)
+        assert ego_hidden.shape == (1, 256)
+        assert torch.isfinite(traj).all()
+
+    def test_map_encoder_attribute_exists(self, build_mock_model, device):
+        model = self._make_model(build_mock_model, device)
+        assert hasattr(model, "MapEncoder"), "AutoE2E missing MapEncoder attribute"
+        assert hasattr(model, "MapBEVFusion"), "AutoE2E missing MapBEVFusion attribute"
+
+    def test_invalid_map_fusion_mode_raises(self, build_mock_model, device):
+        with pytest.raises(ValueError, match="Unknown map_fusion_mode"):
+            build_mock_model(
+                num_views=7,
+                fusion_mode="concat",
+                device=device,
+                map_fusion_mode="nonexistent",
+            )

--- a/Model/tests/test_map_encoder.py
+++ b/Model/tests/test_map_encoder.py
@@ -232,10 +232,10 @@ class TestAutoE2EMapIntegration:
     directly (pytest makes conftest a plugin, not an importable module).
     """
 
-    def _make_model(self, build_mock_model, device, map_fusion_mode="cross_attn"):
+    def _make_model(self, build_mock_model, device, map_fusion_mode="residual"):
         return build_mock_model(
             num_views=7,
-            fusion_mode="concat",
+            fusion_mode="bev",
             device=device,
             map_fusion_mode=map_fusion_mode,
         )
@@ -275,8 +275,8 @@ class TestAutoE2EMapIntegration:
         assert not torch.allclose(traj_a, traj_b, atol=1e-5), \
             "With alpha=1, different map inputs should produce different trajectories"
 
-    def test_map_encoder_parameters_receive_gradients(self, build_mock_model, device):
-        model = self._make_model(build_mock_model, device)
+    def test_cross_attn_map_encoder_parameters_receive_gradients(self, build_mock_model, device):
+        model = self._make_model(build_mock_model, device, map_fusion_mode="cross_attn")
         model.train()
 
         visual = torch.randn(2, 7, 3, 256, 256, device=device)
@@ -292,6 +292,7 @@ class TestAutoE2EMapIntegration:
         assert not no_grad, f"MapEncoder params without grad: {no_grad}"
 
     def test_alpha_receives_gradient(self, build_mock_model, device):
+        """Only for residual fusion: alpha must receive a non-zero gradient when map influences trajectory."""
         model = self._make_model(build_mock_model, device, map_fusion_mode="residual")
         model.train()
         with torch.no_grad():
@@ -306,6 +307,25 @@ class TestAutoE2EMapIntegration:
 
         assert model.MapBEVFusion.alpha.grad is not None, "alpha has no gradient"
         assert model.MapBEVFusion.alpha.grad.abs().max() > 0, "alpha gradient is all-zero"
+
+    def test_map_encoder_receives_gradients_when_alpha_nonzero(self, build_mock_model, device):
+        """Only for residual fusion: MapEncoder parameters must receive gradients once alpha is non-zero."""
+        model = self._make_model(build_mock_model, device, map_fusion_mode="residual")
+        model.train()
+        with torch.no_grad():
+            model.MapBEVFusion.alpha.fill_(0.1)
+
+        visual = torch.randn(2, 7, 3, 256, 256, device=device)
+        map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
+        vis_hist = torch.randn(2, 896, device=device)
+        ego = torch.randn(2, 256, device=device)
+
+        traj, ego_hidden, future = model(visual, map_input, vis_hist, ego)
+        (traj.sum() + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
+
+        no_grad = [n for n, p in model.MapEncoder.named_parameters()
+                if p.requires_grad and p.grad is None]
+        assert not no_grad, f"MapEncoder params without grad after alpha=0.1: {no_grad}"
 
     def test_cross_attn_fusion_mode_forward_succeeds(self, build_mock_model, device):
         model = self._make_model(build_mock_model, device, map_fusion_mode="cross_attn")
@@ -327,7 +347,7 @@ class TestAutoE2EMapIntegration:
         with pytest.raises(ValueError, match="Unknown map_fusion_mode"):
             build_mock_model(
                 num_views=7,
-                fusion_mode="concat",
+                fusion_mode="bev",
                 device=device,
                 map_fusion_mode="nonexistent",
             )

--- a/Model/tests/test_map_encoder.py
+++ b/Model/tests/test_map_encoder.py
@@ -36,11 +36,15 @@ def _make_bev_pair(batch_size, embed_dim, spatial, device):
     return image_bev, map_bev
 
 
+@pytest.fixture(scope="session")
+def map_encoder(device):
+    return RasterizedMapEncoder(embed_dim=256, output_h=8, output_w=8).to(device)
+
+
 class TestRasterizedMapEncoder:
-    def test_output_shape(self, device):
-        enc = RasterizedMapEncoder(in_channels=3, embed_dim=256, output_h=8, output_w=8).to(device)
+    def test_output_shape(self, map_encoder, device):
         x = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
-        out = enc(x)
+        out = map_encoder(x)
         assert out.shape == (2, 256, 8, 8), f"Expected (2, 256, 8, 8), got {tuple(out.shape)}"
 
     def test_output_is_channels_first(self, device):
@@ -51,25 +55,23 @@ class TestRasterizedMapEncoder:
         assert out.shape[1] == 64, "Channel dim should be at position 1"
 
     def test_output_size_is_honoured(self, device):
-        for h, w in [(4, 4), (8, 8), (8, 16), (16, 8)]:
+        for h, w in [(8, 8), (8, 16), (16, 8)]:
             enc = RasterizedMapEncoder(embed_dim=32, output_h=h, output_w=w).to(device)
             x = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
             out = enc(x)
             assert out.shape[-2:] == (h, w), \
                 f"Expected spatial ({h}, {w}), got {tuple(out.shape[-2:])}"
 
-    def test_no_nan_on_zero_input(self, device):
-        enc = RasterizedMapEncoder(embed_dim=256, output_h=8, output_w=8).to(device)
+    def test_no_nan_on_zero_input(self, map_encoder, device):
         x = torch.zeros(2, 3, _MAP_H, _MAP_W, device=device)
-        out = enc(x)
+        out = map_encoder(x)
         assert torch.isfinite(out).all(), "NaN/Inf with zero map input"
 
-    def test_different_inputs_produce_different_outputs(self, device):
-        enc = RasterizedMapEncoder(embed_dim=256, output_h=8, output_w=8).to(device)
-        enc.eval()
+    def test_different_inputs_produce_different_outputs(self, map_encoder, device):
+        map_encoder.eval()
         a = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
         b = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
-        assert not torch.allclose(enc(a), enc(b), atol=1e-5), \
+        assert not torch.allclose(map_encoder(a), map_encoder(b), atol=1e-5), \
             "Different map inputs produced identical features"
 
     def test_gradient_flows_through_encoder(self, device):
@@ -246,14 +248,14 @@ class TestAutoE2EMapIntegration:
         model = self._make_model(build_mock_model, device, map_fusion_mode="residual")
         model.eval()
 
-        visual = torch.randn(1, 7, 3, 256, 256, device=device)
-        map_zero = torch.zeros(1, 3, _MAP_H, _MAP_W, device=device)
-        map_rand = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
-        vis_hist = torch.randn(1, 896, device=device)
-        ego = torch.randn(1, 256, device=device)
+        visual = torch.randn(2, 7, 3, 256, 256, device=device)
+        map_zero = torch.zeros(2, 3, _MAP_H, _MAP_W, device=device)
+        map_rand = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
+        vis_hist = torch.randn(2, 896, device=device)
+        ego = torch.randn(2, 256, device=device)
 
-        traj_zero, _, _ = model(visual, map_zero, vis_hist, ego)
-        traj_rand, _, _ = model(visual, map_rand, vis_hist, ego)
+        traj_zero, _, _ = model(visual, map_zero, vis_hist, ego, mode="infer")
+        traj_rand, _, _ = model(visual, map_rand, vis_hist, ego, mode="infer")
 
         assert torch.allclose(traj_zero, traj_rand, atol=1e-5), \
             "With alpha=0, different map inputs should produce identical trajectories"
@@ -265,12 +267,12 @@ class TestAutoE2EMapIntegration:
         with torch.no_grad():
             model.MapBEVFusion.alpha.fill_(1.0)
 
-        visual = torch.randn(1, 7, 3, 256, 256, device=device)
-        vis_hist = torch.randn(1, 896, device=device)
-        ego = torch.randn(1, 256, device=device)
+        visual = torch.randn(2, 7, 3, 256, 256, device=device)
+        vis_hist = torch.randn(2, 896, device=device)
+        ego = torch.randn(2, 256, device=device)
 
-        traj_a, _, _ = model(visual, torch.randn(1, 3, _MAP_H, _MAP_W, device=device), vis_hist, ego)
-        traj_b, _, _ = model(visual, torch.randn(1, 3, _MAP_H, _MAP_W, device=device), vis_hist, ego)
+        traj_a, _, _ = model(visual, torch.randn(2, 3, _MAP_H, _MAP_W, device=device), vis_hist, ego, mode="infer")
+        traj_b, _, _ = model(visual, torch.randn(2, 3, _MAP_H, _MAP_W, device=device), vis_hist, ego, mode="infer")
 
         assert not torch.allclose(traj_a, traj_b, atol=1e-5), \
             "With alpha=1, different map inputs should produce different trajectories"
@@ -283,9 +285,10 @@ class TestAutoE2EMapIntegration:
         map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
         vis_hist = torch.randn(2, 896, device=device)
         ego = torch.randn(2, 256, device=device)
+        target = torch.randn(2, 128, device=device)
 
-        traj, ego_hidden, future = model(visual, map_input, vis_hist, ego)
-        (traj.sum() + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
+        loss, ego_hidden, future = model(visual, map_input, vis_hist, ego, mode="train", trajectory_target=target)
+        (loss + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
 
         no_grad = [n for n, p in model.MapEncoder.named_parameters()
                    if p.requires_grad and p.grad is None]
@@ -298,12 +301,15 @@ class TestAutoE2EMapIntegration:
         with torch.no_grad():
             model.MapBEVFusion.alpha.fill_(0.1)
 
-        visual = torch.randn(1, 7, 3, 256, 256, device=device)
-        map_input = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
-        vis_hist = torch.randn(1, 896, device=device)
-        ego = torch.randn(1, 256, device=device)
+        visual = torch.randn(2, 7, 3, 256, 256, device=device)
+        map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
+        vis_hist = torch.randn(2, 896, device=device)
+        ego = torch.randn(2, 256, device=device)
+        target = torch.randn(2, 128, device=device)
 
-        model(visual, map_input, vis_hist, ego)[0].sum().backward()
+        loss, ego_hidden, future = model(visual, map_input, vis_hist, ego, mode="train", trajectory_target=target)
+        (loss + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
+
 
         assert model.MapBEVFusion.alpha.grad is not None, "alpha has no gradient"
         assert model.MapBEVFusion.alpha.grad.abs().max() > 0, "alpha gradient is all-zero"
@@ -319,9 +325,10 @@ class TestAutoE2EMapIntegration:
         map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
         vis_hist = torch.randn(2, 896, device=device)
         ego = torch.randn(2, 256, device=device)
+        target = torch.randn(2, 128, device=device)
 
-        traj, ego_hidden, future = model(visual, map_input, vis_hist, ego)
-        (traj.sum() + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
+        loss, ego_hidden, future = model(visual, map_input, vis_hist, ego, mode="train", trajectory_target=target)
+        (loss + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
 
         no_grad = [n for n, p in model.MapEncoder.named_parameters()
                 if p.requires_grad and p.grad is None]
@@ -329,13 +336,13 @@ class TestAutoE2EMapIntegration:
 
     def test_cross_attn_fusion_mode_forward_succeeds(self, build_mock_model, device):
         model = self._make_model(build_mock_model, device, map_fusion_mode="cross_attn")
-        visual = torch.randn(1, 7, 3, 256, 256, device=device)
-        map_input = torch.randn(1, 3, _MAP_H, _MAP_W, device=device)
-        vis_hist = torch.randn(1, 896, device=device)
-        ego = torch.randn(1, 256, device=device)
-        traj, ego_hidden, _ = model(visual, map_input, vis_hist, ego)
-        assert traj.shape == (1, 128)
-        assert ego_hidden.shape == (1, 256)
+        visual = torch.randn(2, 7, 3, 256, 256, device=device)
+        map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
+        vis_hist = torch.randn(2, 896, device=device)
+        ego = torch.randn(2, 256, device=device)
+        traj, ego_hidden, _ = model(visual, map_input, vis_hist, ego, mode="infer")
+        assert traj.shape == (2, 128)
+        assert ego_hidden.shape == (2, 256)
         assert torch.isfinite(traj).all()
 
     def test_map_encoder_attribute_exists(self, build_mock_model, device):


### PR DESCRIPTION
## Separate Map Encoder for Rasterized Nav-Maps
Partially solves #47.

Implements rasterized map encoder for rasterized maps. The map is now supposed to be a separate input with its own encoder branch, fused with image BEV features before the trajectory planner. The data parsers have not been updated in this PR.

---

### What changed

**`model_components/map_encoder/`**:
- `RasterizedMapEncoder`: SwinV2-Tiny; outputs `(B, embed_dim, output_h, output_w)`. Encodes a BEV nav-map image into a spatial feature map; matches feature map shape of BEV features
 
**`model_components/map_encoder/map_bev_fusion/`**:
- `MapCrossAttentionFusion`: image BEV queries attend to map BEV keys/values via pre-norm cross-attention.
- `ResidualMapFusion`: `image_bev + alpha * map_bev` where `alpha` is a per-channel `nn.Parameter` initialized to zero. Map branch contributes nothing at training start; gradient flows once alpha grows (adopted from UMPE (arXiv 2605.02762) based on discussion in #47, but see caveats below).
- Both fusion modes registered in `MAP_FUSION_REGISTRY`.

**`model_components/auto_e2e.py`**:
- `num_views` default changed from 8 to 7.
- `forward()` signature: `(camera_tiles, map_input, visual_history, egomotion_history, ...)`. `map_input` is `(B, 3, 256, 256)`.
- Map encoder output size is derived from the view fusion mode: `(bev_h, bev_w)` for bev mode, `(image_feature_size, image_feature_size)` for concat/cross_attn.

---

**Spatial correspondence caveat.** The residual and cross-attention fusions assume `image_bev[i,j]` and `map_bev[i,j]` correspond to the same location in ego-frame space. This assumption holds cleanly only for `fusion_mode="bev"`, where `BEVViewFusion` builds a metric BEV grid from explicit camera projection matrices and `pc_range`. In that mode both feature maps are anchored to the same ego-frame coordinate system and spatial fusion is geometrically meaningful.

For `fusion_mode="concat"` and `fusion_mode="cross_attn"`, `FeatureFusion` produces an abstract feature map by pooling per-view features; there is no metric spatial correspondence between positions in `image_bev` and positions in `map_bev`. The fusion still works as a learned blending mechanism, but the per-cell spatial alignment that motivates residual and cross-attention fusion in UMPE is not present.

@riita10069 @m-zain-khawaja, Do you think this is actually an issue we should be concerned about?

**Vectorized HD-map encoder deferred.** The registry and `build_map_encoder` interface are already structured to accept a `"vectorized"` key when that encoder is implemented (Lanelet2/OpenDrive, issue #47).

---

### Tests

**`tests/test_map_encoder.py`** - new tests covering:
- `RasterizedMapEncoder`: output shape, non-square outputs, gradient flow, random init verification
- `ResidualMapFusion`: zero-alpha guarantee, per-channel alpha shape, gradient flow
- `MapCrossAttentionFusion`: output shape, map influence on output, gradient flow
- Both registries: unknown key raises `ValueError`, correct types returned
- `TestAutoE2EMapIntegration`: zero-alpha training stability (residual fusion only), map influence with non-zero alpha (residual fusion only), gradient flow through map branch, cross-attn forward pass