### PR TITLE
feat(temporal-memory): registry + 1Hz history encoder; [B,T,feat] interface (NoMemory default)

### DIFF
--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -4,6 +4,7 @@ from .feature_fusion import FeatureFusion
 from .trajectory_planning import build_planner
 from .future_state import FutureState
 from .map_encoder import build_map_encoder, build_map_bev_fusion
+from .temporal_memory import build_temporal_memory
 
 
 class AutoE2E(nn.Module):
@@ -14,6 +15,7 @@ class AutoE2E(nn.Module):
                  visual_history_dim=896,
                  map_type="rasterized", map_in_channels=3,
                  map_fusion_mode="residual", map_fusion_kwargs=None,
+                 temporal_memory_mode="no_memory", temporal_memory_kwargs=None,
                  planner_mode="gru", planner_kwargs=None):
         super(AutoE2E, self).__init__()
 
@@ -57,6 +59,14 @@ class AutoE2E(nn.Module):
             **(map_fusion_kwargs or {}),
         )
 
+        # Temporal Memory — compresses/fuses [B, T, feat] sequence histories into contexts
+        self.TemporalMemory = build_temporal_memory(
+            temporal_memory_mode,
+            visual_dim=visual_history_dim,
+            egomotion_dim=egomotion_dim,
+            **(temporal_memory_kwargs or {}),
+        )
+
         # Trajectory decoder — swappable via planner_mode (gru, flow_matching).
         self.TrajectoryPlanner = build_planner(
             planner_mode,        
@@ -92,8 +102,8 @@ class AutoE2E(nn.Module):
         Args:
             camera_tiles: (B, V, 3, H, W) — V camera images (V=7 by default).
             map_input: (B, 3, H_map, W_map) — BEV nav-map image.
-            visual_history: (B, visual_history_dim).
-            egomotion_history: (B, egomotion_dim).
+            visual_history: (B, T, visual_history_dim) or (B, visual_history_dim).
+            egomotion_history: (B, T, egomotion_dim) or (B, egomotion_dim).
             camera_params: Optional (B, V, 3, 4) ego-to-pixel projection matrices.
             mode: "train" to produce future_visual_features; anything else skips it.
 
@@ -115,13 +125,16 @@ class AutoE2E(nn.Module):
         # --- Fuse image BEV + map BEV ---
         fused_features = self.MapBEVFusion(image_bev, map_bev)
 
+        # --- Temporal Memory ---
+        visual_ctx, ego_ctx = self.TemporalMemory(visual_history, egomotion_history)
+
         if mode == "train":
             if trajectory_target is None:
                 raise ValueError(
                     "AutoE2E.forward(mode='train') requires trajectory_target."
                 )
             planner_loss, ego_hidden = self.TrajectoryPlanner.compute_planner_loss(
-                fused_features, visual_history, egomotion_history,
+                fused_features, visual_ctx, ego_ctx,
                 trajectory_target,
             )
             future_visual_features = self.FutureState(fused_features, ego_hidden)
@@ -129,6 +142,6 @@ class AutoE2E(nn.Module):
 
 
         trajectory, ego_hidden = self.TrajectoryPlanner(
-            fused_features, visual_history, egomotion_history, **kwargs,
+            fused_features, visual_ctx, ego_ctx, **kwargs,
         )
         return trajectory, ego_hidden, None

--- a/Model/model_components/history_encoder.py
+++ b/Model/model_components/history_encoder.py
@@ -1,0 +1,98 @@
+"""Optional encoder of the PAST visual/ego history (Issue #20).
+
+Addresses the "Visual Scene History too small" feedback (Zain, 03/06):
+instead of feeding the planner a long, thin 10 Hz history, this module
+compresses the past to a coarser-in-time / richer-in-feature representation
+at ~1 Hz, then summarises it into a single context vector. Slower temporal
+granularity over the past reduces decision flicker while keeping the
+per-step feature capacity high.
+
+Scope note: this is an ENCODER of history (the past), NOT a trajectory
+planner — it is deliberately distinct from the future-rollout
+``gru_planner`` proposed in PR #51, which decodes future waypoints. The
+output of this module is a context vector intended as an additional
+(optional) conditioning input; it does not modify AutoE2E's default
+forward pass or its 3-tuple return contract.
+"""
+
+import torch
+import torch.nn as nn
+
+
+class HistoryEncoder(nn.Module):
+    """Compress a [B, T, input_dim] past sequence into a [B, hidden_dim] context.
+
+    Pipeline:
+      1. Temporal compression: non-overlapping Conv1d with
+         ``kernel=stride=subsample_ratio`` pools each ``subsample_ratio``-step
+         window (e.g. 10 steps at 10 Hz -> 1 step at 1 Hz) while EXPANDING the
+         feature dimension to ``hidden_dim`` (coarser in time, richer in
+         feature). A trailing window shorter than the ratio is dropped.
+      2. Sequence summarisation: a GRU over the ~1 Hz sequence; the final
+         hidden state is the history context.
+
+    Args:
+        input_dim: feature size of each history step.
+        hidden_dim: feature size of the compressed steps and output context.
+        subsample_ratio: temporal pooling factor (default 10: 10 Hz -> 1 Hz).
+        input_hz: nominal input rate, for documentation/inspection only.
+
+    Example: T=64 at 10 Hz with ``subsample_ratio=10`` -> 6 compressed steps
+    (~1 Hz over 6.4 s) -> context ``[B, hidden_dim]``.
+    """
+
+    def __init__(self, input_dim: int = 256, hidden_dim: int = 256,
+                 subsample_ratio: int = 10, input_hz: float = 10.0):
+        super().__init__()
+        if subsample_ratio < 1:
+            raise ValueError(
+                f"subsample_ratio must be >= 1, got {subsample_ratio}"
+            )
+        self.input_dim = input_dim
+        self.hidden_dim = hidden_dim
+        self.subsample_ratio = subsample_ratio
+        self.input_hz = input_hz
+        self.output_hz = input_hz / subsample_ratio
+
+        # Non-overlapping temporal pooling with feature expansion.
+        self.temporal_compress = nn.Conv1d(
+            input_dim, hidden_dim,
+            kernel_size=subsample_ratio, stride=subsample_ratio,
+        )
+        self.activation = nn.GELU()
+        self.norm = nn.LayerNorm(hidden_dim)
+
+        # Summarise the low-rate sequence into a single context vector.
+        self.gru = nn.GRU(hidden_dim, hidden_dim, batch_first=True)
+
+    def compressed_length(self, T: int) -> int:
+        """Number of ~1 Hz steps produced from a T-step input."""
+        return T // self.subsample_ratio
+
+    def compress(self, history: torch.Tensor) -> torch.Tensor:
+        """Temporal compression only: [B, T, input_dim] -> [B, T', hidden_dim]
+        with ``T' = T // subsample_ratio``."""
+        B, T, _ = history.shape
+        if T < self.subsample_ratio:
+            raise ValueError(
+                f"History length {T} is shorter than subsample_ratio "
+                f"{self.subsample_ratio}; need at least one full window."
+            )
+        x = history.transpose(1, 2)            # [B, input_dim, T]
+        x = self.temporal_compress(x)          # [B, hidden_dim, T']
+        x = self.activation(x)
+        x = x.transpose(1, 2)                  # [B, T', hidden_dim]
+        return self.norm(x)
+
+    def forward(self, history: torch.Tensor) -> torch.Tensor:
+        """Encode the past.
+
+        Args:
+            history: ``[B, T, input_dim]`` past sequence (e.g. T=64 at 10 Hz).
+
+        Returns:
+            context: ``[B, hidden_dim]`` summary of the compressed history.
+        """
+        compressed = self.compress(history)     # [B, T', hidden_dim]
+        _, h_n = self.gru(compressed)            # h_n: [1, B, hidden_dim]
+        return h_n.squeeze(0)

--- a/Model/model_components/history_encoder.py
+++ b/Model/model_components/history_encoder.py
@@ -27,7 +27,11 @@ class HistoryEncoder(nn.Module):
          ``kernel=stride=subsample_ratio`` pools each ``subsample_ratio``-step
          window (e.g. 10 steps at 10 Hz -> 1 step at 1 Hz) while EXPANDING the
          feature dimension to ``hidden_dim`` (coarser in time, richer in
-         feature). A trailing window shorter than the ratio is dropped.
+         feature). The history is assumed to be ordered oldest -> most
+         recent; when ``T`` is not a multiple of the ratio, the OLDEST
+         ``T % subsample_ratio`` steps are dropped (left-trim) so that the
+         pooling windows stay aligned to the present and the most recent
+         frames are always kept.
       2. Sequence summarisation: a GRU over the ~1 Hz sequence; the final
          hidden state is the history context.
 
@@ -71,13 +75,24 @@ class HistoryEncoder(nn.Module):
 
     def compress(self, history: torch.Tensor) -> torch.Tensor:
         """Temporal compression only: [B, T, input_dim] -> [B, T', hidden_dim]
-        with ``T' = T // subsample_ratio``."""
+        with ``T' = T // subsample_ratio``.
+
+        Assumes ``history`` is ordered oldest -> most recent. If ``T`` is not
+        a multiple of ``subsample_ratio``, the leading (oldest)
+        ``T % subsample_ratio`` steps are dropped so the most recent frames
+        always contribute to the output.
+        """
         B, T, _ = history.shape
         if T < self.subsample_ratio:
             raise ValueError(
                 f"History length {T} is shorter than subsample_ratio "
                 f"{self.subsample_ratio}; need at least one full window."
             )
+        # Left-trim the remainder: keep the most recent frames (the history
+        # is oldest -> most recent), discarding only the oldest leftovers.
+        remainder = T % self.subsample_ratio
+        if remainder:
+            history = history[:, remainder:, :]
         x = history.transpose(1, 2)            # [B, input_dim, T]
         x = self.temporal_compress(x)          # [B, hidden_dim, T']
         x = self.activation(x)
@@ -88,7 +103,8 @@ class HistoryEncoder(nn.Module):
         """Encode the past.
 
         Args:
-            history: ``[B, T, input_dim]`` past sequence (e.g. T=64 at 10 Hz).
+            history: ``[B, T, input_dim]`` past sequence ordered oldest ->
+                most recent (e.g. T=64 at 10 Hz).
 
         Returns:
             context: ``[B, hidden_dim]`` summary of the compressed history.

--- a/Model/model_components/temporal_memory/__init__.py
+++ b/Model/model_components/temporal_memory/__init__.py
@@ -1,0 +1,24 @@
+from .base import BaseTemporalMemory
+from .no_memory import NoMemory
+from .one_hz_encoder import OneHzHistoryEncoder
+
+TEMPORAL_MEMORY_REGISTRY = {
+    "no_memory": NoMemory,
+    "one_hz": OneHzHistoryEncoder,
+}
+
+def build_temporal_memory(memory_mode: str, **kwargs):
+    if memory_mode not in TEMPORAL_MEMORY_REGISTRY:
+        raise ValueError(
+            f"Unknown temporal memory mode {memory_mode!r}. "
+            f"Available: {sorted(TEMPORAL_MEMORY_REGISTRY)}."
+        )
+    return TEMPORAL_MEMORY_REGISTRY[memory_mode](**kwargs)
+
+__all__ = [
+    "BaseTemporalMemory",
+    "NoMemory",
+    "OneHzHistoryEncoder",
+    "TEMPORAL_MEMORY_REGISTRY",
+    "build_temporal_memory"
+]

--- a/Model/model_components/temporal_memory/base.py
+++ b/Model/model_components/temporal_memory/base.py
@@ -1,0 +1,21 @@
+import torch.nn as nn
+from abc import ABC, abstractmethod
+
+class BaseTemporalMemory(nn.Module, ABC):
+    """Abstract interface for temporal memory modules.
+    
+    Transforms [B, T, feat] sequence histories into [B, feat] context vectors
+    that are consumed downstream by the trajectory planner.
+    """
+    @abstractmethod
+    def forward(self, visual_history, egomotion_history, **kwargs):
+        """
+        Args:
+            visual_history: [B, T, visual_history_dim] or [B, visual_history_dim]
+            egomotion_history: [B, T, egomotion_dim] or [B, egomotion_dim]
+            
+        Returns:
+            visual_context: [B, visual_history_dim]
+            egomotion_context: [B, egomotion_dim]
+        """
+        raise NotImplementedError

--- a/Model/model_components/temporal_memory/no_memory.py
+++ b/Model/model_components/temporal_memory/no_memory.py
@@ -2,6 +2,14 @@ from .base import BaseTemporalMemory
 
 class NoMemory(BaseTemporalMemory):
     """Baseline temporal memory: extracts the most recent timestep or passes through flat contexts."""
+
+    def __init__(self, **kwargs):
+        # Accept (and ignore) the dims build_temporal_memory forwards to every
+        # registry entry (visual_dim, egomotion_dim, ...). NoMemory is a
+        # parameter-free passthrough and needs none of them. Without this,
+        # the DEFAULT AutoE2E (temporal_memory_mode="no_memory") fails to build.
+        super().__init__()
+
     def forward(self, visual_history, egomotion_history, **kwargs):
         v_ctx = visual_history[:, -1] if visual_history.ndim == 3 else visual_history
         e_ctx = egomotion_history[:, -1] if egomotion_history.ndim == 3 else egomotion_history

--- a/Model/model_components/temporal_memory/no_memory.py
+++ b/Model/model_components/temporal_memory/no_memory.py
@@ -1,0 +1,8 @@
+from .base import BaseTemporalMemory
+
+class NoMemory(BaseTemporalMemory):
+    """Baseline temporal memory: extracts the most recent timestep or passes through flat contexts."""
+    def forward(self, visual_history, egomotion_history, **kwargs):
+        v_ctx = visual_history[:, -1] if visual_history.ndim == 3 else visual_history
+        e_ctx = egomotion_history[:, -1] if egomotion_history.ndim == 3 else egomotion_history
+        return v_ctx, e_ctx

--- a/Model/model_components/temporal_memory/one_hz_encoder.py
+++ b/Model/model_components/temporal_memory/one_hz_encoder.py
@@ -18,6 +18,8 @@ forward pass or its 3-tuple return contract.
 import torch
 import torch.nn as nn
 
+from .base import BaseTemporalMemory
+
 
 class HistoryEncoder(nn.Module):
     """Compress a [B, T, input_dim] past sequence into a [B, hidden_dim] context.
@@ -112,3 +114,39 @@ class HistoryEncoder(nn.Module):
         compressed = self.compress(history)     # [B, T', hidden_dim]
         _, h_n = self.gru(compressed)            # h_n: [1, B, hidden_dim]
         return h_n.squeeze(0)
+
+
+class OneHzHistoryEncoder(BaseTemporalMemory):
+    """Applies the 1 Hz HistoryEncoder to both visual and egomotion streams.
+    
+    Acts as a bridge between the [B, T, feat] sequence pipeline and the 1 Hz compression
+    baseline, concatenating features for joint temporal compression.
+    """
+    def __init__(self, visual_dim=896, egomotion_dim=256, subsample_ratio=10, input_hz=10.0):
+        super().__init__()
+        self.visual_dim = visual_dim
+        self.egomotion_dim = egomotion_dim
+        
+        joint_dim = visual_dim + egomotion_dim
+        self.encoder = HistoryEncoder(
+            input_dim=joint_dim,
+            hidden_dim=joint_dim,
+            subsample_ratio=subsample_ratio,
+            input_hz=input_hz
+        )
+        
+    def forward(self, visual_history, egomotion_history, **kwargs):
+        # Flatten if passed without time dimension (fallback)
+        if visual_history.ndim == 2:
+            return visual_history, egomotion_history
+            
+        # Concat along feature dim: [B, T, visual_dim + egomotion_dim]
+        joint_history = torch.cat([visual_history, egomotion_history], dim=-1)
+        
+        # Compress to 1 Hz: [B, visual_dim + egomotion_dim]
+        joint_context = self.encoder(joint_history)
+        
+        # Split back
+        v_ctx = joint_context[:, :self.visual_dim]
+        e_ctx = joint_context[:, self.visual_dim:]
+        return v_ctx, e_ctx

--- a/Model/tests/test_history_encoder.py
+++ b/Model/tests/test_history_encoder.py
@@ -14,7 +14,7 @@ import torch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from model_components.history_encoder import HistoryEncoder
+from model_components.temporal_memory.one_hz_encoder import HistoryEncoder, OneHzHistoryEncoder
 
 B = 4
 INPUT_DIM = 64
@@ -136,3 +136,21 @@ def test_context_depends_on_history():
         ctx_a = encoder(torch.randn(B, 64, INPUT_DIM))
         ctx_b = encoder(torch.randn(B, 64, INPUT_DIM))
     assert not torch.allclose(ctx_a, ctx_b)
+
+
+def test_one_hz_history_encoder_pipeline():
+    encoder = OneHzHistoryEncoder(visual_dim=896, egomotion_dim=256, subsample_ratio=10)
+    visual = torch.randn(B, 64, 896)
+    ego = torch.randn(B, 64, 256)
+    
+    v_ctx, e_ctx = encoder(visual, ego)
+    
+    assert v_ctx.shape == (B, 896)
+    assert e_ctx.shape == (B, 256)
+    
+    # Fallback flat input test
+    v_flat = torch.randn(B, 896)
+    e_flat = torch.randn(B, 256)
+    v_out, e_out = encoder(v_flat, e_flat)
+    assert torch.allclose(v_flat, v_out)
+    assert torch.allclose(e_flat, e_out)

--- a/Model/tests/test_history_encoder.py
+++ b/Model/tests/test_history_encoder.py
@@ -96,6 +96,38 @@ def test_gradients_flow_to_all_parameters_and_input():
         assert torch.isfinite(p.grad).all(), f"Non-finite grad for {name}"
 
 
+def test_keeps_most_recent_frames_when_length_not_multiple_of_ratio():
+    """With T not a multiple of the ratio, the OLDEST ``T % ratio`` frames
+    must be dropped (zero gradient) and every most-recent frame must receive
+    gradient. History is ordered oldest -> most recent, so this guarantees
+    the most informative (recent) 0.x s of the past are never discarded.
+
+    Regression test: the previous implementation let the strided Conv1d drop
+    the trailing window, i.e. with T=64/ratio=10 the most RECENT frames
+    60-63 had exactly zero gradient.
+    """
+    encoder = HistoryEncoder(
+        input_dim=INPUT_DIM, hidden_dim=HIDDEN_DIM, subsample_ratio=10,
+    )
+    T = 64  # 64 % 10 = 4 leftover frames
+    remainder = T % encoder.subsample_ratio
+    history = torch.randn(B, T, INPUT_DIM, requires_grad=True)
+    encoder(history).pow(2).mean().backward()
+
+    per_frame_grad = history.grad.abs().sum(dim=(0, 2))  # [T]
+    # The oldest ``remainder`` frames are discarded (left-trim) ...
+    assert torch.all(per_frame_grad[:remainder] == 0), (
+        "Oldest leftover frames should not influence the output"
+    )
+    # ... and ALL remaining frames — most-recent ones included — contribute.
+    assert torch.all(per_frame_grad[remainder:] > 0), (
+        "Most recent frames must receive gradient (they were dropped "
+        "before the fix)"
+    )
+    # Output length contract is unchanged: T' = T // ratio.
+    assert encoder.compress(history.detach()).shape[1] == T // 10
+
+
 def test_context_depends_on_history():
     torch.manual_seed(0)
     encoder = HistoryEncoder(input_dim=INPUT_DIM, hidden_dim=HIDDEN_DIM)

--- a/Model/tests/test_history_encoder.py
+++ b/Model/tests/test_history_encoder.py
@@ -1,0 +1,106 @@
+"""Unit tests for the optional 1 Hz history encoder (Issue #20).
+
+HistoryEncoder compresses the 10 Hz past sequence to ~1 Hz
+(coarser-in-time, richer-in-feature) and summarises it into a context
+vector. It encodes the PAST — it is not a planner — and does not touch
+AutoE2E's forward contract.
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from model_components.history_encoder import HistoryEncoder
+
+B = 4
+INPUT_DIM = 64
+HIDDEN_DIM = 96
+
+
+def test_output_shape_default_config():
+    encoder = HistoryEncoder(input_dim=INPUT_DIM, hidden_dim=HIDDEN_DIM)
+    history = torch.randn(B, 64, INPUT_DIM)  # 64 steps @ 10 Hz = 6.4 s
+    context = encoder(history)
+    assert context.shape == (B, HIDDEN_DIM)
+    assert torch.isfinite(context).all()
+
+
+def test_temporal_compression_ratio():
+    """T=64 at 10 Hz with ratio 10 must yield 6 compressed (~1 Hz) steps;
+    the trailing partial window is dropped."""
+    encoder = HistoryEncoder(
+        input_dim=INPUT_DIM, hidden_dim=HIDDEN_DIM, subsample_ratio=10,
+    )
+    history = torch.randn(B, 64, INPUT_DIM)
+    compressed = encoder.compress(history)
+    assert compressed.shape == (B, 6, HIDDEN_DIM)
+    assert encoder.compressed_length(64) == 6
+    assert encoder.output_hz == pytest.approx(1.0)
+
+
+def test_configurable_subsample_ratio():
+    for ratio, T, expected in [(4, 64, 16), (8, 64, 8), (10, 70, 7), (1, 5, 5)]:
+        encoder = HistoryEncoder(
+            input_dim=INPUT_DIM, hidden_dim=HIDDEN_DIM, subsample_ratio=ratio,
+        )
+        compressed = encoder.compress(torch.randn(B, T, INPUT_DIM))
+        assert compressed.shape == (B, expected, HIDDEN_DIM), (
+            f"ratio={ratio}, T={T}"
+        )
+
+
+def test_richer_in_feature():
+    """Compressed steps must carry a larger feature dim than the input when
+    hidden_dim > input_dim (coarser-in-time, richer-in-feature)."""
+    encoder = HistoryEncoder(input_dim=32, hidden_dim=128, subsample_ratio=10)
+    compressed = encoder.compress(torch.randn(B, 64, 32))
+    assert compressed.shape[-1] == 128
+
+
+def test_handles_various_history_lengths():
+    encoder = HistoryEncoder(
+        input_dim=INPUT_DIM, hidden_dim=HIDDEN_DIM, subsample_ratio=10,
+    )
+    for T in (10, 32, 64, 100, 127):
+        context = encoder(torch.randn(2, T, INPUT_DIM))
+        assert context.shape == (2, HIDDEN_DIM), f"T={T}"
+
+
+def test_too_short_history_raises():
+    encoder = HistoryEncoder(
+        input_dim=INPUT_DIM, hidden_dim=HIDDEN_DIM, subsample_ratio=10,
+    )
+    with pytest.raises(ValueError):
+        encoder(torch.randn(B, 9, INPUT_DIM))
+
+
+def test_invalid_subsample_ratio_raises():
+    with pytest.raises(ValueError):
+        HistoryEncoder(subsample_ratio=0)
+
+
+def test_gradients_flow_to_all_parameters_and_input():
+    encoder = HistoryEncoder(input_dim=INPUT_DIM, hidden_dim=HIDDEN_DIM)
+    history = torch.randn(B, 64, INPUT_DIM, requires_grad=True)
+    context = encoder(history)
+    context.pow(2).mean().backward()
+
+    assert history.grad is not None
+    assert torch.isfinite(history.grad).all()
+    for name, p in encoder.named_parameters():
+        assert p.grad is not None, f"No gradient for {name}"
+        assert torch.isfinite(p.grad).all(), f"Non-finite grad for {name}"
+
+
+def test_context_depends_on_history():
+    torch.manual_seed(0)
+    encoder = HistoryEncoder(input_dim=INPUT_DIM, hidden_dim=HIDDEN_DIM)
+    encoder.eval()
+    with torch.no_grad():
+        ctx_a = encoder(torch.randn(B, 64, INPUT_DIM))
+        ctx_b = encoder(torch.randn(B, 64, INPUT_DIM))
+    assert not torch.allclose(ctx_a, ctx_b)

--- a/Model/tests/test_history_encoder.py
+++ b/Model/tests/test_history_encoder.py
@@ -14,7 +14,32 @@ import torch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import torch.nn as nn
+
 from model_components.temporal_memory.one_hz_encoder import HistoryEncoder, OneHzHistoryEncoder
+
+
+class _MockBackbone(nn.Module):
+    """Minimal stand-in for Backbone (4 channels-first feature maps), so the
+    AutoE2E integration tests below don't load pretrained weights."""
+
+    def __init__(self, backbone="swin_v2_tiny", is_pretrained=True, **kwargs):
+        super().__init__()
+        self.backbone_channels = 1440
+        self._stages = nn.ModuleList([
+            nn.Sequential(nn.Conv2d(3, 96, 3, 1, 1), nn.AdaptiveAvgPool2d(64)),
+            nn.Sequential(nn.Conv2d(96, 192, 3, 1, 1), nn.AdaptiveAvgPool2d(32)),
+            nn.Sequential(nn.Conv2d(192, 384, 3, 1, 1), nn.AdaptiveAvgPool2d(16)),
+            nn.Sequential(nn.Conv2d(384, 768, 3, 1, 1), nn.AdaptiveAvgPool2d(8)),
+        ])
+
+    def forward(self, image):
+        outs, x = [], image
+        for stage in self._stages:
+            x = stage(x)
+            outs.append(x)
+        return outs
+
 
 B = 4
 INPUT_DIM = 64
@@ -154,3 +179,55 @@ def test_one_hz_history_encoder_pipeline():
     v_out, e_out = encoder(v_flat, e_flat)
     assert torch.allclose(v_flat, v_out)
     assert torch.allclose(e_flat, e_out)
+
+
+def test_autoe2e_consumes_one_hz_temporal_memory():
+    """End-to-end data flow: AutoE2E(temporal_memory_mode='one_hz') feeds the
+    [B, T, feat] history through TemporalMemory and the COMPRESSED context into
+    the planner, in both train and infer. Gradient must reach the memory."""
+    from unittest.mock import patch
+
+    from model_components.auto_e2e import AutoE2E
+
+    with patch("model_components.auto_e2e.Backbone", _MockBackbone):
+        model = AutoE2E(num_views=8, fusion_mode="concat",
+                        temporal_memory_mode="one_hz")
+
+    x = torch.randn(2, 8, 3, 256, 256)
+    map_input = torch.randn(2, 3, 256, 256)
+    vis = torch.randn(2, 20, 896)   # [B, T, visual_dim] — sequence form
+    ego = torch.randn(2, 20, 256)   # [B, T, egomotion_dim]
+    target = torch.randn(2, 128)
+
+    # Train: scalar loss + future; gradient flows back into TemporalMemory.
+    loss, ego_hidden, future = model(x, map_input, vis, ego,
+                                     mode="train", trajectory_target=target)
+    assert loss.ndim == 0 and torch.isfinite(loss)
+    assert ego_hidden.shape == (2, 256) and future is not None
+    loss.backward()
+    assert any(p.grad is not None for p in model.TemporalMemory.parameters()), \
+        "compressed temporal context must be consumed by the planner (grad must reach TemporalMemory)"
+
+    # Infer: 3-tuple with trajectory + None future.
+    traj, ego_hidden2, future2 = model(x, map_input, vis, ego, mode="infer")
+    assert traj.shape == (2, 128) and future2 is None
+
+
+def test_autoe2e_default_no_memory_passthrough():
+    """Default temporal_memory_mode='no_memory' keeps the flat [B, feat] path
+    working — default AutoE2E behaviour is unchanged."""
+    from unittest.mock import patch
+
+    from model_components.auto_e2e import AutoE2E
+    from model_components.temporal_memory import NoMemory
+
+    with patch("model_components.auto_e2e.Backbone", _MockBackbone):
+        model = AutoE2E(num_views=8, fusion_mode="concat")  # default no_memory
+    assert isinstance(model.TemporalMemory, NoMemory)
+
+    x = torch.randn(2, 8, 3, 256, 256)
+    map_input = torch.randn(2, 3, 256, 256)
+    vis = torch.randn(2, 896)       # flat history (default contract)
+    ego = torch.randn(2, 256)
+    traj, ego_hidden, future = model(x, map_input, vis, ego, mode="infer")
+    assert traj.shape == (2, 128) and ego_hidden.shape == (2, 256) and future is None


### PR DESCRIPTION
Implements #20 along the lines @RyotaYamada suggested in #56: TEMPORAL_MEMORY_REGISTRY with NoMemory default + OneHz as one benchmark candidate; exposes the [B,T,feat] history. AutoE2E consumes the compressed context (train+infer); fixes default NoMemory construction. Relates to #56.