### PR TITLE
fix(data_parsing): pass empty subtype to _get_rgb to satisfy tests

### DIFF
--- a/Model/data_parsing/kit_scenes/map.py
+++ b/Model/data_parsing/kit_scenes/map.py
@@ -222,7 +222,7 @@ def generate_bev_map_tile(
             b_sub = _attr(bound, "subtype")
             color = _get_rgb(b_type, b_sub)
             if color == _FALLBACK_RGB:
-                color = _get_rgb("pedestrian_marking", None)
+                color = _get_rgb("pedestrian_marking", "")
             _cv_line(canvas, pts, ego, yaw, scale, rs, color, lw)
 
     # Pass 4: stop lines


### PR DESCRIPTION
Fixes the failing `mypy` CI step on `kit_scenes/map.py:225`, where `_get_rgb` (signature `subtype: str`) was called with `None`.

Pass `""` instead, matching every other call site. Behaviour-preserving. 
Both `""` and `None` resolve to the same yellow via the `(line_type, None)` wildcard lookup.

