### PR TITLE
build: drive setup from neutral requirements.txt and add test suite targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
-    env:
-      # `make setup` is platform-neutral; this steers pip to CPU torch wheels.
-      PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
     steps:
       - uses: actions/checkout@v4
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 .DEFAULT_GOAL := help
 
 PYTEST = python -m pytest
+# pytorch wheel channel: cpu (default, CI parity) or a CUDA build such as cu118/cu121
+TORCH_CHANNEL ?= cpu
+# suite for test-local: all | map | integration
+SUITE ?= all
 
 # --- Setup -------------------------------------------------------------------
 
-setup: ## install core dependencies
-	pip install torch timm pytest ruff
+setup: ## pinned deps from requirements.txt (make setup TORCH_CHANNEL=cu118 for CUDA)
+	pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/$(TORCH_CHANNEL)
 
 setup-map: ## extra deps for the map_rendering tests (not installed in CI)
 	pip install matplotlib osmnx
@@ -14,17 +18,30 @@ setup-local: setup setup-map ## full dev setup
 
 # --- Checks ------------------------------------------------------------------
 
-lint: ## ruff over the whole repo (same as CI)
+# run setup first if deps are missing (presence check only, versions not verified)
+deps:
+	@{ python -c "import torch, timm, pytest" && command -v ruff; } >/dev/null 2>&1 || $(MAKE) setup
+
+deps-map:
+	@python -c "import matplotlib, osmnx" >/dev/null 2>&1 || $(MAKE) setup-map
+
+lint: deps ## ruff over the whole repo (same as CI)
 	ruff check
 
-test: ## unit tests (same selection as CI)
+test: deps ## unit tests (same selection as CI)
 	$(PYTEST) Model/tests -v
 
-# run from Model/ so `data_parsing.*` imports resolve (the package has no __init__.py)
-test-map: ## map_rendering tests (deps via setup-map)
+# map suite runs from Model/ so `data_parsing.*` imports resolve (no __init__.py).
+# The integration suite is slow and downloads pretrained backbone weights on first run.
+test-local-map: deps deps-map
 	cd Model && $(PYTEST) data_parsing/map_rendering -v
 
-test-local: test test-map ## everything runnable on a dev machine
+test-local-integration: deps
+	$(PYTEST) Model/tests -m integration -v
+
+test-local-all: test test-local-map test-local-integration
+
+test-local: test-local-$(SUITE) ## local tests (make test-local SUITE=all|map|integration)
 
 ci: lint test ## exactly what CI runs
 
@@ -34,6 +51,16 @@ benchmark: ## speed benchmark
 	cd Model/speed_benchmark && python speed_benchmark.py
 
 help: ## list available targets
-	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+	@echo "Getting started (activate your virtualenv first — targets use the active python/pip):"
+	@echo "  make setup-local                  install everything for local dev (CPU torch wheels)"
+	@echo "  make setup TORCH_CHANNEL=cu121    pinned deps with CUDA 12.1 torch wheels instead"
+	@echo "  make test-local                   run all local tests (unit + map + integration)"
+	@echo "  make test-local SUITE=map         run a single suite (all | map | integration)"
+	@echo "  make ci                           run exactly what CI runs (lint + unit tests)"
+	@echo ""
+	@echo "Targets:"
+	@grep -hE '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Defaults: TORCH_CHANNEL=$(TORCH_CHANNEL) (cpu | cu118 | cu121 | ...), SUITE=$(SUITE) (all | map | integration), PYTEST='$(PYTEST)'"
 
-.PHONY: setup setup-map setup-local lint test test-map test-local ci benchmark help
+.PHONY: setup setup-map setup-local deps deps-map lint test test-local test-local-all test-local-map test-local-integration ci benchmark help

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ AutoE2E outputs can be fused with Physics-based sensors such as LIDAR/RADAR to p
 To learn more about how to participate in this project, please read the [onboarding guide](/ONBOARDING.md)
 
 ## Getting started
-- Install the dependencies from the **requirements.txt** file
+- Install the dependencies with `make setup` (CPU torch wheels) or `make setup TORCH_CHANNEL=cu118` for a CUDA build; plain `pip install -r requirements.txt` also works and uses the default PyPI torch wheels
 - Visit the [Model](./Model/) folder to view the model components, run training and perform inference
 - See the [Trial Guide](./TRIAL.md) for step-by-step instructions on running the inference test on AWS EC2
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ AutoE2E outputs can be fused with Physics-based sensors such as LIDAR/RADAR to p
 To learn more about how to participate in this project, please read the [onboarding guide](/ONBOARDING.md)
 
 ## Getting started
-- Install the dependencies with `make setup` (CPU torch wheels) or `make setup TORCH_CHANNEL=cu118` for a CUDA build; plain `pip install -r requirements.txt` also works and uses the default PyPI torch wheels
+- Install the dependencies:
+
+  ```bash
+  make setup                      # CPU torch wheels
+  make setup TORCH_CHANNEL=cu118  # CUDA 11.8 build (cu121, ... work too)
+  ```
+
+  Plain `pip install -r requirements.txt` also works and uses the default PyPI torch wheels.
 - Visit the [Model](./Model/) folder to view the model components, run training and perform inference
 - See the [Trial Guide](./TRIAL.md) for step-by-step instructions on running the inference test on AWS EC2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
---extra-index-url https://download.pytorch.org/whl/cu118
 numpy==2.4.6
 pytest==9.0.3
+ruff==0.15.16
 timm==1.0.27
-torch==2.4.1+cu118
+torch==2.4.1


### PR DESCRIPTION
## Summary

`requirements.txt` pinned `torch==2.4.1+cu118`, so the file was installable only on CUDA 11.8 — which is why `make setup` and CI installed unpinned deps instead (CI currently floats to torch 2.12). This PR makes the pin file platform-neutral and selects the hardware flavor at install time, so one file serves CPU users, CI, and every CUDA generation. It also rounds out the Makefile test interface from #54.

## What changed

- **requirements.txt** — dropped the cu118 index and `+cu118` tag (`torch==2.4.1`), added `ruff==0.15.16`. Plain `pip install -r requirements.txt` still works (default PyPI wheels).
- **Makefile**
  - `make setup` installs the pins with `TORCH_CHANNEL ?= cpu` steering the torch wheel index (`make setup TORCH_CHANNEL=cu118` for CUDA).
  - `make test-local SUITE=all|map|integration` (default `all`) — unit + map_rendering + full-backbone integration suites, individually selectable.
  - `deps`/`deps-map` guards: test/lint targets run setup first only if packages are missing (presence check, not versions).
  - `make help` gained getting-started examples and prints the effective defaults.
- **ci.yml** — removed the now-redundant `PIP_EXTRA_INDEX_URL` env. CI becomes pinned (torch 2.4.1+cpu) as a side effect.
- **README.md** — Getting started documents the `make setup` variants.

## Behavior change 

`pip install -r requirements.txt` no longer defaults to cu118 wheels — CUDA 11.8 users now run `make setup TORCH_CHANNEL=cu118`. In exchange, one pin file works everywhere and CI tests pinned versions.



