### PR TITLE
feat(world-model): FutureState feature-reconstruction (JEPA) loss + optional action conditioning Feat/future state jepa

### DIFF
--- a/Model/model_components/future_state.py
+++ b/Model/model_components/future_state.py
@@ -10,15 +10,30 @@ class FutureState(nn.Module):
     or Flow Matching). ``ego_hidden`` summarises the planner's intent over
     the prediction horizon, so the future feature predictions reflect the
     trajectory the model expects to drive.
+
+    Optional action conditioning (``action_dim``): when set, the flattened
+    trajectory ``[B, num_timesteps * num_signals]`` is projected and added as
+    an extra per-channel bias (on top of ``ego_hidden``). This makes the
+    world model explicitly action-conditioned, enabling counterfactual
+    rollouts ("what would the scene look like if I drove trajectory A vs B?").
+    With ``action_dim=None`` (default) the behaviour is identical to the
+    unconditioned module.
     """
 
-    def __init__(self, embed_dim=256, ego_hidden_dim=256):
+    def __init__(self, embed_dim=256, ego_hidden_dim=256, action_dim=None):
         super(FutureState, self).__init__()
 
         self.embed_dim = embed_dim
+        self.action_dim = action_dim
 
         # Project ego_hidden to per-channel bias broadcast over BEV spatial dims
         self.ego_proj = nn.Linear(ego_hidden_dim, embed_dim)
+
+        # Optional projection of the planned trajectory (action) to a second
+        # per-channel bias for counterfactual, action-conditioned rollouts.
+        self.action_proj = (
+            nn.Linear(action_dim, embed_dim) if action_dim is not None else None
+        )
 
         # Predict future visual features (4 timesteps × C channels = 4C)
         self.predict_future_1 = nn.Conv2d(embed_dim, 2*embed_dim, 3, 1, 1)
@@ -32,12 +47,26 @@ class FutureState(nn.Module):
         # Activation
         self.activation = nn.GELU()
 
-    def forward(self, fused_features, ego_hidden):
+    def forward(self, fused_features, ego_hidden, trajectory=None):
         # fused_features: [B, C, H, W]; ego_hidden: [B, ego_hidden_dim]
+        # trajectory (optional): [B, action_dim] flattened planned trajectory,
+        # only used when the module was built with ``action_dim`` set.
 
         # Inject planner intent as a per-channel bias broadcast over the BEV grid
         bias = self.ego_proj(ego_hidden).view(-1, self.embed_dim, 1, 1)
         conditioned = fused_features + bias
+
+        if trajectory is not None:
+            if self.action_proj is None:
+                raise ValueError(
+                    "FutureState received a trajectory but was built with "
+                    "action_dim=None; pass action_dim at construction to "
+                    "enable action conditioning."
+                )
+            action_bias = self.action_proj(trajectory).view(
+                -1, self.embed_dim, 1, 1
+            )
+            conditioned = conditioned + action_bias
 
         # Predicting 4 future visual feature vectors over a
         # 6.4s horizon equivalent to 1.6s intervals

--- a/Model/model_components/losses/__init__.py
+++ b/Model/model_components/losses/__init__.py
@@ -1,3 +1,4 @@
 from .trajectory_loss import TrajectoryImitationLoss
+from .feature_reconstruction_loss import FeatureReconstructionLoss
 
-__all__ = ["TrajectoryImitationLoss"]
+__all__ = ["TrajectoryImitationLoss", "FeatureReconstructionLoss"]

--- a/Model/model_components/losses/feature_reconstruction_loss.py
+++ b/Model/model_components/losses/feature_reconstruction_loss.py
@@ -18,6 +18,10 @@ class FeatureReconstructionLoss(nn.Module):
     ``"none"`` reduction that returns the per-timestep losses for logging.
     """
 
+    # Declares the registered buffer's type so mypy resolves it to Tensor
+    # (not Tensor | Module) when it is used in arithmetic below.
+    temporal_weights: torch.Tensor
+
     def __init__(self, num_future_steps: int = 4, temporal_weights=None,
                  reduction: str = "mean"):
         super().__init__()
@@ -69,16 +73,16 @@ class FeatureReconstructionLoss(nn.Module):
                 f"got {len(target_features)}"
             )
 
-        per_step = []
+        per_step_losses: list[torch.Tensor] = []
         for pred, target in zip(predicted_features, target_features):
             if pred.shape != target.shape:
                 raise ValueError(
                     f"Shape mismatch: predicted {tuple(pred.shape)} vs "
                     f"target {tuple(target.shape)}"
                 )
-            per_step.append(torch.mean((pred - target) ** 2))
+            per_step_losses.append(torch.mean((pred - target) ** 2))
 
-        per_step = torch.stack(per_step)  # [num_future_steps]
+        per_step = torch.stack(per_step_losses)  # [num_future_steps]
         weighted = per_step * self.temporal_weights
 
         if self.reduction == "none":

--- a/Model/model_components/losses/feature_reconstruction_loss.py
+++ b/Model/model_components/losses/feature_reconstruction_loss.py
@@ -36,7 +36,12 @@ class FeatureReconstructionLoss(nn.Module):
                     f"got {weights.numel()}"
                 )
         # Normalise so the weighted mean stays on the same scale as plain MSE.
-        weights = weights / weights.sum() * num_future_steps
+        # Guard against a zero (or numerically negligible) sum: dividing by it
+        # would turn the loss into NaN. In that degenerate case we skip the
+        # normalisation and keep the weights as provided.
+        total = weights.sum()
+        if torch.abs(total) > 1e-8:
+            weights = weights / total * num_future_steps
         self.register_buffer("temporal_weights", weights)
 
     def forward(self, predicted_features, target_features) -> torch.Tensor:

--- a/Model/model_components/losses/feature_reconstruction_loss.py
+++ b/Model/model_components/losses/feature_reconstruction_loss.py
@@ -1,0 +1,81 @@
+import torch
+import torch.nn as nn
+
+
+class FeatureReconstructionLoss(nn.Module):
+    """JEPA-style feature reconstruction loss for the FutureState world model.
+
+    Compares the future BEV feature maps predicted by ``FutureState`` (a
+    tuple/list of ``num_future_steps`` tensors, each ``[B, C, H, W]``) against
+    target feature maps of identical shapes. Following the JEPA recipe, the
+    loss lives in *feature space* rather than pixel space: in production the
+    targets are extracted by a frozen copy of the image backbone (no gradient)
+    applied to the future frames at +1.6s, +3.2s, +4.8s and +6.4s, so the
+    world model learns to predict abstract scene dynamics instead of
+    reconstructing pixels.
+
+    Supports mean reduction (optionally weighted per future timestep) and a
+    ``"none"`` reduction that returns the per-timestep losses for logging.
+    """
+
+    def __init__(self, num_future_steps: int = 4, temporal_weights=None,
+                 reduction: str = "mean"):
+        super().__init__()
+        if reduction not in ("mean", "none"):
+            raise ValueError(f"Unsupported reduction: {reduction}")
+        self.num_future_steps = num_future_steps
+        self.reduction = reduction
+
+        if temporal_weights is None:
+            weights = torch.ones(num_future_steps)
+        else:
+            weights = torch.as_tensor(temporal_weights, dtype=torch.float32)
+            if weights.numel() != num_future_steps:
+                raise ValueError(
+                    f"temporal_weights must have {num_future_steps} elements, "
+                    f"got {weights.numel()}"
+                )
+        # Normalise so the weighted mean stays on the same scale as plain MSE.
+        weights = weights / weights.sum() * num_future_steps
+        self.register_buffer("temporal_weights", weights)
+
+    def forward(self, predicted_features, target_features) -> torch.Tensor:
+        """Compute the loss.
+
+        Args:
+            predicted_features: tuple/list of ``num_future_steps`` tensors
+                ``[B, C, H, W]`` as returned by ``FutureState.forward``.
+            target_features: tuple/list of tensors with the same shapes,
+                produced by a frozen backbone on the future frames (targets
+                should be detached / require no grad).
+
+        Returns:
+            Scalar loss (``reduction="mean"``) or per-timestep losses of
+            shape ``[num_future_steps]`` (``reduction="none"``).
+        """
+        if len(predicted_features) != self.num_future_steps:
+            raise ValueError(
+                f"Expected {self.num_future_steps} predicted feature maps, "
+                f"got {len(predicted_features)}"
+            )
+        if len(target_features) != self.num_future_steps:
+            raise ValueError(
+                f"Expected {self.num_future_steps} target feature maps, "
+                f"got {len(target_features)}"
+            )
+
+        per_step = []
+        for pred, target in zip(predicted_features, target_features):
+            if pred.shape != target.shape:
+                raise ValueError(
+                    f"Shape mismatch: predicted {tuple(pred.shape)} vs "
+                    f"target {tuple(target.shape)}"
+                )
+            per_step.append(torch.mean((pred - target) ** 2))
+
+        per_step = torch.stack(per_step)  # [num_future_steps]
+        weighted = per_step * self.temporal_weights
+
+        if self.reduction == "none":
+            return weighted
+        return weighted.mean()

--- a/Model/tests/test_feature_reconstruction_loss.py
+++ b/Model/tests/test_feature_reconstruction_loss.py
@@ -95,6 +95,21 @@ class TestFeatureReconstructionLoss:
         with pytest.raises(ValueError):
             loss_fn(pred, target)
 
+    def test_zero_sum_temporal_weights_do_not_produce_nan(self):
+        """A zero-sum weight vector must not poison the loss with NaN
+        (normalisation would otherwise divide by zero)."""
+        loss_fn = FeatureReconstructionLoss(
+            temporal_weights=[0.0, 0.0, 0.0, 0.0]
+        )
+        assert torch.isfinite(loss_fn.temporal_weights).all()
+        pred = _make_features(requires_grad=True, seed=0)
+        target = _make_features(seed=1)
+        loss = loss_fn(pred, target)
+        assert torch.isfinite(loss).all()
+        loss.backward()
+        for t in pred:
+            assert torch.isfinite(t.grad).all()
+
     def test_wrong_temporal_weights_length_raises(self):
         with pytest.raises(ValueError):
             FeatureReconstructionLoss(temporal_weights=[1.0, 2.0])

--- a/Model/tests/test_feature_reconstruction_loss.py
+++ b/Model/tests/test_feature_reconstruction_loss.py
@@ -1,0 +1,177 @@
+"""Unit tests for the JEPA feature-reconstruction loss and the optional
+action conditioning of FutureState (Issue #13).
+
+The loss compares FutureState's predicted future BEV features against
+targets that, in production, come from a frozen backbone applied to the
+future frames (+1.6/3.2/4.8/6.4s). Here we use random tensors of the
+correct shapes — the contract under test is shapes/reduction/gradients,
+not the data pipeline.
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from model_components.future_state import FutureState
+from model_components.losses import FeatureReconstructionLoss
+
+EMBED_DIM = 32  # small for fast tests; production uses 256
+B, H, W = 2, 8, 8
+
+
+def _make_features(requires_grad=False, seed=None):
+    if seed is not None:
+        torch.manual_seed(seed)
+    return tuple(
+        torch.randn(B, EMBED_DIM, H, W, requires_grad=requires_grad)
+        for _ in range(4)
+    )
+
+
+class TestFeatureReconstructionLoss:
+    def test_zero_when_pred_equals_target(self):
+        loss_fn = FeatureReconstructionLoss()
+        target = _make_features()
+        pred = tuple(t.clone() for t in target)
+        loss = loss_fn(pred, target)
+        assert loss.dim() == 0
+        assert loss.item() == pytest.approx(0.0, abs=1e-8)
+
+    def test_positive_when_pred_differs(self):
+        loss_fn = FeatureReconstructionLoss()
+        pred = _make_features(seed=0)
+        target = _make_features(seed=1)
+        loss = loss_fn(pred, target)
+        assert loss.item() > 0.0
+
+    def test_gradient_flows_to_predictions(self):
+        loss_fn = FeatureReconstructionLoss()
+        pred = _make_features(requires_grad=True)
+        target = _make_features()
+        loss = loss_fn(pred, target)
+        loss.backward()
+        for t in pred:
+            assert t.grad is not None
+            assert torch.isfinite(t.grad).all()
+
+    def test_temporal_weighting_changes_loss(self):
+        pred = _make_features(seed=0)
+        target = _make_features(seed=1)
+        uniform = FeatureReconstructionLoss()(pred, target)
+        weighted = FeatureReconstructionLoss(
+            temporal_weights=[8.0, 1.0, 1.0, 1.0]
+        )(pred, target)
+        assert not torch.isclose(uniform, weighted)
+
+    def test_reduction_none_returns_per_step(self):
+        loss_fn = FeatureReconstructionLoss(reduction="none")
+        pred = _make_features(seed=0)
+        target = _make_features(seed=1)
+        per_step = loss_fn(pred, target)
+        assert per_step.shape == (4,)
+        assert (per_step > 0).all()
+
+    def test_invalid_reduction_raises(self):
+        with pytest.raises(ValueError):
+            FeatureReconstructionLoss(reduction="sum")
+
+    def test_wrong_number_of_steps_raises(self):
+        loss_fn = FeatureReconstructionLoss()
+        feats = _make_features()
+        with pytest.raises(ValueError):
+            loss_fn(feats[:3], feats)
+        with pytest.raises(ValueError):
+            loss_fn(feats, feats[:3])
+
+    def test_shape_mismatch_raises(self):
+        loss_fn = FeatureReconstructionLoss()
+        pred = _make_features()
+        target = list(_make_features())
+        target[2] = torch.randn(B, EMBED_DIM, H + 1, W)
+        with pytest.raises(ValueError):
+            loss_fn(pred, target)
+
+    def test_wrong_temporal_weights_length_raises(self):
+        with pytest.raises(ValueError):
+            FeatureReconstructionLoss(temporal_weights=[1.0, 2.0])
+
+    def test_end_to_end_with_future_state(self):
+        """Loss must propagate gradients through FutureState parameters."""
+        model = FutureState(embed_dim=EMBED_DIM, ego_hidden_dim=EMBED_DIM)
+        fused = torch.randn(B, EMBED_DIM, H, W)
+        ego_hidden = torch.randn(B, EMBED_DIM)
+        pred = model(fused, ego_hidden)
+        target = tuple(t.detach() + 0.1 for t in pred)
+        loss = FeatureReconstructionLoss()(pred, target)
+        loss.backward()
+        for name, p in model.named_parameters():
+            assert p.grad is not None, f"No gradient for {name}"
+
+
+class TestFutureStateActionConditioning:
+    ACTION_DIM = 128  # 64 timesteps x 2 signals
+
+    def test_default_behavior_unchanged_shapes(self):
+        """action_dim=None (default) keeps the original contract intact."""
+        model = FutureState(embed_dim=EMBED_DIM, ego_hidden_dim=EMBED_DIM)
+        assert model.action_proj is None
+        fused = torch.randn(B, EMBED_DIM, H, W)
+        ego_hidden = torch.randn(B, EMBED_DIM)
+        out = model(fused, ego_hidden)
+        assert len(out) == 4
+        for t in out:
+            assert t.shape == (B, EMBED_DIM, H, W)
+
+    def test_trajectory_changes_output_when_action_dim_set(self):
+        torch.manual_seed(0)
+        model = FutureState(
+            embed_dim=EMBED_DIM, ego_hidden_dim=EMBED_DIM,
+            action_dim=self.ACTION_DIM,
+        )
+        fused = torch.randn(B, EMBED_DIM, H, W)
+        ego_hidden = torch.randn(B, EMBED_DIM)
+        traj_a = torch.randn(B, self.ACTION_DIM)
+        traj_b = torch.randn(B, self.ACTION_DIM)
+        out_a = model(fused, ego_hidden, trajectory=traj_a)
+        out_b = model(fused, ego_hidden, trajectory=traj_b)
+        assert not torch.allclose(out_a[0], out_b[0]), (
+            "Counterfactual trajectories must produce different rollouts"
+        )
+
+    def test_action_dim_set_but_no_trajectory_still_works(self):
+        model = FutureState(
+            embed_dim=EMBED_DIM, ego_hidden_dim=EMBED_DIM,
+            action_dim=self.ACTION_DIM,
+        )
+        fused = torch.randn(B, EMBED_DIM, H, W)
+        ego_hidden = torch.randn(B, EMBED_DIM)
+        out = model(fused, ego_hidden)
+        assert len(out) == 4
+
+    def test_trajectory_without_action_dim_raises(self):
+        model = FutureState(embed_dim=EMBED_DIM, ego_hidden_dim=EMBED_DIM)
+        fused = torch.randn(B, EMBED_DIM, H, W)
+        ego_hidden = torch.randn(B, EMBED_DIM)
+        traj = torch.randn(B, self.ACTION_DIM)
+        with pytest.raises(ValueError):
+            model(fused, ego_hidden, trajectory=traj)
+
+    def test_gradient_flows_through_trajectory(self):
+        """Gradients must reach the trajectory — required for training the
+        planner through the world-model loss."""
+        model = FutureState(
+            embed_dim=EMBED_DIM, ego_hidden_dim=EMBED_DIM,
+            action_dim=self.ACTION_DIM,
+        )
+        fused = torch.randn(B, EMBED_DIM, H, W)
+        ego_hidden = torch.randn(B, EMBED_DIM)
+        traj = torch.randn(B, self.ACTION_DIM, requires_grad=True)
+        out = model(fused, ego_hidden, trajectory=traj)
+        sum(t.pow(2).mean() for t in out).backward()
+        assert traj.grad is not None
+        assert torch.isfinite(traj.grad).all()
+        assert model.action_proj.weight.grad is not None


### PR DESCRIPTION
## What

Implements the loss side of **#13** — FutureState feature-reconstruction (JEPA) — as **Priority #1** per the maintainer feedback in #56 (@riita10069).

**Two additive changes, both optional/non-breaking:**

1. `losses/feature_reconstruction_loss.py` — `FeatureReconstructionLoss`: JEPA-style MSE between FutureState's 4 predicted future feature maps and frozen-backbone targets at +1.6/3.2/4.8/6.4 s, with optional temporal weighting and a zero-sum-weights guard.
2. `future_state.py` — optional **action conditioning** (`action_dim=None` ⇒ byte-identical to current). Enables counterfactual "what-if" rollouts by projecting the trajectory into a per-channel bias.

`AutoE2E.forward()` contract unchanged. 16 tests added, 157 total green.

## Files changed
- `Model/model_components/losses/feature_reconstruction_loss.py` (new)
- `Model/model_components/losses/__init__.py` (export)
- `Model/model_components/future_state.py` (optional path, default unchanged)
- `Model/tests/test_feature_reconstruction_loss.py` (16 tests)

Relates to #13. See tracking in #56.

