### PR TITLE
Proposal: add issue forms with auto-labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug report
+description: Report something that is broken or behaves incorrectly
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please fill in the sections below so it can be reproduced.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I run ..., I get ... but expected ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal commands or code to trigger the bug.
+      placeholder: |
+        1. make setup
+        2. cd Model && pytest tests/...
+        3. ...
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Traceback / logs
+      description: Paste the full error output. Automatically formatted as code.
+      render: shell
+    validations:
+      required: false
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device
+      options:
+        - CPU
+        - GPU (CUDA)
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Python, torch/timm versions (e.g. `python -c "import torch; print(torch.__version__)"`).
+      placeholder: Ubuntu 22.04, Python 3.12, torch 2.4.1+cpu, timm 1.0.27
+    validations:
+      required: true
+
+  - type: input
+    id: model-config
+    attributes:
+      label: Model config (if relevant)
+      description: Backbone, fusion mode, planner mode, etc.
+      placeholder: backbone=swin_v2_tiny, fusion_mode=bev, planner_mode=gru
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,14 +21,18 @@ body:
     id: repro
     attributes:
       label: Steps to reproduce
-      description: Minimal commands or code to trigger the bug.
+      description: >-
+        Minimal commands or code to trigger the bug. If it isn't reliably
+        reproducible (intermittent, environment-specific, seen once during a
+        run), leave this blank and describe when/how it appeared under
+        "What happened?" instead.
       placeholder: |
         1. make setup
         2. cd Model && pytest tests/...
         3. ...
       render: shell
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: logs
@@ -50,6 +54,19 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: test-status
+    attributes:
+      label: Local test status
+      description: Does the test suite (`cd Model && pytest`) reproduce the problem locally?
+      options:
+        - Tests are failing locally
+        - Tests pass locally
+        - Haven't run the tests
+        - Not applicable
+    validations:
+      required: true
+
   - type: input
     id: env
     attributes:
@@ -57,7 +74,7 @@ body:
       description: OS, Python, torch/timm versions (e.g. `python -c "import torch; print(torch.__version__)"`).
       placeholder: Ubuntu 22.04, Python 3.12, torch 2.4.1+cpu, timm 1.0.27
     validations:
-      required: true
+      required: false
 
   - type: input
     id: model-config

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,3 @@
-# Keep blank issues enabled so reports that fit neither form (e.g. feature
-# ideas) can still be opened without forcing the bug/question label.
+# Keep blank issues enabled so reports that fit none of the forms can still
+# be opened without forcing a label.
 blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Keep blank issues enabled so reports that fit neither form (e.g. feature
+# ideas) can still be opened without forcing the bug/question label.
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest a new capability or an improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Please describe the problem first, then the proposal.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that is hard or impossible today?
+      placeholder: I'm trying to ... but currently ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen? API, behavior, or config sketch is welcome.
+      placeholder: Add a ... that ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've thought about.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,44 @@
+name: Question / support
+description: Ask a question about using the model, setup, or training
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For usage and setup questions. If something is broken, please use the Bug report form instead.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What are you trying to do, and what's unclear?
+      placeholder: How do I ... ? I expected ... but ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: What you've tried
+      description: Commands, config, or docs you've already looked at.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: env
+    attributes:
+      label: Environment (if relevant)
+      description: OS, Python, torch/timm versions, CPU/GPU.
+      placeholder: Ubuntu 22.04, Python 3.12, torch 2.4.1+cpu, CPU
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and discussions and did not find an answer.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -25,20 +25,3 @@ body:
       render: shell
     validations:
       required: false
-
-  - type: input
-    id: env
-    attributes:
-      label: Environment (if relevant)
-      description: OS, Python, torch/timm versions, CPU/GPU.
-      placeholder: Ubuntu 22.04, Python 3.12, torch 2.4.1+cpu, CPU
-    validations:
-      required: false
-
-  - type: checkboxes
-    id: checks
-    attributes:
-      label: Confirmation
-      options:
-        - label: I searched existing issues and discussions and did not find an answer.
-          required: true


### PR DESCRIPTION
Adds GitHub issue forms under `.github/ISSUE_TEMPLATE/` so new issues are categorized and labeled automatically on submission. No action or token required.

### Forms
- **Bug report** → labels `bug` — symptom (required), optional repro, traceback, device, local test status, env, model config
- **Feature request** → labels `enhancement` — problem + proposed solution
- **Question / support** → labels `question`

Blank issues stay enabled (`config.yml`) for anything that fits none of the forms.