### PR TITLE
docs(installation-intruction): added package installation instruction for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ To learn more about how to participate in this project, please read the [onboard
 
 Requires **Python 3.12** (the pinned PyTorch build has no wheels for 3.13+).
 
+### Linux ###
+<details open>
+  <summary>Toggle view</summary>
+
 1. **Clone and install dependencies**
 
    ```bash
@@ -53,6 +57,24 @@ Requires **Python 3.12** (the pinned PyTorch build has no wheels for 3.13+).
    ```bash
    make test
    ```
+</details>
+
+### Windows ###
+<details open>
+  <summary>Toggle view</summary>
+
+**Clone and install dependencies**
+
+```bash
+git clone https://github.com/autowarefoundation/auto_e2e.git
+cd auto_e2e
+pip install -r requirements.txt                      # CPU torch wheels
+pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu118  # or a CUDA build (cu121, ... work too)
+```
+
+On Windows, you unfortunately cannot verify the install using a `test` from the Makefile without extra tools. If you wish to do so, it is highly recommended to install a package manager for Windows (for example [Chocolatey](https://chocolatey.org/)). This would allow you to use the instruction for Linux above.
+
+</details>
 
 ### Next steps
 - Explore the [Model](./Model/) folder for the model components, training and inference.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To learn more about how to participate in this project, please read the [onboard
 
 Requires **Python 3.12** (the pinned PyTorch build has no wheels for 3.13+).
 
-### Linux ###
+### Using `make` tool ###
 <details open>
   <summary>Toggle view</summary>
 
@@ -50,8 +50,6 @@ Requires **Python 3.12** (the pinned PyTorch build has no wheels for 3.13+).
    make setup TORCH_CHANNEL=cu118  # or a CUDA build (cu121, ... work too)
    ```
 
-   Plain `pip install -r requirements.txt` also works and uses the default PyPI torch wheels.
-
 2. **Verify the install** (optional)
 
    ```bash
@@ -59,7 +57,7 @@ Requires **Python 3.12** (the pinned PyTorch build has no wheels for 3.13+).
    ```
 </details>
 
-### Windows ###
+### Using plain pip ###
 <details open>
   <summary>Toggle view</summary>
 
@@ -72,7 +70,9 @@ pip install -r requirements.txt                      # CPU torch wheels
 pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu118  # or a CUDA build (cu121, ... work too)
 ```
 
-On Windows, you unfortunately cannot verify the install using a `test` from the Makefile without extra tools. If you wish to do so, it is highly recommended to install a package manager for Windows (for example [Chocolatey](https://chocolatey.org/)). This would allow you to use the instruction for Linux above.
+Without a `make` tool, you unfortunately cannot verify the install 
+using a `test` from the Makefile. It is highly recommended to install 
+the tool through a [package manager](https://chocolatey.org/).
 
 </details>
 


### PR DESCRIPTION
# Problem #

Originally, the instruction steps provided in the README file 
```bash
git clone https://github.com/autowarefoundation/auto_e2e.git
cd auto_e2e
make setup                      # CPU torch wheels
make setup TORCH_CHANNEL=cu118  # or a CUDA build (cu121, ... work too)
```
were not reproducible natively on Windows. 

Moreover, the pip installation covered only the default PyPI torch wheels.

# Fix #

I added a separate instruction for Windows
```bash
git clone https://github.com/autowarefoundation/auto_e2e.git
cd auto_e2e
pip install -r requirements.txt                      # CPU torch wheels
pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu118  # or a CUDA build (cu121, ... work too)
```

# What is needed # 

I believe that on macOS, it works like on Linux by default. This seems to be confirmed by https://stackoverflow.com/questions/1469994/using-make-on-os-x. But I would want to get a confirmation for this specific setup from somebody who uses macOS.

@m-zain-khawaja 