### PR TITLE
 feat(temporal-memory): add BEV-queue temporal-attention candidate (#20)

### DIFF
--- a/Model/model_components/temporal_memory/__init__.py
+++ b/Model/model_components/temporal_memory/__init__.py
@@ -1,10 +1,12 @@
 from .base import BaseTemporalMemory
 from .no_memory import NoMemory
 from .one_hz_encoder import OneHzHistoryEncoder
+from .bev_queue import BevQueueMemory
 
 TEMPORAL_MEMORY_REGISTRY = {
     "no_memory": NoMemory,
     "one_hz": OneHzHistoryEncoder,
+    "bev_queue": BevQueueMemory,
 }
 
 def build_temporal_memory(memory_mode: str, **kwargs):
@@ -19,6 +21,7 @@ __all__ = [
     "BaseTemporalMemory",
     "NoMemory",
     "OneHzHistoryEncoder",
+    "BevQueueMemory",
     "TEMPORAL_MEMORY_REGISTRY",
     "build_temporal_memory"
 ]

--- a/Model/model_components/temporal_memory/bev_queue.py
+++ b/Model/model_components/temporal_memory/bev_queue.py
@@ -1,0 +1,120 @@
+"""BEV-queue temporal-attention memory candidate (Issue #20).
+
+@RyotaYamada proposed in #20 benchmarking several temporal-fusion designs —
+BEVFormer / BEVDet4D / StreamPETR / SOLOFusion — against the ``no_memory``
+baseline and the recurrent ``one_hz`` encoder, favouring a BEVFormer-style
+start. BEVFormer fuses history through **temporal self-attention over a queue
+of past BEV features** (Li et al. 2022, "BEVFormer", arXiv:2203.17270);
+StreamPETR/SOLOFusion likewise attend over a recent-frame queue.
+
+At the ``[B, T, feat]`` history-vector interface used by this registry (not the
+spatial BEV grid), the faithful analog is a **Transformer encoder that attends
+over the most recent ``queue_len`` history steps** and pools them into a single
+context vector via a learnable query (CLS) token. This is the attention-based,
+order-aware alternative to the recurrent 1 Hz compression — a third candidate
+for the memory benchmark requested in #20.
+
+It keeps the registry contract intact: ``forward(visual_history,
+egomotion_history) -> (visual_context [B, visual_dim], egomotion_context
+[B, egomotion_dim])``, and falls back to a pass-through when the history has no
+time dimension, exactly like ``OneHzHistoryEncoder``.
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+
+from .base import BaseTemporalMemory
+
+
+def _sinusoidal_position_encoding(length: int, dim: int,
+                                  device: torch.device) -> torch.Tensor:
+    """Standard sinusoidal positional encoding ``[length, dim]`` (dim even).
+
+    Temporal order matters for fusion, but self-attention is permutation
+    invariant, so positions must be encoded explicitly (Vaswani et al. 2017).
+    """
+    pos = torch.arange(length, device=device, dtype=torch.float32).unsqueeze(1)
+    div = torch.exp(torch.arange(0, dim, 2, device=device, dtype=torch.float32)
+                    * (-math.log(10000.0) / dim))
+    pe = torch.zeros(length, dim, device=device)
+    pe[:, 0::2] = torch.sin(pos * div)
+    pe[:, 1::2] = torch.cos(pos * div)
+    return pe
+
+
+class BevQueueMemory(BaseTemporalMemory):
+    """Temporal self-attention over the recent history queue (BEVFormer-style).
+
+    Args:
+        visual_dim: visual history feature size (output ``visual_context`` size).
+        egomotion_dim: egomotion history feature size.
+        d_model: attention width (must be even; default 512).
+        num_heads: attention heads (must divide ``d_model``; default 8).
+        num_layers: Transformer encoder layers (default 2).
+        queue_len: keep only the most recent ``queue_len`` steps (``None`` = all),
+            mirroring BEVFormer's fixed-length BEV queue.
+        dim_feedforward: FFN width (default ``4 * d_model``).
+        dropout: attention/FFN dropout (default 0.0 for deterministic inference).
+    """
+
+    def __init__(self, visual_dim: int = 896, egomotion_dim: int = 256,
+                 d_model: int = 512, num_heads: int = 8, num_layers: int = 2,
+                 queue_len: int | None = None, dim_feedforward: int | None = None,
+                 dropout: float = 0.0):
+        super().__init__()
+        if d_model % 2 != 0:
+            raise ValueError(f"d_model must be even, got {d_model}")
+        if d_model % num_heads != 0:
+            raise ValueError(
+                f"d_model ({d_model}) must be divisible by num_heads ({num_heads})"
+            )
+        if queue_len is not None and queue_len < 1:
+            raise ValueError(f"queue_len must be >= 1 or None, got {queue_len}")
+        self.visual_dim = visual_dim
+        self.egomotion_dim = egomotion_dim
+        self.d_model = d_model
+        self.queue_len = queue_len
+
+        joint_dim = visual_dim + egomotion_dim
+        # Project the joint history step into the attention space and back.
+        self.in_proj = nn.Linear(joint_dim, d_model)
+        self.out_proj = nn.Linear(d_model, joint_dim)
+        # Learnable query token that pools the attended queue into one vector.
+        self.query_token = nn.Parameter(torch.zeros(1, 1, d_model))
+        nn.init.trunc_normal_(self.query_token, std=0.02)
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=d_model, nhead=num_heads,
+            dim_feedforward=dim_feedforward or 4 * d_model,
+            dropout=dropout, batch_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+
+    def forward(self, visual_history, egomotion_history, **kwargs):
+        # Fallback: no temporal dimension -> pass through (matches OneHz/NoMemory).
+        if visual_history.ndim == 2:
+            return visual_history, egomotion_history
+
+        # Join the two streams along the feature dim: [B, T, visual+ego].
+        joint = torch.cat([visual_history, egomotion_history], dim=-1)
+
+        # Keep only the most recent steps (BEVFormer's fixed-length queue). The
+        # history is oldest -> most recent, so slice from the tail.
+        if self.queue_len is not None:
+            joint = joint[:, -self.queue_len:, :]
+
+        B, T, _ = joint.shape
+        x = self.in_proj(joint)                                   # [B, T, d]
+        x = x + _sinusoidal_position_encoding(T, self.d_model, x.device)
+
+        # Prepend the learnable query token; its output pools the queue.
+        query = self.query_token.expand(B, -1, -1)                # [B, 1, d]
+        x = torch.cat([query, x], dim=1)                          # [B, T+1, d]
+        x = self.encoder(x)                                       # [B, T+1, d]
+
+        context = self.out_proj(x[:, 0])                          # [B, visual+ego]
+        visual_context = context[:, :self.visual_dim]
+        egomotion_context = context[:, self.visual_dim:]
+        return visual_context, egomotion_context

--- a/Model/speed_benchmark/results/temporal_memory_benchmark_20260623_154838.json
+++ b/Model/speed_benchmark/results/temporal_memory_benchmark_20260623_154838.json
@@ -1,0 +1,57 @@
+{
+  "device": "cuda",
+  "torch": "2.12.0+cu130",
+  "history": {
+    "B": 1,
+    "T": 64,
+    "visual_dim": 896,
+    "ego_dim": 256
+  },
+  "rows": [
+    {
+      "memory": "no_memory",
+      "params": 0,
+      "latency_p50_ms": 0.016,
+      "latency_p99_ms": 0.029,
+      "jitter_ms": 0.013,
+      "visual_ctx_dim": [
+        1,
+        896
+      ],
+      "ego_ctx_dim": [
+        1,
+        256
+      ]
+    },
+    {
+      "memory": "one_hz",
+      "params": 21244032,
+      "latency_p50_ms": 1.563,
+      "latency_p99_ms": 2.218,
+      "jitter_ms": 0.655,
+      "visual_ctx_dim": [
+        1,
+        896
+      ],
+      "ego_ctx_dim": [
+        1,
+        256
+      ]
+    },
+    {
+      "memory": "bev_queue",
+      "params": 7486592,
+      "latency_p50_ms": 1.606,
+      "latency_p99_ms": 2.144,
+      "jitter_ms": 0.538,
+      "visual_ctx_dim": [
+        1,
+        896
+      ],
+      "ego_ctx_dim": [
+        1,
+        256
+      ]
+    }
+  ]
+}

--- a/Model/speed_benchmark/temporal_memory_benchmark.py
+++ b/Model/speed_benchmark/temporal_memory_benchmark.py
@@ -1,0 +1,112 @@
+"""Temporal-memory benchmark — no_memory vs one_hz vs bev_queue (Issue #20).
+
+Compares the candidates registered in ``TEMPORAL_MEMORY_REGISTRY`` under
+IDENTICAL conditions (same history shape / device), as @RyotaYamada requested
+in #20 (benchmark no-memory / 1 Hz / BEV-queue style fusion). Mirrors
+``planner_benchmark.py``.
+
+Measures (no trained checkpoint needed):
+  * inference latency (p50 / p99 / jitter, ms) on a [B, T, feat] history
+  * parameter count
+  * output context shape (sanity that the [B,T,feat] -> [B,feat] contract holds)
+
+Run:
+    env -u PYTHONPATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+        python Model/speed_benchmark/temporal_memory_benchmark.py
+"""
+
+import json
+import os
+import sys
+import time
+
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from model_components.temporal_memory import (  # noqa: E402
+    TEMPORAL_MEMORY_REGISTRY,
+    build_temporal_memory,
+)
+
+VISUAL_DIM, EGO_DIM = 896, 256
+T, BATCH = 64, 1          # 64 history steps (e.g. 6.4 s @10 Hz)
+WARMUP, ITERS = 10, 50
+CANDIDATES = ["no_memory", "one_hz", "bev_queue"]
+
+
+def _make_history(device):
+    return (torch.randn(BATCH, T, VISUAL_DIM, device=device),
+            torch.randn(BATCH, T, EGO_DIM, device=device))
+
+
+def _bench_one(name, device):
+    torch.manual_seed(0)
+    mem = build_temporal_memory(name, visual_dim=VISUAL_DIM,
+                                egomotion_dim=EGO_DIM).to(device).eval()
+    n_params = sum(p.numel() for p in mem.parameters())
+    vis, ego = _make_history(device)
+    with torch.no_grad():
+        for _ in range(WARMUP):
+            v_ctx, e_ctx = mem(vis, ego)
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        times = []
+        for _ in range(ITERS):
+            t0 = time.perf_counter()
+            v_ctx, e_ctx = mem(vis, ego)
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+            times.append((time.perf_counter() - t0) * 1000.0)
+    times.sort()
+    p50 = times[len(times) // 2]
+    p99 = times[min(len(times) - 1, int(round(len(times) * 0.99)) - 1)]
+    return {
+        "memory": name,
+        "params": n_params,
+        "latency_p50_ms": round(p50, 3),
+        "latency_p99_ms": round(p99, 3),
+        "jitter_ms": round(p99 - p50, 3),
+        "visual_ctx_dim": tuple(v_ctx.shape),
+        "ego_ctx_dim": tuple(e_ctx.shape),
+    }
+
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    rows = []
+    for name in CANDIDATES:
+        if name not in TEMPORAL_MEMORY_REGISTRY:
+            print(f"skip {name}: not in registry")
+            continue
+        try:
+            rows.append(_bench_one(name, device))
+        except Exception as e:  # noqa: BLE001
+            rows.append({"memory": name, "error": repr(e)})
+
+    print(f"\nDevice: {device} | torch {torch.__version__} | "
+          f"history [B={BATCH}, T={T}, vis={VISUAL_DIM}, ego={EGO_DIM}]\n")
+    hdr = ["memory", "params", "latency_p50_ms", "latency_p99_ms", "jitter_ms"]
+    print("| " + " | ".join(hdr) + " |")
+    print("|" + "|".join(["---"] * len(hdr)) + "|")
+    for r in rows:
+        if "error" in r:
+            print(f"| {r['memory']} | ERROR: {r['error']} |")
+            continue
+        print("| " + " | ".join(str(r[h]) for h in hdr) + " |")
+
+    out_dir = os.path.join(os.path.dirname(__file__), "results")
+    os.makedirs(out_dir, exist_ok=True)
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+    out_path = os.path.join(out_dir, f"temporal_memory_benchmark_{stamp}.json")
+    with open(out_path, "w") as f:
+        json.dump({"device": str(device), "torch": torch.__version__,
+                   "history": {"B": BATCH, "T": T, "visual_dim": VISUAL_DIM,
+                               "ego_dim": EGO_DIM}, "rows": rows}, f, indent=2)
+    print(f"\nSaved: {out_path}")
+    print("\nNOTE: this measures cost only. Which memory helps DRIVING needs a "
+          "trained model + open/closed-loop eval (see #66 / #20).")
+
+
+if __name__ == "__main__":
+    main()

--- a/Model/tests/test_bev_queue_memory.py
+++ b/Model/tests/test_bev_queue_memory.py
@@ -1,0 +1,146 @@
+"""Unit tests for the BEV-queue temporal-attention memory candidate (#20)."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from model_components.temporal_memory import (
+    BaseTemporalMemory,
+    BevQueueMemory,
+    build_temporal_memory,
+)
+
+VIS, EGO = 896, 256
+
+
+def _hist(B, T, device):
+    return (torch.randn(B, T, VIS, device=device),
+            torch.randn(B, T, EGO, device=device))
+
+
+def test_is_base_temporal_memory(device):
+    m = BevQueueMemory(visual_dim=VIS, egomotion_dim=EGO).to(device)
+    assert isinstance(m, BaseTemporalMemory)
+
+
+def test_output_contract_shapes(device):
+    m = BevQueueMemory(visual_dim=VIS, egomotion_dim=EGO).to(device)
+    v, e = _hist(2, 6, device)
+    v_ctx, e_ctx = m(v, e)
+    assert v_ctx.shape == (2, VIS)
+    assert e_ctx.shape == (2, EGO)
+    assert torch.isfinite(v_ctx).all() and torch.isfinite(e_ctx).all()
+
+
+def test_registry_builds_bev_queue(device):
+    m = build_temporal_memory("bev_queue", visual_dim=VIS, egomotion_dim=EGO,
+                              num_heads=4, num_layers=1).to(device)
+    assert isinstance(m, BevQueueMemory)
+    v, e = _hist(2, 5, device)
+    v_ctx, e_ctx = m(v, e)
+    assert v_ctx.shape == (2, VIS) and e_ctx.shape == (2, EGO)
+
+
+def test_fallback_passthrough_when_no_time_dim(device):
+    m = BevQueueMemory(visual_dim=VIS, egomotion_dim=EGO).to(device)
+    v = torch.randn(2, VIS, device=device)
+    e = torch.randn(2, EGO, device=device)
+    v_ctx, e_ctx = m(v, e)
+    assert torch.equal(v_ctx, v) and torch.equal(e_ctx, e)
+
+
+def test_variable_sequence_length(device):
+    m = BevQueueMemory(visual_dim=VIS, egomotion_dim=EGO).to(device)
+    for T in (1, 3, 16):
+        v, e = _hist(2, T, device)
+        v_ctx, e_ctx = m(v, e)
+        assert v_ctx.shape == (2, VIS)
+
+
+def test_queue_len_keeps_most_recent(device):
+    """With queue_len=K, only the last K steps drive the output: changing the
+    older (trimmed) steps must NOT change the context."""
+    torch.manual_seed(0)
+    m = BevQueueMemory(visual_dim=VIS, egomotion_dim=EGO, queue_len=3).to(device)
+    m.eval()
+    v, e = _hist(1, 8, device)
+    v_ctx_a, _ = m(v, e)
+    # Mutate the OLDEST step (index 0), which is trimmed away by queue_len=3.
+    v2 = v.clone()
+    v2[:, 0, :] += 100.0
+    v_ctx_b, _ = m(v2, e)
+    assert torch.allclose(v_ctx_a, v_ctx_b, atol=1e-5)
+
+
+def test_temporal_order_matters(device):
+    """Positional encoding makes the module order-aware: reversing the queue
+    must change the output (unlike a permutation-invariant pool)."""
+    torch.manual_seed(0)
+    m = BevQueueMemory(visual_dim=VIS, egomotion_dim=EGO).to(device)
+    m.eval()
+    v, e = _hist(1, 6, device)
+    fwd, _ = m(v, e)
+    rev, _ = m(v.flip(1), e.flip(1))
+    assert not torch.allclose(fwd, rev, atol=1e-5)
+
+
+def test_gradients_flow(device):
+    m = BevQueueMemory(visual_dim=VIS, egomotion_dim=EGO, num_layers=1).to(device)
+    v, e = _hist(2, 5, device)
+    v_ctx, e_ctx = m(v, e)
+    (v_ctx.pow(2).mean() + e_ctx.pow(2).mean()).backward()
+    for name, p in m.named_parameters():
+        assert p.grad is not None, f"no grad for {name}"
+
+
+def test_invalid_args():
+    with pytest.raises(ValueError, match="even"):
+        BevQueueMemory(d_model=255)
+    with pytest.raises(ValueError, match="divisible"):
+        BevQueueMemory(d_model=512, num_heads=7)
+    with pytest.raises(ValueError, match="queue_len"):
+        BevQueueMemory(queue_len=0)
+
+
+def test_reactive_e2e_with_bev_queue_memory(device):
+    """ReactiveE2E (post-refactor home of the temporal memory) must accept
+    temporal_memory_mode='bev_queue' with a [B, T, feat] history and run
+    end-to-end (BEV fusion; planner='bezier' since GRU was removed)."""
+    from unittest.mock import patch
+
+    from model_components.reactive_e2e import ReactiveE2E
+
+    class _MockBackbone(nn.Module):
+        def __init__(self, backbone="swin_v2_tiny", is_pretrained=True, **kwargs):
+            super().__init__()
+            self.backbone_channels = 1440
+            self._stages = nn.ModuleList([
+                nn.Sequential(nn.Conv2d(3, 96, 3, 1, 1), nn.AdaptiveAvgPool2d(64)),
+                nn.Sequential(nn.Conv2d(96, 192, 3, 1, 1), nn.AdaptiveAvgPool2d(32)),
+                nn.Sequential(nn.Conv2d(192, 384, 3, 1, 1), nn.AdaptiveAvgPool2d(16)),
+                nn.Sequential(nn.Conv2d(384, 768, 3, 1, 1), nn.AdaptiveAvgPool2d(8)),
+            ])
+
+        def forward(self, image):
+            outs, x = [], image
+            for stage in self._stages:
+                x = stage(x)
+                outs.append(x)
+            return outs
+
+    with patch("model_components.reactive_e2e.Backbone", _MockBackbone):
+        model = ReactiveE2E(num_views=8,
+                            view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
+                            planner_mode="bezier",
+                            temporal_memory_mode="bev_queue",
+                            temporal_memory_kwargs={"num_layers": 1}).to(device)
+    assert isinstance(model.TemporalMemory, BevQueueMemory)
+
+    x = torch.randn(2, 8, 3, 256, 256, device=device)
+    map_input = torch.randn(2, 3, 256, 256, device=device)
+    vis = torch.randn(2, 4, 896, device=device)   # [B, T, feat] history
+    ego = torch.randn(2, 4, 256, device=device)
+    out = model(x, map_input, vis, ego)
+    traj = out[0] if isinstance(out, (tuple, list)) else out
+    assert traj.shape == (2, 128)
+    assert torch.isfinite(traj).all()


### PR DESCRIPTION
Adds `bev_queue` to `TEMPORAL_MEMORY_REGISTRY` — a BEVFormer-style temporal self-attention over the recent history queue (arXiv:2203.17270), the order-aware, attention-based alternative to `no_memory` and the recurrent `one_hz` encoder you asked to benchmark in #20. Works on the `[B,T,feat]` contract (in/out projections + learnable query token + sinusoidal positions); optional `queue_len` mirrors BEVFormer's fixed-length queue; pass-through fallback like OneHz. Includes `temporal_memory_benchmark.py` (no_memory/one_hz/bev_queue): bev_queue is ~3× lighter than one_hz at similar latency. Additive — `no_memory` stays the default. 10 new tests, suite 272 green, mypy/ruff clean. Which memory helps *driving* still needs the open-loop eval (#66)