### PR TITLE
feat(reasoning): optional System 2 causal head behind a typed SceneContext

### DIFF
--- a/Model/model_components/causal_reasoning.py
+++ b/Model/model_components/causal_reasoning.py
@@ -1,0 +1,107 @@
+"""Optional System 2 causal reasoning head (Issue #17).
+
+A lightweight auxiliary head that takes a context vector (e.g. the planner's
+``ego_hidden``) and produces:
+
+  * ``reasoning_latent`` — a continuous latent that can condition the
+    planner downstream (cascade design),
+  * ``decision_logits`` — a 5-way classification over the dominant causal
+    factor of the current scene.
+
+Training signal: ``causal_consistency_loss`` (cross-entropy) against
+pseudo-labels produced by a VLM (vision-language model) prompted over the
+KITScenes LongTail dataset. The labels are therefore noisy pseudo-labels,
+not human ground truth; the head is auxiliary and OPTIONAL — it does not
+modify AutoE2E's default forward pass or its 3-tuple return contract.
+
+Cascade requirement: gradients must flow from the reasoning outputs back to
+the trunk that produced the context vector (no ``torch.no_grad`` anywhere),
+so that the auxiliary objective shapes the shared representation.
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# Dominant causal factor classes (pseudo-labelled by a VLM on KITScenes
+# LongTail). Order is part of the contract — do not reorder.
+CAUSAL_CLASSES = (
+    "intersection",
+    "pedestrian",
+    "traffic_light",
+    "obstacle",
+    "clear",
+)
+NUM_CAUSAL_CLASSES = len(CAUSAL_CLASSES)
+
+
+class CausalReasoningModule(nn.Module):
+    """System 2 head: context vector -> (reasoning_latent, decision_logits).
+
+    Args:
+        embed_dim: dimensionality of the input context vector
+            (e.g. ``ego_hidden`` is 256 in AutoE2E).
+        latent_dim: dimensionality of ``reasoning_latent``. Defaults to
+            ``embed_dim`` so the latent can be summed/concatenated into the
+            planner without extra projections.
+        num_classes: number of causal decision classes (default 5, see
+            ``CAUSAL_CLASSES``).
+    """
+
+    def __init__(self, embed_dim: int = 256, latent_dim: int = None,
+                 num_classes: int = NUM_CAUSAL_CLASSES):
+        super().__init__()
+        latent_dim = embed_dim if latent_dim is None else latent_dim
+        self.embed_dim = embed_dim
+        self.latent_dim = latent_dim
+        self.num_classes = num_classes
+
+        # Shared reasoning trunk. Plain differentiable ops only — gradients
+        # must reach the upstream context producer (cascade design).
+        self.reasoning_trunk = nn.Sequential(
+            nn.Linear(embed_dim, 2 * embed_dim),
+            nn.GELU(),
+            nn.Linear(2 * embed_dim, latent_dim),
+            nn.LayerNorm(latent_dim),
+        )
+
+        # Decision head on top of the reasoning latent.
+        self.decision_head = nn.Linear(latent_dim, num_classes)
+
+    def reason(self, context: torch.Tensor) -> torch.Tensor:
+        """Return only the reasoning latent ``[B, latent_dim]``.
+
+        This is the cascade hook: the latent can be fed to the planner
+        (e.g. added to ``ego_hidden`` or concatenated to its input) so the
+        System 2 head conditions trajectory generation. Fully
+        differentiable — no ``torch.no_grad``.
+        """
+        return self.reasoning_trunk(context)
+
+    def forward(self, context: torch.Tensor):
+        """Full pass.
+
+        Args:
+            context: ``[B, embed_dim]`` context vector (e.g. ``ego_hidden``).
+
+        Returns:
+            reasoning_latent: ``[B, latent_dim]``
+            decision_logits: ``[B, num_classes]``
+        """
+        reasoning_latent = self.reason(context)
+        decision_logits = self.decision_head(reasoning_latent)
+        return reasoning_latent, decision_logits
+
+
+def causal_consistency_loss(decision_logits: torch.Tensor,
+                            labels: torch.Tensor) -> torch.Tensor:
+    """Cross-entropy between predicted causal decisions and pseudo-labels.
+
+    ``labels`` are integer class indices ``[B]`` obtained by pseudo-labelling
+    KITScenes LongTail scenes with a VLM (the VLM is prompted to name the
+    dominant causal factor; its answer is mapped to ``CAUSAL_CLASSES``).
+    Because the labels are model-generated they are noisy — treat this as an
+    auxiliary consistency objective, weighted low relative to the imitation
+    loss.
+    """
+    return F.cross_entropy(decision_logits, labels)

--- a/Model/model_components/causal_reasoning.py
+++ b/Model/model_components/causal_reasoning.py
@@ -94,7 +94,10 @@ class CausalReasoningModule(nn.Module):
 
 
 def causal_consistency_loss(decision_logits: torch.Tensor,
-                            labels: torch.Tensor) -> torch.Tensor:
+                            labels: torch.Tensor,
+                            label_smoothing: float = 0.0,
+                            class_weights: torch.Tensor = None,
+                            ) -> torch.Tensor:
     """Cross-entropy between predicted causal decisions and pseudo-labels.
 
     ``labels`` are integer class indices ``[B]`` obtained by pseudo-labelling
@@ -103,5 +106,20 @@ def causal_consistency_loss(decision_logits: torch.Tensor,
     Because the labels are model-generated they are noisy — treat this as an
     auxiliary consistency objective, weighted low relative to the imitation
     loss.
+
+    Args:
+        decision_logits: ``[B, num_classes]`` raw logits.
+        labels: ``[B]`` integer class indices (VLM pseudo-labels).
+        label_smoothing: optional smoothing factor in ``[0, 1)`` passed to
+            ``F.cross_entropy``. Recommended > 0 here: the VLM pseudo-labels
+            over KITScenes LongTail are noisy, and smoothing softens the
+            penalty for confidently disagreeing with a wrong pseudo-label.
+        class_weights: optional ``[num_classes]`` per-class weights (e.g. to
+            upweight rare long-tail classes); passed as ``weight`` to
+            ``F.cross_entropy``.
     """
-    return F.cross_entropy(decision_logits, labels)
+    return F.cross_entropy(
+        decision_logits, labels,
+        weight=class_weights,
+        label_smoothing=label_smoothing,
+    )

--- a/Model/model_components/causal_reasoning.py
+++ b/Model/model_components/causal_reasoning.py
@@ -23,6 +23,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from .scene_context import SceneContext, CausalReasoningContext
+
 # Dominant causal factor classes (pseudo-labelled by a VLM on KITScenes
 # LongTail). Order is part of the contract — do not reorder.
 CAUSAL_CLASSES = (
@@ -91,6 +93,23 @@ class CausalReasoningModule(nn.Module):
         reasoning_latent = self.reason(context)
         decision_logits = self.decision_head(reasoning_latent)
         return reasoning_latent, decision_logits
+
+    def produce_context(self, context: torch.Tensor) -> SceneContext:
+        """Produce structured SceneContext for the planner downstream.
+        
+        This satisfies the 'optional producer' architecture requested by
+        the working group: instead of passing raw logits, it packages the
+        reasoning with explicit confidence and provenance.
+        """
+        reasoning_latent, decision_logits = self.forward(context)
+        confidence = F.softmax(decision_logits, dim=-1).max(dim=-1).values
+        causal_context = CausalReasoningContext(
+            reasoning_latent=reasoning_latent,
+            causal_class_logits=decision_logits,
+            confidence=confidence,
+            provenance="vlm_causal_head"
+        )
+        return SceneContext(causal_reasoning=causal_context)
 
 
 def causal_consistency_loss(decision_logits: torch.Tensor,

--- a/Model/model_components/causal_reasoning.py
+++ b/Model/model_components/causal_reasoning.py
@@ -50,7 +50,7 @@ class CausalReasoningModule(nn.Module):
             ``CAUSAL_CLASSES``).
     """
 
-    def __init__(self, embed_dim: int = 256, latent_dim: int = None,
+    def __init__(self, embed_dim: int = 256, latent_dim: int | None = None,
                  num_classes: int = NUM_CAUSAL_CLASSES):
         super().__init__()
         latent_dim = embed_dim if latent_dim is None else latent_dim
@@ -115,7 +115,7 @@ class CausalReasoningModule(nn.Module):
 def causal_consistency_loss(decision_logits: torch.Tensor,
                             labels: torch.Tensor,
                             label_smoothing: float = 0.0,
-                            class_weights: torch.Tensor = None,
+                            class_weights: torch.Tensor | None = None,
                             ) -> torch.Tensor:
     """Cross-entropy between predicted causal decisions and pseudo-labels.
 

--- a/Model/model_components/scene_context.py
+++ b/Model/model_components/scene_context.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Optional
+import torch
+
+
+@dataclass
+class CausalReasoningContext:
+    """Structured output for causal reasoning with confidence and provenance."""
+    reasoning_latent: torch.Tensor          # [B, latent_dim]
+    causal_class_logits: torch.Tensor       # [B, num_classes]
+    confidence: torch.Tensor                # [B] scalar probability
+    provenance: str = "vlm_causal_head"     # origin of this reasoning
+
+
+@dataclass
+class SceneContext:
+    """Typed interface for structured scene context passed to trajectory planners.
+    
+    Acts as a standardized bus for high-level scene understanding to avoid locking
+    the planner into a single fixed head. Planners can optionally consume these
+    fields (e.g. VLM outputs, HD map info, route commands).
+    """
+    causal_reasoning: Optional[CausalReasoningContext] = None

--- a/Model/model_components/trajectory_planning/base.py
+++ b/Model/model_components/trajectory_planning/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 import torch.nn as nn
 
@@ -28,13 +29,14 @@ class BasePlanner(nn.Module, ABC):
 
     @abstractmethod
     def forward(self, bev_features, visual_history, egomotion_history,
-                **kwargs):
+                scene_context: Optional["SceneContext"] = None, **kwargs):
         """Inference: return ``(trajectory, ego_hidden)``."""
         raise NotImplementedError
 
     @abstractmethod
     def compute_planner_loss(self, bev_features, visual_history,
-                             egomotion_history, trajectory_target):
+                             egomotion_history, trajectory_target,
+                             scene_context: Optional["SceneContext"] = None):
         """Return ``(loss, ego_hidden)``.
 
         Args:

--- a/Model/model_components/trajectory_planning/base.py
+++ b/Model/model_components/trajectory_planning/base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 
 import torch.nn as nn
 
@@ -29,14 +28,13 @@ class BasePlanner(nn.Module, ABC):
 
     @abstractmethod
     def forward(self, bev_features, visual_history, egomotion_history,
-                scene_context: Optional["SceneContext"] = None, **kwargs):
+                **kwargs):
         """Inference: return ``(trajectory, ego_hidden)``."""
         raise NotImplementedError
 
     @abstractmethod
     def compute_planner_loss(self, bev_features, visual_history,
-                             egomotion_history, trajectory_target,
-                             scene_context: Optional["SceneContext"] = None):
+                             egomotion_history, trajectory_target):
         """Return ``(loss, ego_hidden)``.
 
         Args:

--- a/Model/tests/test_causal_reasoning.py
+++ b/Model/tests/test_causal_reasoning.py
@@ -1,0 +1,174 @@
+"""Unit tests for the optional System 2 causal reasoning head (Issue #17).
+
+The module is auxiliary and independent: it does NOT modify AutoE2E's
+forward pass or its (trajectory, ego_hidden, future) 3-tuple contract.
+Key property under test: gradients flow end-to-end (no torch.no_grad in
+the cascade), so the head can shape the shared representation and the
+reasoning latent can condition the planner.
+"""
+
+import os
+import sys
+
+import torch
+import torch.nn as nn
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from model_components.causal_reasoning import (
+    CAUSAL_CLASSES,
+    CausalReasoningModule,
+    causal_consistency_loss,
+)
+
+
+class _MockBackbone(nn.Module):
+    """Minimal stand-in for Backbone (4 channels-first feature maps),
+    self-contained so this test file does not depend on conftest imports."""
+
+    def __init__(self, backbone="swin_v2_tiny", is_pretrained=True, **kwargs):
+        super().__init__()
+        self.backbone_channels = 1440
+        self._stages = nn.ModuleList([
+            nn.Sequential(nn.Conv2d(3, 96, 3, 1, 1), nn.AdaptiveAvgPool2d(64)),
+            nn.Sequential(nn.Conv2d(96, 192, 3, 1, 1), nn.AdaptiveAvgPool2d(32)),
+            nn.Sequential(nn.Conv2d(192, 384, 3, 1, 1), nn.AdaptiveAvgPool2d(16)),
+            nn.Sequential(nn.Conv2d(384, 768, 3, 1, 1), nn.AdaptiveAvgPool2d(8)),
+        ])
+
+    def forward(self, image):
+        outs, x = [], image
+        for stage in self._stages:
+            x = stage(x)
+            outs.append(x)
+        return outs
+
+
+EMBED_DIM = 256
+B = 4
+
+
+def test_class_vocabulary():
+    assert CAUSAL_CLASSES == (
+        "intersection", "pedestrian", "traffic_light", "obstacle", "clear",
+    )
+
+
+def test_output_shapes():
+    module = CausalReasoningModule(embed_dim=EMBED_DIM)
+    context = torch.randn(B, EMBED_DIM)
+    reasoning_latent, decision_logits = module(context)
+    assert decision_logits.shape == (B, 5)
+    assert reasoning_latent.shape == (B, EMBED_DIM)
+    assert torch.isfinite(decision_logits).all()
+    assert torch.isfinite(reasoning_latent).all()
+
+
+def test_custom_latent_dim():
+    module = CausalReasoningModule(embed_dim=EMBED_DIM, latent_dim=128)
+    context = torch.randn(B, EMBED_DIM)
+    reasoning_latent, decision_logits = module(context)
+    assert reasoning_latent.shape == (B, 128)
+    assert decision_logits.shape == (B, 5)
+
+
+def test_reason_method_matches_cascade_latent():
+    """reason() is the cascade hook — it must expose the same latent the
+    decision head consumes."""
+    module = CausalReasoningModule(embed_dim=EMBED_DIM)
+    module.eval()
+    context = torch.randn(B, EMBED_DIM)
+    with torch.no_grad():
+        latent_only = module.reason(context)
+        latent_full, _ = module(context)
+    assert torch.allclose(latent_only, latent_full)
+
+
+def test_gradients_flow_to_all_parameters_and_context():
+    """No torch.no_grad anywhere: gradients must reach every parameter of
+    the module AND the upstream context vector (cascade requirement)."""
+    module = CausalReasoningModule(embed_dim=EMBED_DIM)
+    context = torch.randn(B, EMBED_DIM, requires_grad=True)
+    reasoning_latent, decision_logits = module(context)
+    labels = torch.randint(0, 5, (B,))
+    loss = causal_consistency_loss(decision_logits, labels)
+    loss = loss + reasoning_latent.pow(2).mean()
+    loss.backward()
+
+    assert context.grad is not None, "Gradient must reach upstream context"
+    assert torch.isfinite(context.grad).all()
+    for name, p in module.named_parameters():
+        assert p.grad is not None, f"No gradient for {name}"
+        assert torch.isfinite(p.grad).all(), f"Non-finite grad for {name}"
+
+
+def test_loss_lower_for_correct_labels():
+    """Cross-entropy must be lower for labels matching the argmax decisions
+    than for deliberately wrong labels."""
+    torch.manual_seed(0)
+    module = CausalReasoningModule(embed_dim=EMBED_DIM)
+    context = torch.randn(B, EMBED_DIM)
+    _, decision_logits = module(context)
+    correct = decision_logits.argmax(dim=1)
+    wrong = (correct + 1) % 5
+    loss_correct = causal_consistency_loss(decision_logits, correct)
+    loss_wrong = causal_consistency_loss(decision_logits, wrong)
+    assert loss_correct.item() < loss_wrong.item()
+
+
+def test_loss_decreases_with_training():
+    """A few optimisation steps on fixed pseudo-labels must reduce the
+    consistency loss (head is trainable end-to-end)."""
+    torch.manual_seed(0)
+    module = CausalReasoningModule(embed_dim=EMBED_DIM)
+    context = torch.randn(16, EMBED_DIM)
+    labels = torch.randint(0, 5, (16,))
+    optimizer = torch.optim.Adam(module.parameters(), lr=1e-3)
+
+    _, logits = module(context)
+    initial = causal_consistency_loss(logits, labels).item()
+    for _ in range(30):
+        optimizer.zero_grad()
+        _, logits = module(context)
+        loss = causal_consistency_loss(logits, labels)
+        loss.backward()
+        optimizer.step()
+    final = causal_consistency_loss(module(context)[1], labels).item()
+    assert final < initial
+
+
+def test_autoe2e_contract_untouched_with_manual_integration(device):
+    """Manual cascade integration: run AutoE2E (mock backbone), feed
+    ego_hidden into the reasoning head. The AutoE2E 3-tuple contract is
+    untouched and gradients reach the trunk through the auxiliary loss."""
+    from unittest.mock import patch
+
+    from model_components.auto_e2e import AutoE2E
+
+    with patch("model_components.auto_e2e.Backbone", _MockBackbone):
+        model = AutoE2E(num_views=8, fusion_mode="concat").to(device)
+    head = CausalReasoningModule(embed_dim=EMBED_DIM).to(device)
+
+    x = torch.randn(2, 8, 3, 256, 256, device=device)
+    vis = torch.randn(2, 896, device=device)
+    ego = torch.randn(2, 256, device=device)
+    out = model(x, vis, ego)
+
+    # Default contract: exactly a 3-tuple (trajectory, ego_hidden, future)
+    assert isinstance(out, tuple) and len(out) == 3
+    trajectory, ego_hidden, future = out
+    assert trajectory.shape == (2, 128)
+    assert ego_hidden.shape == (2, 256)
+    assert future is not None
+
+    # Auxiliary head consumes ego_hidden; gradient reaches AutoE2E trunk.
+    _, decision_logits = head(ego_hidden)
+    labels = torch.randint(0, 5, (2,), device=device)
+    causal_consistency_loss(decision_logits, labels).backward()
+    trunk_grads = [
+        p.grad for p in model.TrajectoryPlanner.parameters()
+        if p.grad is not None
+    ]
+    assert len(trunk_grads) > 0, (
+        "Auxiliary loss must backpropagate into the shared trunk"
+    )

--- a/Model/tests/test_causal_reasoning.py
+++ b/Model/tests/test_causal_reasoning.py
@@ -137,6 +137,47 @@ def test_loss_decreases_with_training():
     assert final < initial
 
 
+def test_label_smoothing_changes_loss_and_keeps_gradients():
+    """With label_smoothing > 0 the loss must differ from the unsmoothed one
+    (the VLM pseudo-labels are noisy, so smoothing is the intended regime)
+    and must remain differentiable end-to-end."""
+    torch.manual_seed(0)
+    module = CausalReasoningModule(embed_dim=EMBED_DIM)
+    context = torch.randn(B, EMBED_DIM, requires_grad=True)
+    _, decision_logits = module(context)
+    labels = torch.randint(0, 5, (B,))
+
+    plain = causal_consistency_loss(decision_logits, labels)
+    smoothed = causal_consistency_loss(
+        decision_logits, labels, label_smoothing=0.1,
+    )
+    assert not torch.isclose(plain, smoothed), (
+        "label_smoothing > 0 must change the loss value"
+    )
+
+    smoothed.backward()
+    assert context.grad is not None
+    assert torch.isfinite(context.grad).all()
+    for name, p in module.named_parameters():
+        assert p.grad is not None, f"No gradient for {name}"
+        assert torch.isfinite(p.grad).all(), f"Non-finite grad for {name}"
+
+
+def test_class_weights_change_loss():
+    """Optional per-class weights (e.g. to upweight rare long-tail classes)
+    must be honoured by the loss."""
+    torch.manual_seed(0)
+    module = CausalReasoningModule(embed_dim=EMBED_DIM)
+    _, decision_logits = module(torch.randn(B, EMBED_DIM))
+    labels = torch.randint(0, 5, (B,))
+    plain = causal_consistency_loss(decision_logits, labels)
+    weighted = causal_consistency_loss(
+        decision_logits, labels,
+        class_weights=torch.tensor([4.0, 1.0, 1.0, 1.0, 0.5]),
+    )
+    assert not torch.isclose(plain, weighted)
+
+
 def test_autoe2e_contract_untouched_with_manual_integration(device):
     """Manual cascade integration: run AutoE2E (mock backbone), feed
     ego_hidden into the reasoning head. The AutoE2E 3-tuple contract is

--- a/Model/tests/test_causal_reasoning.py
+++ b/Model/tests/test_causal_reasoning.py
@@ -218,7 +218,7 @@ def test_autoe2e_contract_untouched_with_manual_integration(device):
     trajectory, ego_hidden, future = out
     assert trajectory.shape == (2, 128)
     assert ego_hidden.shape == (2, 256)
-    assert future is not None
+    assert future is None  # infer mode returns no future visual features (contract)
 
     # Auxiliary head consumes ego_hidden; gradient reaches AutoE2E trunk.
     _, decision_logits = head(ego_hidden)

--- a/Model/tests/test_causal_reasoning.py
+++ b/Model/tests/test_causal_reasoning.py
@@ -102,6 +102,22 @@ def test_gradients_flow_to_all_parameters_and_context():
         assert torch.isfinite(p.grad).all(), f"Non-finite grad for {name}"
 
 
+def test_produce_context():
+    """Test that the module produces a well-formed SceneContext with
+    confidence and provenance, as requested by the architectural review."""
+    module = CausalReasoningModule(embed_dim=EMBED_DIM)
+    context = torch.randn(B, EMBED_DIM)
+    scene_context = module.produce_context(context)
+    
+    assert scene_context.causal_reasoning is not None
+    cr = scene_context.causal_reasoning
+    assert cr.reasoning_latent.shape == (B, EMBED_DIM)
+    assert cr.causal_class_logits.shape == (B, 5)
+    assert cr.confidence.shape == (B,)
+    assert (cr.confidence >= 0).all() and (cr.confidence <= 1).all()
+    assert cr.provenance == "vlm_causal_head"
+
+
 def test_loss_lower_for_correct_labels():
     """Cross-entropy must be lower for labels matching the argmax decisions
     than for deliberately wrong labels."""
@@ -191,9 +207,11 @@ def test_autoe2e_contract_untouched_with_manual_integration(device):
     head = CausalReasoningModule(embed_dim=EMBED_DIM).to(device)
 
     x = torch.randn(2, 8, 3, 256, 256, device=device)
+    map_input = torch.randn(2, 3, 256, 256, device=device)
     vis = torch.randn(2, 896, device=device)
     ego = torch.randn(2, 256, device=device)
-    out = model(x, vis, ego)
+    # The signature is: forward(camera_tiles, map_input, visual_history, egomotion_history)
+    out = model(x, map_input, vis, ego, mode="infer")
 
     # Default contract: exactly a 3-tuple (trajectory, ego_hidden, future)
     assert isinstance(out, tuple) and len(out) == 3


### PR DESCRIPTION
Implements #17 / the typed-context reframing @RyotaYamada asked for in #56: typed SceneContext (confidence+provenance), causal head as an OPTIONAL producer, passed to planners via **kwargs — BasePlanner interface untouched. Labels via KIT longtail (pending). Relates to #56.