### PR TITLE
chore(docs): fix readme location and delete redundant le_robot_l2d folder

### DIFF
--- a/Model/data_parsing/README.md
+++ b/Model/data_parsing/README.md
@@ -4,8 +4,8 @@ Dataset loaders and utilities for AutoE2E training data.
 
 ## Modules
 
-- **`l2d/`** — [L2D dataset]((https://huggingface.co/datasets/yaak-ai/L2D)) loader with camera and egomotion utilities
-- **`nvidia_physical_ai/`** — [NVIDIA Autonomous Vehicle dataset]((https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles)) loader
+- **`l2d/`** — [L2D dataset](https://huggingface.co/datasets/yaak-ai/L2D) loader with camera and egomotion utilities
+- **`nvidia_physical_ai/`** — [NVIDIA Autonomous Vehicle dataset](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles) loader
 - **`map_rendering/`** — Map tile rendering and GPS-to-map conversions
 - **`kit_scenes/`** — [KITScenes](https://kitscenes.com/multimodal/) data utilities
 

--- a/Model/data_parsing/README.md
+++ b/Model/data_parsing/README.md
@@ -1,22 +1,12 @@
-# Nvidia Physical AI Data
+# Data Parsing
 
-## Data format description
+Dataset loaders and utilities for AutoE2E training data.
 
-```
-data/
-    camera/
-        camera_front_wide_120fov/
-            <clip_uuid>.camera_front_wide_120fov.mp4
-            <clip_uuid>.camera_front_wide_120fov.timestamps.parquet
-        camera_front_tele_30fov/    ...
-        camera_cross_left_120fov/   ...
-        camera_cross_right_120fov/  ...
-        camera_rear_left_70fov/     ...
-        camera_rear_right_70fov/    ...
-        camera_rear_tele_30fov/     ...
-    labels/
-        egomotion/
-            <clip_uuid>.egomotion.parquet
-```
+## Modules
 
-Each clip is 20s. The egomotion parquet contains 100Hz motion data; camera videos run at 30fps. Both use a shared per-clip timestamp reference (t=0 = clip anchor), which is used to align camera frames to egomotion moments.
+- **`l2d/`** — [L2D dataset]((https://huggingface.co/datasets/yaak-ai/L2D)) loader with camera and egomotion utilities
+- **`nvidia_physical_ai/`** — [NVIDIA Autonomous Vehicle dataset]((https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles)) loader
+- **`map_rendering/`** — Map tile rendering and GPS-to-map conversions
+- **`kit_scenes/`** — [KITScenes](https://kitscenes.com/multimodal/) data utilities
+
+Each module provides dataset classes (`*Dataset`) and helper functions for loading camera frames, extracting egomotion, and handling map data.

--- a/Model/data_parsing/le_robot_l2d/README.md
+++ b/Model/data_parsing/le_robot_l2d/README.md
@@ -1,1 +1,0 @@
-# Data parsing recipe for [LeRobot L2D Dataset](https://huggingface.co/blog/lerobot-goes-to-driving-school)

--- a/Model/data_parsing/le_robot_l2d/data/README.md
+++ b/Model/data_parsing/le_robot_l2d/data/README.md
@@ -1,3 +1,0 @@
-# LeRobot L2D Data
-
-## Data format description

--- a/Model/data_parsing/nvidia_physical_ai/data/README.md
+++ b/Model/data_parsing/nvidia_physical_ai/data/README.md
@@ -1,3 +1,22 @@
 # Nvidia Physical AI Data
 
 ## Data format description
+
+```
+data/
+    camera/
+        camera_front_wide_120fov/
+            <clip_uuid>.camera_front_wide_120fov.mp4
+            <clip_uuid>.camera_front_wide_120fov.timestamps.parquet
+        camera_front_tele_30fov/    ...
+        camera_cross_left_120fov/   ...
+        camera_cross_right_120fov/  ...
+        camera_rear_left_70fov/     ...
+        camera_rear_right_70fov/    ...
+        camera_rear_tele_30fov/     ...
+    labels/
+        egomotion/
+            <clip_uuid>.egomotion.parquet
+```
+
+Each clip is 20s. The egomotion parquet contains 100Hz motion data; camera videos run at 30fps. Both use a shared per-clip timestamp reference (t=0 = clip anchor), which is used to align camera frames to egomotion moments.


### PR DESCRIPTION
## Changes
1. The `README` for the NVIDIA PhysicalAI dataset structure was in the `data_parser` folder. Moved it to `nvidia_physical_ai/data/`. Added a fresh README for the `data_parser` folder.
2. Since the parser for the L2D dataset has been implemented in the `l2d` folder, the `le_robot_l2d` folder becomes redundant. Deleted the READMEs in `le_robot_l2d`, which becomes an empty folder now.

