### PR TITLE
fix(tests): repair the unit-test suite after the Reactive_E2E refactor (#88)

### DIFF
--- a/Model/model_components/losses/trajectory_loss.py
+++ b/Model/model_components/losses/trajectory_loss.py
@@ -5,13 +5,18 @@ import torch.nn as nn
 class TrajectoryImitationLoss(nn.Module):
     """Primary task loss: imitation loss over predicted trajectory."""
 
+    # Class-level annotations so mypy resolves these to their real types
+    # instead of nn.Module's ``__getattr__ -> Tensor | Module`` fallback
+    # (otherwise ``self.loss_fn(...)`` is flagged "Tensor not callable").
+    loss_fn: nn.Module
+    temporal_weights: torch.Tensor
+
     def __init__(self, loss_type: str = "smooth_l1", temporal_decay: float = 0.95,
                  num_timesteps: int = 64, num_signals: int = 2):
         # temporal_decay defaults to 0.95 so near-future predictions are
         # weighted more heavily than far-future ones; near-future accuracy
         # is more safety-critical for planning.
         super().__init__()
-        self.loss_fn: nn.Module
         if loss_type == "smooth_l1":
             self.loss_fn = nn.SmoothL1Loss(reduction="none")
         elif loss_type == "mse":

--- a/Model/model_components/map_encoder/raster_map_encoder.py
+++ b/Model/model_components/map_encoder/raster_map_encoder.py
@@ -4,6 +4,8 @@ Takes a BEV-space RGB map image and produces a spatial feature map at the same r
 features, so the two can be fused directly.
 """
 
+from typing import Any
+
 import torch
 import torch.nn as nn
 import timm
@@ -40,8 +42,11 @@ class RasterizedMapEncoder(nn.Module):
             in_chans=in_channels,
         )
  
+        # timm's FeatureInfo is exposed via __getattr__ (typed Tensor | Module),
+        # so bind through Any to iterate it without a mypy union-attr error.
+        backbone: Any = self._backbone
         self._feature_channels = [
-            stage["num_chs"] for stage in self._backbone.feature_info
+            stage["num_chs"] for stage in backbone.feature_info
         ]
         backbone_channels = sum(self._feature_channels)
  

--- a/Model/tests/conftest.py
+++ b/Model/tests/conftest.py
@@ -76,30 +76,30 @@ class MockBackbone(nn.Module):
         return self.backbone(image)
 
 
-def _build_model_with_mock_backbone(num_views, fusion_mode, device,
+def _build_model_with_mock_backbone(num_views, fusion_mode="bev", device=None,
                                     num_timesteps=64, map_fusion_mode="residual",
-                                    planner_mode="gru", planner_kwargs=None):
+                                    planner_mode="bezier", planner_kwargs=None,
+                                    **model_kwargs):
     """Construct AutoE2E with the mock backbone injected.
 
-    Patches Backbone at the module level during construction to avoid
-    loading pretrained weights entirely. Forces BEV fusion to a small
-    8x8 grid so tests stay fast and memory-light; the production default
-    (450x300) is exercised by dedicated configuration tests.
+    Post-refactor (#86): the model is ``AutoE2E`` -> ``Reactive_E2E`` and the
+    image backbone now lives in ``reactive_e2e``; fusion is always BEV
+    (concat/cross_attn were removed) and GRU was dropped. ``fusion_mode`` is
+    accepted for backward-compatibility with existing call sites but ignored
+    (always BEV at a small 8x8 grid). Extra ``model_kwargs`` are forwarded.
     """
     from unittest.mock import patch
     from model_components.auto_e2e import AutoE2E
 
-    view_fusion_kwargs = {"bev_h": 8, "bev_w": 8} if fusion_mode == "bev" else None
-
-    with patch('model_components.auto_e2e.Backbone', MockBackbone):
+    with patch('model_components.reactive_e2e.Backbone', MockBackbone):
         model = AutoE2E(
             num_views=num_views,
-            fusion_mode=fusion_mode,
-            view_fusion_kwargs=view_fusion_kwargs,
+            view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
             num_timesteps=num_timesteps,
             planner_mode=planner_mode,
             planner_kwargs=planner_kwargs,
             map_fusion_mode=map_fusion_mode,
+            **model_kwargs,
         )
     return model.to(device)
 
@@ -115,13 +115,13 @@ def build_mock_model():
     return _build_model_with_mock_backbone
 
 
-@pytest.fixture(scope="session", params=["concat", "cross_attn", "bev"])
+@pytest.fixture(scope="session", params=["bev"])
 def model(request, device):
     """Session-scoped model with mock backbone — shared across all tests.
 
-    Built once per fusion mode to avoid redundant 1.5s construction overhead
-    per test. Gradient state is reset before each test via the autouse
-    _reset_model_grads fixture below.
+    Post-refactor only BEV fusion exists. Built once to avoid redundant
+    construction overhead; gradient state is reset before each test via the
+    autouse fixture below.
     """
     return _build_model_with_mock_backbone(
         num_views=7, fusion_mode=request.param, device=device
@@ -138,16 +138,14 @@ def _reset_model_state(request):
         model.train()
 
 
-@pytest.fixture(params=["concat", "cross_attn", "bev"])
+@pytest.fixture(params=["bev"])
 def full_model(request, device):
     """Full model with real backbone — use only for integration tests."""
     from model_components.auto_e2e import AutoE2E
 
-    view_fusion_kwargs = {"bev_h": 8, "bev_w": 8} if request.param == "bev" else None
     try:
         model = AutoE2E(
-            num_views=7, fusion_mode=request.param,
-            view_fusion_kwargs=view_fusion_kwargs,
+            num_views=7, view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
         )
     except (FileNotFoundError, OSError) as e:
         pytest.skip(f"Pretrained weights unavailable: {e}")

--- a/Model/tests/test_auto_e2e.py
+++ b/Model/tests/test_auto_e2e.py
@@ -1,6 +1,20 @@
+"""End-to-end tests for AutoE2E after the #86 refactor.
+
+Post-refactor contract (#88):
+- ``AutoE2E`` wraps ``Reactive_E2E``; the backbone / view fusion / map encoder /
+  planner all live under ``Reactive_E2E.*``.
+- ``forward(...)`` returns ONLY ``trajectory`` ``[B, num_timesteps*num_signals]``
+  in every mode. The old 3-tuple ``(loss/traj, ego_hidden, future_features)`` and
+  the BEV ``FutureState`` output were removed (the planner loss is computed
+  separately via ``compute_planner_loss``; see ``test_trajectory_planning.py``).
+- Only ``bev`` view fusion exists (``concat``/``cross_attn`` were removed).
+"""
+
+import sys
+
 import pytest
 import torch
-import sys
+
 sys.path.append('..')
 
 
@@ -15,6 +29,15 @@ def make_inputs(batch_size, num_views, device, include_camera_params=False):
     return visual, map_input, visual_history, egomotion
 
 
+# Submodule param-name prefixes that are actually exercised by the reactive
+# forward pass. FutureState is instantiated but unused in this path, and the
+# MapEncoder is gated by ResidualMapFusion's alpha=0 init, so neither receives
+# gradient at init — both are excluded from the gradient-coverage checks.
+USED_GROUPS = ["Reactive_E2E.Backbone", "Reactive_E2E.FeatureFusion",
+               "Reactive_E2E.TrajectoryPlanner"]
+NO_GRAD_OK = ("Reactive_E2E.MapEncoder.", "Reactive_E2E.FutureState.")
+
+
 # ---------------------------------------------------------------------------
 # 1. Output shape correctness
 # ---------------------------------------------------------------------------
@@ -23,24 +46,18 @@ class TestOutputShapes:
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     def test_trajectory_shape(self, model, device, batch_size):
         visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
-        traj, _, _ = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
         assert traj.shape == (batch_size, 128)
 
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
-    def test_ego_hidden_shape(self, model, device, batch_size):
-        visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
-        _, ego_hidden, _ = model(visual, map_input, vis_hist, ego, mode="infer")
-        assert ego_hidden.shape == (batch_size, 256)
-
-    @pytest.mark.parametrize("batch_size", [1, 2, 4])
-    def test_future_features_shape(self, model, device, batch_size):
+    def test_train_mode_also_returns_trajectory(self, model, device, batch_size):
+        """forward returns the trajectory in train mode too (the loss is a
+        separate planner concern)."""
         visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
         target = torch.randn(batch_size, 128, device=device)
-        _, _, future = model(visual, map_input, vis_hist, ego, mode="train",
-                             trajectory_target=target)
-        assert len(future) == 4
-        for f in future:
-            assert f.shape == (batch_size, 256, 8, 8)
+        traj = model(visual, map_input, vis_hist, ego, mode="train",
+                     trajectory_target=target)
+        assert traj.shape == (batch_size, 128)
 
 
 # ---------------------------------------------------------------------------
@@ -53,14 +70,10 @@ class TestBatchIndependence:
         torch.manual_seed(42)
         visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
 
-        # Full batch forward
-        traj_both, _, _ = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj_both = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj_single = model(visual[0:1], map_input[0:1], vis_hist[0:1], ego[0:1],
+                            mode="infer")
 
-        # Single sample forward (sample 0)
-        traj_single, _, _ = model(visual[0:1], map_input[0:1], vis_hist[0:1], ego[0:1],
-                                  mode="infer")
-
-        # Sample 0's output must be identical regardless of what sample 1 contains
         assert torch.allclose(traj_both[0], traj_single[0], atol=1e-5), \
             "Batch samples are interfering with each other"
 
@@ -69,101 +82,63 @@ class TestBatchIndependence:
         torch.manual_seed(42)
         visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
 
-        traj_a, _, _ = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj_a = model(visual, map_input, vis_hist, ego, mode="infer")
 
-        # Change sample 1 completely
         visual_modified = visual.clone()
         visual_modified[1] = torch.randn_like(visual_modified[1])
+        traj_b = model(visual_modified, map_input, vis_hist, ego, mode="infer")
 
-        traj_b, _, _ = model(visual_modified, map_input, vis_hist, ego, mode="infer")
-
-        # Sample 0 output must remain unchanged
         assert torch.allclose(traj_a[0], traj_b[0], atol=1e-5), \
             "Modifying another sample in the batch affected this sample's output"
 
 
 # ---------------------------------------------------------------------------
-# 4. Gradient flow — all parameters receive gradients
+# 4. Gradient flow — the exercised path receives gradients
 # ---------------------------------------------------------------------------
 
 class TestGradientFlow:
     def test_backward_succeeds(self, model, device):
         visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
-        target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(visual, map_input, vis_hist, ego,
-                                         mode="train", trajectory_target=target)
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj.pow(2).mean().backward()
 
-        total = loss + ego_hidden.sum() + sum(f.sum() for f in future)
-        total.backward()
-
-    def test_all_parameters_have_gradients(self, model, device):
+    def test_used_path_parameters_have_gradients(self, model, device):
         visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
-        target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(visual, map_input, vis_hist, ego,
-                                         mode="train", trajectory_target=target)
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj.pow(2).mean().backward()
 
-        total = loss + ego_hidden.sum() + sum(f.sum() for f in future)
-        total.backward()
-
-        params_without_grad = []
-        for name, param in model.named_parameters():
-            if param.requires_grad and param.grad is None:
-            # MapEncoder parameters legitimately receive zero gradient
-                # at init because ResidualMapFusion uses alpha=0, which
-                # zeroes out ∂loss/∂map_bev entirely (chain rule:
-                # ∂fused/∂map_bev = alpha = 0). This is intentional: the
-                # zero-init scheme ensures the map branch doesn't destabilise
-                # early training. Gradient will flow once alpha grows > 0.
-                if name.startswith("MapEncoder."):
-                    continue
-                params_without_grad.append(name)
-
-        assert len(params_without_grad) == 0, \
-            f"Parameters with no gradient: {params_without_grad}"
+        missing = [
+            name for name, p in model.named_parameters()
+            if p.requires_grad and p.grad is None
+            and not name.startswith(NO_GRAD_OK)
+        ]
+        assert not missing, f"Parameters with no gradient: {missing}"
 
     def test_no_vanishing_gradients(self, model, device):
         visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
-        target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(
-             visual, map_input, vis_hist, ego,
-            mode="train", trajectory_target=target)
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj.pow(2).mean().backward()
 
-        total = loss + ego_hidden.sum() + sum(f.sum() for f in future)
-        total.backward()
-
-        zero_grad_params = []
-        for name, param in model.named_parameters():
-            if param.requires_grad and param.grad is not None:
-                if param.grad.abs().max() == 0:
-                    if name.startswith("MapEncoder."):
-                        continue
-                    zero_grad_params.append(name)
-
-        assert len(zero_grad_params) == 0, \
-            f"Parameters with all-zero gradients: {zero_grad_params}"
+        zero_grad = [
+            name for name, p in model.named_parameters()
+            if p.requires_grad and p.grad is not None
+            and p.grad.abs().max() == 0
+            and not name.startswith(NO_GRAD_OK)
+        ]
+        assert not zero_grad, f"Parameters with all-zero gradients: {zero_grad}"
 
 
 # ---------------------------------------------------------------------------
-# 5. num_views flexibility — model works with different view counts
+# 5. num_views flexibility — model works with different view counts (BEV only)
 # ---------------------------------------------------------------------------
 
 class TestNumViewsFlexibility:
-    @pytest.mark.parametrize("num_views,fusion_mode", [
-        (1, "concat"), (4, "concat"), (8, "concat"), (12, "concat"),
-        (1, "cross_attn"), (4, "cross_attn"), (8, "cross_attn"), (12, "cross_attn"),
-        (1, "bev"), (4, "bev"), (8, "bev"), (12, "bev"),
-    ])
-    def test_various_num_views(self, build_mock_model, device, num_views, fusion_mode):
-        model = build_mock_model(num_views, fusion_mode, device)
+    @pytest.mark.parametrize("num_views", [1, 4, 8, 12])
+    def test_various_num_views(self, build_mock_model, device, num_views):
+        model = build_mock_model(num_views, device=device)
         visual, map_input, vis_hist, ego = make_inputs(2, num_views, device)
-        target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(
-             visual, map_input, vis_hist, ego,
-            mode="train", trajectory_target=target)
-
-        assert loss.dim() == 0
-        assert ego_hidden.shape == (2, 256)
-        assert all(f.shape == (2, 256, 8, 8) for f in future)
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
+        assert traj.shape == (2, 128)
 
 
 # ---------------------------------------------------------------------------
@@ -173,27 +148,13 @@ class TestNumViewsFlexibility:
 class TestNumericalStability:
     def test_no_nan_in_outputs(self, model, device):
         visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
-        target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(
-             visual, map_input, vis_hist, ego,
-            mode="train", trajectory_target=target)
-
-        assert not torch.isnan(loss), "NaN in planner loss"
-        assert not torch.isnan(ego_hidden).any(), "NaN in ego_hidden"
-        for i, f in enumerate(future):
-            assert not torch.isnan(f).any(), f"NaN in future feature {i}"
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
+        assert not torch.isnan(traj).any(), "NaN in trajectory"
 
     def test_no_inf_in_outputs(self, model, device):
         visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
-        target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(
-             visual, map_input, vis_hist, ego,
-            mode="train", trajectory_target=target)
-
-        assert not torch.isinf(loss), "Inf in planner loss"
-        assert not torch.isinf(ego_hidden).any(), "Inf in ego_hidden"
-        for i, f in enumerate(future):
-            assert not torch.isinf(f).any(), f"Inf in future feature {i}"
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
+        assert not torch.isinf(traj).any(), "Inf in trajectory"
 
     def test_large_input_values(self, model, device):
         """Model should not produce NaN/Inf even with large inputs."""
@@ -201,33 +162,23 @@ class TestNumericalStability:
         map_input = torch.randn(1, 3, 256, 256, device=device) * 100
         vis_hist = torch.randn(1, 896, device=device) * 100
         ego = torch.randn(1, 256, device=device) * 100
-        traj, _, _ = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
 
         assert not torch.isnan(traj).any(), "NaN with large inputs"
         assert not torch.isinf(traj).any(), "Inf with large inputs"
 
 
 # ---------------------------------------------------------------------------
-# Training loop integration — optimizer.step + loss
+# Training loop integration — optimizer.step + loss on the trajectory
 # ---------------------------------------------------------------------------
 
 class TestTrainingLoop:
     def test_optimizer_step_updates_parameters(self, build_mock_model, device):
-        """forward → loss → backward → optimizer.step() must move parameters
-        in EACH submodule, not just somewhere in the model. A grad that only
-        reaches the last layer would still satisfy a "any parameter changed"
-        check; this verifies every major group actually trains.
-
-        The loss is constructed from trajectory + ego_hidden + future so that
-        every group has a path to the loss:
-          - Backbone: feeds image features into FeatureFusion
-          - FeatureFusion: produces BEV / fused feats
-          - TrajectoryPlanner: outputs trajectory + ego_hidden
-          - FutureState: produces future feature pyramid (consumed below)
-        """
-        model = build_mock_model(num_views=7, fusion_mode="concat", device=device)
+        """forward → MSE on trajectory → backward → optimizer.step() must move
+        parameters in every exercised submodule (Backbone, FeatureFusion,
+        TrajectoryPlanner), not just the last layer."""
+        model = build_mock_model(num_views=7, device=device)
         model.train()
-
         optimizer = torch.optim.SGD(model.parameters(), lr=1e-2)
 
         before = {n: p.detach().clone() for n, p in model.named_parameters()
@@ -235,53 +186,47 @@ class TestTrainingLoop:
 
         visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
         target = torch.randn(2, 128, device=device)
-        planner_loss, ego_hidden, future = model(
-            visual, map_input, vis_hist, ego, mode="train", trajectory_target=target)
-        loss = planner_loss + ego_hidden.sum() + sum(f.sum() for f in future)
+        traj = model(visual, map_input, vis_hist, ego, mode="train",
+                     trajectory_target=target)
+        loss = (traj - target).pow(2).mean()
 
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
 
-        groups = ["Backbone", "FeatureFusion", "TrajectoryPlanner", "FutureState"]
-        changed_per_group = {g: False for g in groups}
+        changed = {g: False for g in USED_GROUPS}
         for name, p in model.named_parameters():
-            if not p.requires_grad:
+            if not p.requires_grad or torch.equal(p.detach(), before[name]):
                 continue
-            if torch.equal(p.detach(), before[name]):
-                continue
-            for prefix in groups:
+            for prefix in USED_GROUPS:
                 if name.startswith(prefix + "."):
-                    changed_per_group[prefix] = True
+                    changed[prefix] = True
 
-        unchanged = [g for g, ok in changed_per_group.items() if not ok]
+        unchanged = [g for g, ok in changed.items() if not ok]
         assert not unchanged, \
             f"optimizer.step() did not update any parameter in: {unchanged}"
 
     def test_model_to_loss_backward_integration(self, build_mock_model, device):
-        """Pipe trajectory output into TrajectoryImitationLoss and run backward."""
-        model = build_mock_model(num_views=7, fusion_mode="bev", device=device)
+        """Pipe the trajectory output into an MSE loss and run backward; the
+        upstream Backbone and the downstream TrajectoryPlanner must each see a
+        nonzero gradient (full network depth, not just the last layer)."""
+        model = build_mock_model(num_views=7, device=device)
         model.train()
 
         visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
         target = torch.randn(2, 128, device=device)
-        loss, _, _ = model(visual, map_input, vis_hist, ego,
-                           mode="train", trajectory_target=target)
+        traj = model(visual, map_input, vis_hist, ego, mode="train",
+                     trajectory_target=target)
+        loss = (traj - target).pow(2).mean()
 
-        assert loss.dim() == 0, "planner loss must be a scalar in train mode"
-        assert loss.requires_grad
+        assert loss.dim() == 0 and loss.requires_grad
         assert torch.isfinite(loss), "Loss is non-finite"
-
         loss.backward()
 
-        # Verify gradient propagates through the full network depth, not just
-        # the last layer: both the upstream Backbone and the downstream
-        # TrajectoryPlanner must each see a nonzero grad on at least one param.
-        groups = {"Backbone": False, "TrajectoryPlanner": False}
+        groups = {"Reactive_E2E.Backbone": False,
+                  "Reactive_E2E.TrajectoryPlanner": False}
         for name, p in model.named_parameters():
-            if not p.requires_grad or p.grad is None:
-                continue
-            if p.grad.abs().max() == 0:
+            if not p.requires_grad or p.grad is None or p.grad.abs().max() == 0:
                 continue
             for prefix in groups:
                 if name.startswith(prefix + "."):
@@ -290,15 +235,14 @@ class TestTrainingLoop:
             assert has_grad, f"No parameter in {prefix} received nonzero gradient"
 
 
-
 # ---------------------------------------------------------------------------
 # Full-pipeline robustness
 # ---------------------------------------------------------------------------
 
 class TestFullPipelineRobustness:
     def test_all_zero_inputs_produce_finite_outputs(self, build_mock_model, device):
-        """Zero inputs across all paths must not cause NaN/Inf anywhere downstream."""
-        model = build_mock_model(num_views=7, fusion_mode="concat", device=device)
+        """Zero inputs across all paths must not cause NaN/Inf downstream."""
+        model = build_mock_model(num_views=7, device=device)
         model.eval()
 
         visual = torch.zeros(2, 7, 3, 256, 256, device=device)
@@ -306,38 +250,34 @@ class TestFullPipelineRobustness:
         vis_hist = torch.zeros(2, 896, device=device)
         ego = torch.zeros(2, 256, device=device)
 
-        traj, ego_hidden, _ = model(visual, map_input, vis_hist, ego, mode="infer")
-
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
         assert torch.isfinite(traj).all(), "NaN/Inf in trajectory with zero inputs"
-        assert torch.isfinite(ego_hidden).all(), "NaN/Inf in ego_hidden with zero inputs"
 
     def test_camera_params_none_then_valid_switching(self, build_mock_model, device):
         """A BEV-fusion model must accept both None and valid camera_params on the
         same instance, producing finite and distinct outputs."""
-        model = build_mock_model(num_views=7, fusion_mode="bev", device=device)
+        model = build_mock_model(num_views=7, device=device)
         model.eval()
 
-        visual, map_input, vis_hist, ego = make_inputs(1, 7, device, include_camera_params=False)
+        visual, map_input, vis_hist, ego = make_inputs(1, 7, device)
 
-        traj_none, _, _ = model(visual, map_input, vis_hist, ego, mode="infer",
-                                camera_params=None)
+        traj_none = model(visual, map_input, vis_hist, ego, mode="infer",
+                          camera_params=None)
         cam_params = torch.randn(1, 7, 3, 4, device=device)
-        traj_cam, _, _ = model(visual, map_input, vis_hist, ego, mode="infer",
-                                camera_params=cam_params)
+        traj_cam = model(visual, map_input, vis_hist, ego, mode="infer",
+                         camera_params=cam_params)
 
         assert torch.isfinite(traj_none).all(), "NaN/Inf with camera_params=None"
         assert torch.isfinite(traj_cam).all(), "NaN/Inf with valid camera_params"
         assert not torch.allclose(traj_none, traj_cam, atol=1e-5), \
-            "camera_params None vs valid produced identical outputs — projection has no effect"
+            "camera_params None vs valid produced identical outputs"
 
     def test_batch_size_one_smoke(self, build_mock_model, device):
-        """End-to-end forward must work at batch_size=1 with correct shapes and no NaN."""
-        model = build_mock_model(num_views=7, fusion_mode="concat", device=device)
+        """End-to-end forward must work at batch_size=1 with correct shape."""
+        model = build_mock_model(num_views=7, device=device)
         model.eval()
         visual, map_input, vis_hist, ego = make_inputs(1, 7, device)
-        traj, ego_hidden, _ = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
 
         assert traj.shape == (1, 128)
-        assert ego_hidden.shape == (1, 256)
         assert torch.isfinite(traj).all()
-        assert torch.isfinite(ego_hidden).all()

--- a/Model/tests/test_bezier_planner.py
+++ b/Model/tests/test_bezier_planner.py
@@ -1,11 +1,10 @@
-"""Unit tests for the optional Bezier trajectory planner.
+"""Unit tests for the Bezier trajectory planner.
 
-These tests exercise the planner in isolation (no backbone) and verify:
-  - the output contract matches TrajectoryPlanner (trajectory + ego_hidden),
-  - the Bezier expansion yields low-jerk control-signal profiles by
-    construction (much smoother than raw per-step regression),
-  - the registry resolves "bezier" and rejects unknown names,
-  - shapes are configurable and gradients flow to all parameters.
+Post-refactor (#88): the planner ``forward`` performs inference and returns
+ONLY the trajectory ``[B, num_timesteps*num_signals]`` (no ego_hidden), and the
+per-planner ``compute_planner_loss`` was removed — the training objective lives
+in the training loop. AutoE2E.forward returns the trajectory directly. Only the
+``bev`` view fusion and the ``bezier``/``flow_matching`` planners remain.
 """
 
 import pytest
@@ -17,6 +16,10 @@ from model_components.trajectory_planning import (
     BezierPlanner,
     build_planner,
 )
+
+EMBED_DIM = 256
+EGO_DIM = 256
+VIS_DIM = 896
 
 
 class _MockBackbone(nn.Module):
@@ -41,11 +44,6 @@ class _MockBackbone(nn.Module):
         return outs
 
 
-EMBED_DIM = 256
-EGO_DIM = 256
-VIS_DIM = 896
-
-
 def _make_inputs(batch_size, device, h=8, w=8):
     bev = torch.randn(batch_size, EMBED_DIM, h, w, device=device)
     visual_history = torch.randn(batch_size, VIS_DIM, device=device)
@@ -53,15 +51,24 @@ def _make_inputs(batch_size, device, h=8, w=8):
     return bev, visual_history, egomotion_history
 
 
+def _autoe2e_bezier(device):
+    """Build an AutoE2E with the mock backbone and the bezier planner."""
+    from unittest.mock import patch
+
+    from model_components.auto_e2e import AutoE2E
+    with patch("model_components.reactive_e2e.Backbone", _MockBackbone):
+        model = AutoE2E(num_views=8, view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
+                        planner_mode="bezier").to(device)
+    return model
+
+
 def test_output_contract_shapes(device):
     planner = BezierPlanner(embed_dim=EMBED_DIM).to(device)
     bev, vis, ego = _make_inputs(4, device)
-    trajectory, ego_hidden = planner(bev, vis, ego)
+    trajectory = planner(bev, vis, ego)
     # 64 timesteps x 2 signals (accel, curvature)
     assert trajectory.shape == (4, 128)
-    assert ego_hidden.shape == (4, EMBED_DIM)
     assert torch.isfinite(trajectory).all()
-    assert torch.isfinite(ego_hidden).all()
 
 
 def test_is_base_planner_subclass():
@@ -72,7 +79,7 @@ def test_registry_builds_bezier(device):
     planner = build_planner("bezier", embed_dim=EMBED_DIM).to(device)
     assert isinstance(planner, BezierPlanner)
     bev, vis, ego = _make_inputs(2, device)
-    trajectory, ego_hidden = planner(bev, vis, ego)
+    trajectory = planner(bev, vis, ego)
     assert trajectory.shape == (2, 128)
 
 
@@ -86,7 +93,7 @@ def test_resolution_invariant_to_bev_size(device):
     planner = BezierPlanner(embed_dim=EMBED_DIM).to(device)
     for h, w in [(8, 8), (45, 30), (7, 7)]:
         bev, vis, ego = _make_inputs(2, device, h=h, w=w)
-        trajectory, _ = planner(bev, vis, ego)
+        trajectory = planner(bev, vis, ego)
         assert trajectory.shape == (2, 128)
 
 
@@ -95,7 +102,7 @@ def test_configurable_timesteps_and_signals(device):
         embed_dim=EMBED_DIM, num_timesteps=32, num_signals=3, num_controls=4
     ).to(device)
     bev, vis, ego = _make_inputs(2, device)
-    trajectory, _ = planner(bev, vis, ego)
+    trajectory = planner(bev, vis, ego)
     assert trajectory.shape == (2, 32 * 3)
 
 
@@ -122,7 +129,7 @@ def test_smoothness_lower_jerk_than_raw_regression(device):
     planner = BezierPlanner(embed_dim=EMBED_DIM, num_timesteps=64,
                             num_signals=2, num_controls=5).to(device)
     bev, vis, ego = _make_inputs(8, device)
-    trajectory, _ = planner(bev, vis, ego)
+    trajectory = planner(bev, vis, ego)
     traj = trajectory.view(8, 64, 2)
 
     # First-difference variance per signal channel (jerk proxy).
@@ -140,41 +147,26 @@ def test_smoothness_lower_jerk_than_raw_regression(device):
 
 
 def test_autoe2e_with_bezier_planner_end_to_end(device):
-    """AutoE2E must accept planner='bezier' and keep the (trajectory,
-    ego_hidden, future) 3-tuple contract intact."""
-    from unittest.mock import patch
-
-    from model_components.auto_e2e import AutoE2E
+    """AutoE2E must accept planner='bezier' and return the trajectory."""
     from model_components.trajectory_planning import BezierPlanner
 
-    with patch("model_components.auto_e2e.Backbone", _MockBackbone):
-        model = AutoE2E(num_views=8, fusion_mode="concat",
-                        planner_mode="bezier").to(device)
-
-    assert isinstance(model.TrajectoryPlanner, BezierPlanner)
+    model = _autoe2e_bezier(device)
+    assert isinstance(model.Reactive_E2E.TrajectoryPlanner, BezierPlanner)
 
     x = torch.randn(2, 8, 3, 256, 256, device=device)
     map_input = torch.randn(2, 3, 256, 256, device=device)
     vis = torch.randn(2, 896, device=device)
     ego = torch.randn(2, 256, device=device)
-    trajectory, ego_hidden, future = model(x, map_input, vis, ego, mode="infer")
+    trajectory = model(x, map_input, vis, ego, mode="infer")
 
     assert trajectory.shape == (2, 128)
-    assert ego_hidden.shape == (2, 256)
-    assert future is None  # infer mode returns None for future visual features
+    assert torch.isfinite(trajectory).all()
 
 
 def test_autoe2e_with_bezier_planner_train_mode(device):
-    """Full forward pass in train mode: AutoE2E -> BezierPlanner.compute_planner_loss
-    returns a SCALAR loss, future features are produced, and gradients flow back
-    through the planner. This exercises the actual layers end-to-end."""
-    from unittest.mock import patch
-
-    from model_components.auto_e2e import AutoE2E
-
-    with patch("model_components.auto_e2e.Backbone", _MockBackbone):
-        model = AutoE2E(num_views=8, fusion_mode="concat",
-                        planner_mode="bezier").to(device)
+    """Full forward pass in train mode returns the trajectory; an MSE on it must
+    backprop into the planner (exercises the actual layers end-to-end)."""
+    model = _autoe2e_bezier(device)
 
     x = torch.randn(2, 8, 3, 256, 256, device=device)
     map_input = torch.randn(2, 3, 256, 256, device=device)
@@ -182,54 +174,31 @@ def test_autoe2e_with_bezier_planner_train_mode(device):
     ego = torch.randn(2, 256, device=device)
     target = torch.randn(2, 128, device=device)
 
-    loss, ego_hidden, future = model(
-        x, map_input, vis, ego, mode="train", trajectory_target=target
-    )
+    trajectory = model(x, map_input, vis, ego, mode="train")
+    assert trajectory.shape == (2, 128)
 
-    assert loss.ndim == 0, "train mode must return a scalar planner loss"
-    assert torch.isfinite(loss) and loss.item() >= 0.0
-    assert ego_hidden.shape == (2, 256)
-    assert future is not None  # train mode produces future visual features
-
-    loss.backward()
-    assert any(p.grad is not None for p in model.TrajectoryPlanner.parameters()), \
-        "planner must receive gradient from compute_planner_loss"
+    (trajectory - target).pow(2).mean().backward()
+    assert any(p.grad is not None
+               for p in model.Reactive_E2E.TrajectoryPlanner.parameters()), \
+        "planner must receive gradient from a trajectory loss"
 
 
-def test_compute_planner_loss_delegates_to_shared_loss(device):
-    """compute_planner_loss must use the shared TrajectoryImitationLoss
-    (losses/ module), not an inline loss, and honour the (loss, ego_hidden)
-    BasePlanner contract."""
-    from model_components.losses.trajectory_loss import TrajectoryImitationLoss
-
-    planner = BezierPlanner(embed_dim=EMBED_DIM).to(device)
-    assert isinstance(planner.trajectory_loss, TrajectoryImitationLoss)
-
-    bev, vis, ego = _make_inputs(2, device)
-    target = torch.randn(2, 128, device=device)
-    loss, ego_hidden = planner.compute_planner_loss(bev, vis, ego, target)
-    assert loss.ndim == 0 and torch.isfinite(loss)
-    assert ego_hidden.shape == (2, EMBED_DIM)
-    loss.backward()  # loss must be differentiable through the planner
-
-
-def test_autoe2e_default_planner_unchanged(device):
-    """Default planner must remain the autoregressive TrajectoryPlanner."""
+def test_autoe2e_default_planner_is_bezier(device):
+    """The default planner is the Bezier planner (GRU was removed in #86)."""
     from unittest.mock import patch
 
     from model_components.auto_e2e import AutoE2E
-    from model_components.trajectory_planning import GRUPlanner as TrajectoryPlanner
-
-    with patch("model_components.auto_e2e.Backbone", _MockBackbone):
-        model = AutoE2E(num_views=8, fusion_mode="concat").to(device)
-    assert isinstance(model.TrajectoryPlanner, TrajectoryPlanner)
+    with patch("model_components.reactive_e2e.Backbone", _MockBackbone):
+        model = AutoE2E(num_views=8,
+                        view_fusion_kwargs={"bev_h": 8, "bev_w": 8}).to(device)
+    assert isinstance(model.Reactive_E2E.TrajectoryPlanner, BezierPlanner)
 
 
 def test_gradients_flow_to_all_parameters(device):
     planner = BezierPlanner(embed_dim=EMBED_DIM).to(device)
     bev, vis, ego = _make_inputs(2, device)
-    trajectory, ego_hidden = planner(bev, vis, ego)
-    (trajectory.pow(2).mean() + ego_hidden.pow(2).mean()).backward()
+    trajectory = planner(bev, vis, ego)
+    trajectory.pow(2).mean().backward()
     for name, p in planner.named_parameters():
         assert p.grad is not None, f"No gradient for {name}"
         assert torch.isfinite(p.grad).all(), f"Non-finite grad for {name}"

--- a/Model/tests/test_causal_reasoning.py
+++ b/Model/tests/test_causal_reasoning.py
@@ -194,40 +194,34 @@ def test_class_weights_change_loss():
     assert not torch.isclose(plain, weighted)
 
 
-def test_autoe2e_contract_untouched_with_manual_integration(device):
-    """Manual cascade integration: run AutoE2E (mock backbone), feed
-    ego_hidden into the reasoning head. The AutoE2E 3-tuple contract is
-    untouched and gradients reach the trunk through the auxiliary loss."""
+def test_autoe2e_contract_and_reasoning_head(device):
+    """Post-refactor (#86/#88) AutoE2E.forward returns the trajectory only — the
+    planner's internal ego embedding is no longer surfaced. This verifies the
+    new contract, and exercises the (independent) CausalReasoningModule on a
+    256-d embedding so its auxiliary loss stays differentiable."""
     from unittest.mock import patch
 
     from model_components.auto_e2e import AutoE2E
 
-    with patch("model_components.auto_e2e.Backbone", _MockBackbone):
-        model = AutoE2E(num_views=8, fusion_mode="concat").to(device)
-    head = CausalReasoningModule(embed_dim=EMBED_DIM).to(device)
+    with patch("model_components.reactive_e2e.Backbone", _MockBackbone):
+        model = AutoE2E(num_views=8,
+                        view_fusion_kwargs={"bev_h": 8, "bev_w": 8}).to(device)
 
     x = torch.randn(2, 8, 3, 256, 256, device=device)
     map_input = torch.randn(2, 3, 256, 256, device=device)
     vis = torch.randn(2, 896, device=device)
     ego = torch.randn(2, 256, device=device)
-    # The signature is: forward(camera_tiles, map_input, visual_history, egomotion_history)
+    # forward(camera_tiles, map_input, visual_history, egomotion_history)
     out = model(x, map_input, vis, ego, mode="infer")
 
-    # Default contract: exactly a 3-tuple (trajectory, ego_hidden, future)
-    assert isinstance(out, tuple) and len(out) == 3
-    trajectory, ego_hidden, future = out
-    assert trajectory.shape == (2, 128)
-    assert ego_hidden.shape == (2, 256)
-    assert future is None  # infer mode returns no future visual features (contract)
+    # New contract: a single trajectory tensor [B, num_timesteps*num_signals].
+    assert torch.is_tensor(out) and out.shape == (2, 128)
 
-    # Auxiliary head consumes ego_hidden; gradient reaches AutoE2E trunk.
-    _, decision_logits = head(ego_hidden)
+    # The auxiliary reasoning head consumes a 256-d embedding; its consistency
+    # loss must remain differentiable wrt that embedding.
+    head = CausalReasoningModule(embed_dim=EMBED_DIM).to(device)
+    embedding = torch.randn(2, EMBED_DIM, device=device, requires_grad=True)
+    _, decision_logits = head(embedding)
     labels = torch.randint(0, 5, (2,), device=device)
     causal_consistency_loss(decision_logits, labels).backward()
-    trunk_grads = [
-        p.grad for p in model.TrajectoryPlanner.parameters()
-        if p.grad is not None
-    ]
-    assert len(trunk_grads) > 0, (
-        "Auxiliary loss must backpropagate into the shared trunk"
-    )
+    assert embedding.grad is not None and torch.isfinite(embedding.grad).all()

--- a/Model/tests/test_feature_fusion.py
+++ b/Model/tests/test_feature_fusion.py
@@ -7,7 +7,8 @@ from model_components.feature_fusion import FeatureFusion
 
 class TestFeatureFusionComponent:
     def test_output_shape(self, device):
-        fusion = FeatureFusion(num_views=8, fusion_mode="concat").to(device)
+        fusion = FeatureFusion(num_views=8, fusion_mode="bev",
+                               view_fusion_kwargs={"bev_h": 8, "bev_w": 8}).to(device)
         features = [
             torch.randn(16, 96, 64, 64, device=device),
             torch.randn(16, 192, 32, 32, device=device),
@@ -19,7 +20,8 @@ class TestFeatureFusionComponent:
 
     def test_view_reduction_changes_output(self, device):
         """Verify that view_reduce is not identity (actually mixes views)."""
-        fusion = FeatureFusion(num_views=8, fusion_mode="concat").to(device)
+        fusion = FeatureFusion(num_views=8, fusion_mode="bev",
+                               view_fusion_kwargs={"bev_h": 8, "bev_w": 8}).to(device)
         fusion.eval()
 
         features_a = [
@@ -43,7 +45,8 @@ class TestFeatureFusionWithSwinChannels:
         at their natural spatial resolutions and produce the expected fused shape."""
         backbone_channels = 96 + 192 + 384 + 768  # 1440
         fusion = FeatureFusion(
-            num_views=8, backbone_channels=backbone_channels, fusion_mode="concat",
+            num_views=8, backbone_channels=backbone_channels, fusion_mode="bev",
+            view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
         ).to(device)
 
         # Per-stage Swin spatial dims for a 256x256 input

--- a/Model/tests/test_history_encoder.py
+++ b/Model/tests/test_history_encoder.py
@@ -189,28 +189,27 @@ def test_autoe2e_consumes_one_hz_temporal_memory():
 
     from model_components.auto_e2e import AutoE2E
 
-    with patch("model_components.auto_e2e.Backbone", _MockBackbone):
-        model = AutoE2E(num_views=8, fusion_mode="concat",
+    with patch("model_components.reactive_e2e.Backbone", _MockBackbone):
+        model = AutoE2E(num_views=8, view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
                         temporal_memory_mode="one_hz")
 
     x = torch.randn(2, 8, 3, 256, 256)
     map_input = torch.randn(2, 3, 256, 256)
     vis = torch.randn(2, 20, 896)   # [B, T, visual_dim] — sequence form
     ego = torch.randn(2, 20, 256)   # [B, T, egomotion_dim]
-    target = torch.randn(2, 128)
 
-    # Train: scalar loss + future; gradient flows back into TemporalMemory.
-    loss, ego_hidden, future = model(x, map_input, vis, ego,
-                                     mode="train", trajectory_target=target)
-    assert loss.ndim == 0 and torch.isfinite(loss)
-    assert ego_hidden.shape == (2, 256) and future is not None
-    loss.backward()
-    assert any(p.grad is not None for p in model.TemporalMemory.parameters()), \
+    # Train: forward returns the trajectory; an MSE on it must backprop into
+    # TemporalMemory (its compressed context is consumed by the planner).
+    traj = model(x, map_input, vis, ego, mode="train")
+    assert traj.shape == (2, 128) and torch.isfinite(traj).all()
+    traj.pow(2).mean().backward()
+    assert any(p.grad is not None
+               for p in model.Reactive_E2E.TemporalMemory.parameters()), \
         "compressed temporal context must be consumed by the planner (grad must reach TemporalMemory)"
 
-    # Infer: 3-tuple with trajectory + None future.
-    traj, ego_hidden2, future2 = model(x, map_input, vis, ego, mode="infer")
-    assert traj.shape == (2, 128) and future2 is None
+    # Infer: trajectory only.
+    traj2 = model(x, map_input, vis, ego, mode="infer")
+    assert traj2.shape == (2, 128)
 
 
 def test_autoe2e_default_no_memory_passthrough():
@@ -221,13 +220,14 @@ def test_autoe2e_default_no_memory_passthrough():
     from model_components.auto_e2e import AutoE2E
     from model_components.temporal_memory import NoMemory
 
-    with patch("model_components.auto_e2e.Backbone", _MockBackbone):
-        model = AutoE2E(num_views=8, fusion_mode="concat")  # default no_memory
-    assert isinstance(model.TemporalMemory, NoMemory)
+    with patch("model_components.reactive_e2e.Backbone", _MockBackbone):
+        model = AutoE2E(num_views=8,
+                        view_fusion_kwargs={"bev_h": 8, "bev_w": 8})  # default no_memory
+    assert isinstance(model.Reactive_E2E.TemporalMemory, NoMemory)
 
     x = torch.randn(2, 8, 3, 256, 256)
     map_input = torch.randn(2, 3, 256, 256)
     vis = torch.randn(2, 896)       # flat history (default contract)
     ego = torch.randn(2, 256)
-    traj, ego_hidden, future = model(x, map_input, vis, ego, mode="infer")
-    assert traj.shape == (2, 128) and ego_hidden.shape == (2, 256) and future is None
+    traj = model(x, map_input, vis, ego, mode="infer")
+    assert traj.shape == (2, 128)

--- a/Model/tests/test_integration.py
+++ b/Model/tests/test_integration.py
@@ -29,33 +29,20 @@ class TestFullBackboneIntegration:
     """
 
     def test_full_forward_pass(self, full_model, device):
-        """Smoke test: full model forward produces expected output shapes."""
+        """Smoke test: full model forward produces the expected trajectory shape."""
         visual, map_input, vis_hist, ego = make_inputs(1, 7, device)
-        target = torch.randn(1, 128, device=device)
-        loss, ego_hidden, future = full_model(
-             visual, map_input, vis_hist, ego,
-            mode="train", trajectory_target=target)
 
-        assert loss.dim() == 0
-        assert ego_hidden.shape == (1, 256)
-        assert len(future) == 4
-        for f in future:
-            assert f.shape == (1, 256, 8, 8)
-
-        traj, _, _ = full_model(visual, map_input, vis_hist, ego, mode="infer")
+        traj = full_model(visual, map_input, vis_hist, ego, mode="train")
         assert traj.shape == (1, 128)
+
+        traj2 = full_model(visual, map_input, vis_hist, ego, mode="infer")
+        assert traj2.shape == (1, 128)
 
     def test_full_forward_no_nan(self, full_model, device):
         """Full pipeline must not produce NaN with real backbone weights."""
         visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
-        target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = full_model(visual, map_input, vis_hist, ego,
-                                              mode="train", trajectory_target=target)
-
-        assert not torch.isnan(loss)
-        assert not torch.isnan(ego_hidden).any()
-        for f in future:
-            assert not torch.isnan(f).any()
+        traj = full_model(visual, map_input, vis_hist, ego, mode="train")
+        assert not torch.isnan(traj).any()
 
 
 @pytest.mark.integration
@@ -68,31 +55,24 @@ class TestResNet50Backbone:
         from model_components.auto_e2e import AutoE2E
         try:
             model = AutoE2E(
-                backbone="res_net_50", num_views=7, fusion_mode="concat",
+                backbone="res_net_50", num_views=7,
+                view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
                 is_pretrained=False,
             ).to(device)
         except (FileNotFoundError, OSError) as e:
             pytest.skip(f"Backbone construction failed: {e}")
 
         # Dynamic backbone_channels = sum of all 5 ResNet50 stages = 3904
-        assert model.Backbone.backbone_channels == 64 + 256 + 512 + 1024 + 2048
+        assert model.Reactive_E2E.Backbone.backbone_channels == \
+            64 + 256 + 512 + 1024 + 2048
 
         visual, map_input, vis_hist, ego = make_inputs(1, 7, device)
-        target = torch.randn(1, 128, device=device)
-        loss, ego_hidden, future = model(
-            visual, map_input, vis_hist, ego, mode="train", trajectory_target=target)
 
-        assert loss.dim() == 0
-        assert ego_hidden.shape == (1, 256)
-        assert len(future) == 4
-        for f in future:
-            assert f.shape == (1, 256, 8, 8)
-        assert torch.isfinite(loss)
-        assert torch.isfinite(ego_hidden).all()
+        traj = model(visual, map_input, vis_hist, ego, mode="train")
+        assert traj.shape == (1, 128) and torch.isfinite(traj).all()
 
-        traj, _, _ = model(visual, map_input, vis_hist, ego, mode="infer")
-        assert traj.shape == (1, 128)
-        assert torch.isfinite(traj).all()
+        traj2 = model(visual, map_input, vis_hist, ego, mode="infer")
+        assert traj2.shape == (1, 128) and torch.isfinite(traj2).all()
 
 
 class TestRealArchitectureSmoke:
@@ -113,25 +93,18 @@ class TestRealArchitectureSmoke:
     def test_real_backbone_forward(self, backbone, device):
         from model_components.auto_e2e import AutoE2E
         model = AutoE2E(
-            backbone=backbone, num_views=7, fusion_mode="concat",
+            backbone=backbone, num_views=7,
+            view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
             is_pretrained=False,
         ).to(device)
 
-        assert model.Backbone.backbone_channels == self.EXPECTED_CHANNELS[backbone]
+        assert model.Reactive_E2E.Backbone.backbone_channels == \
+            self.EXPECTED_CHANNELS[backbone]
 
         visual, map_input, vis_hist, ego = make_inputs(1, 7, device)
-        target = torch.randn(1, 128, device=device)
 
-        loss, ego_hidden, future = model(
-            visual, map_input, vis_hist, ego, mode="train",
-            trajectory_target=target)
-        assert loss.dim() == 0
-        assert ego_hidden.shape == (1, 256)
-        assert len(future) == 4
-        for f in future:
-            assert f.shape == (1, 256, 8, 8)
-        assert torch.isfinite(loss)
+        traj = model(visual, map_input, vis_hist, ego, mode="train")
+        assert traj.shape == (1, 128) and torch.isfinite(traj).all()
 
-        traj, _, _ = model(visual, map_input, vis_hist, ego, mode="infer")
-        assert traj.shape == (1, 128)
-        assert torch.isfinite(traj).all()
+        traj2 = model(visual, map_input, vis_hist, ego, mode="infer")
+        assert traj2.shape == (1, 128) and torch.isfinite(traj2).all()

--- a/Model/tests/test_map_encoder.py
+++ b/Model/tests/test_map_encoder.py
@@ -254,8 +254,8 @@ class TestAutoE2EMapIntegration:
         vis_hist = torch.randn(2, 896, device=device)
         ego = torch.randn(2, 256, device=device)
 
-        traj_zero, _, _ = model(visual, map_zero, vis_hist, ego, mode="infer")
-        traj_rand, _, _ = model(visual, map_rand, vis_hist, ego, mode="infer")
+        traj_zero = model(visual, map_zero, vis_hist, ego, mode="infer")
+        traj_rand = model(visual, map_rand, vis_hist, ego, mode="infer")
 
         assert torch.allclose(traj_zero, traj_rand, atol=1e-5), \
             "With alpha=0, different map inputs should produce identical trajectories"
@@ -265,14 +265,14 @@ class TestAutoE2EMapIntegration:
         model = self._make_model(build_mock_model, device, map_fusion_mode="residual")
         model.eval()
         with torch.no_grad():
-            model.MapBEVFusion.alpha.fill_(1.0)
+            model.Reactive_E2E.MapBEVFusion.alpha.fill_(1.0)
 
         visual = torch.randn(2, 7, 3, 256, 256, device=device)
         vis_hist = torch.randn(2, 896, device=device)
         ego = torch.randn(2, 256, device=device)
 
-        traj_a, _, _ = model(visual, torch.randn(2, 3, _MAP_H, _MAP_W, device=device), vis_hist, ego, mode="infer")
-        traj_b, _, _ = model(visual, torch.randn(2, 3, _MAP_H, _MAP_W, device=device), vis_hist, ego, mode="infer")
+        traj_a = model(visual, torch.randn(2, 3, _MAP_H, _MAP_W, device=device), vis_hist, ego, mode="infer")
+        traj_b = model(visual, torch.randn(2, 3, _MAP_H, _MAP_W, device=device), vis_hist, ego, mode="infer")
 
         assert not torch.allclose(traj_a, traj_b, atol=1e-5), \
             "With alpha=1, different map inputs should produce different trajectories"
@@ -285,12 +285,11 @@ class TestAutoE2EMapIntegration:
         map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
         vis_hist = torch.randn(2, 896, device=device)
         ego = torch.randn(2, 256, device=device)
-        target = torch.randn(2, 128, device=device)
 
-        loss, ego_hidden, future = model(visual, map_input, vis_hist, ego, mode="train", trajectory_target=target)
-        (loss + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
+        traj = model(visual, map_input, vis_hist, ego, mode="train")
+        traj.pow(2).mean().backward()
 
-        no_grad = [n for n, p in model.MapEncoder.named_parameters()
+        no_grad = [n for n, p in model.Reactive_E2E.MapEncoder.named_parameters()
                    if p.requires_grad and p.grad is None]
         assert not no_grad, f"MapEncoder params without grad: {no_grad}"
 
@@ -299,38 +298,36 @@ class TestAutoE2EMapIntegration:
         model = self._make_model(build_mock_model, device, map_fusion_mode="residual")
         model.train()
         with torch.no_grad():
-            model.MapBEVFusion.alpha.fill_(0.1)
+            model.Reactive_E2E.MapBEVFusion.alpha.fill_(0.1)
 
         visual = torch.randn(2, 7, 3, 256, 256, device=device)
         map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
         vis_hist = torch.randn(2, 896, device=device)
         ego = torch.randn(2, 256, device=device)
-        target = torch.randn(2, 128, device=device)
 
-        loss, ego_hidden, future = model(visual, map_input, vis_hist, ego, mode="train", trajectory_target=target)
-        (loss + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
+        traj = model(visual, map_input, vis_hist, ego, mode="train")
+        traj.pow(2).mean().backward()
 
-
-        assert model.MapBEVFusion.alpha.grad is not None, "alpha has no gradient"
-        assert model.MapBEVFusion.alpha.grad.abs().max() > 0, "alpha gradient is all-zero"
+        alpha = model.Reactive_E2E.MapBEVFusion.alpha
+        assert alpha.grad is not None, "alpha has no gradient"
+        assert alpha.grad.abs().max() > 0, "alpha gradient is all-zero"
 
     def test_map_encoder_receives_gradients_when_alpha_nonzero(self, build_mock_model, device):
         """Only for residual fusion: MapEncoder parameters must receive gradients once alpha is non-zero."""
         model = self._make_model(build_mock_model, device, map_fusion_mode="residual")
         model.train()
         with torch.no_grad():
-            model.MapBEVFusion.alpha.fill_(0.1)
+            model.Reactive_E2E.MapBEVFusion.alpha.fill_(0.1)
 
         visual = torch.randn(2, 7, 3, 256, 256, device=device)
         map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
         vis_hist = torch.randn(2, 896, device=device)
         ego = torch.randn(2, 256, device=device)
-        target = torch.randn(2, 128, device=device)
 
-        loss, ego_hidden, future = model(visual, map_input, vis_hist, ego, mode="train", trajectory_target=target)
-        (loss + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
+        traj = model(visual, map_input, vis_hist, ego, mode="train")
+        traj.pow(2).mean().backward()
 
-        no_grad = [n for n, p in model.MapEncoder.named_parameters()
+        no_grad = [n for n, p in model.Reactive_E2E.MapEncoder.named_parameters()
                 if p.requires_grad and p.grad is None]
         assert not no_grad, f"MapEncoder params without grad after alpha=0.1: {no_grad}"
 
@@ -340,15 +337,14 @@ class TestAutoE2EMapIntegration:
         map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
         vis_hist = torch.randn(2, 896, device=device)
         ego = torch.randn(2, 256, device=device)
-        traj, ego_hidden, _ = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
         assert traj.shape == (2, 128)
-        assert ego_hidden.shape == (2, 256)
         assert torch.isfinite(traj).all()
 
     def test_map_encoder_attribute_exists(self, build_mock_model, device):
         model = self._make_model(build_mock_model, device)
-        assert hasattr(model, "MapEncoder"), "AutoE2E missing MapEncoder attribute"
-        assert hasattr(model, "MapBEVFusion"), "AutoE2E missing MapBEVFusion attribute"
+        assert hasattr(model.Reactive_E2E, "MapEncoder"), "Reactive_E2E missing MapEncoder attribute"
+        assert hasattr(model.Reactive_E2E, "MapBEVFusion"), "Reactive_E2E missing MapBEVFusion attribute"
 
     def test_invalid_map_fusion_mode_raises(self, build_mock_model, device):
         with pytest.raises(ValueError, match="Unknown map_fusion_mode"):

--- a/Model/tests/test_trajectory_planning.py
+++ b/Model/tests/test_trajectory_planning.py
@@ -52,36 +52,14 @@ class TestFlowMatchingPlanner:
         assert target_velocity.shape == (4, 128)
         assert (t >= 0).all() and (t <= 1).all()
 
-    def test_compute_planner_loss_end_to_end(self, device):
-        """The canonical training-loop pattern must work:
-        compute_planner_loss returns a scalar loss + ego_hidden, and
-        backprop reaches the BEV input."""
-        planner = FlowMatchingPlanner(embed_dim=256).to(device)
-        planner.train()
-        bev = torch.randn(2, 256, 8, 8, device=device, requires_grad=True)
-        vis_hist = torch.randn(2, 896, device=device)
-        ego = torch.randn(2, 256, device=device)
-        target = torch.randn(2, 128, device=device)
-
-        loss, ego_hidden = planner.compute_planner_loss(
-            bev, vis_hist, ego, target,
-        )
-        assert loss.dim() == 0
-        assert ego_hidden.shape == (2, 256)
-        assert torch.isfinite(loss)
-
-        loss.backward()
-        assert bev.grad is not None and bev.grad.abs().max() > 0
-
     def test_inference_forward_returns_trajectory_shape(self, device):
         planner = FlowMatchingPlanner(embed_dim=256).to(device)
         planner.eval()
         bev = torch.randn(2, 256, 8, 8, device=device)
         vis_hist = torch.randn(2, 896, device=device)
         ego = torch.randn(2, 256, device=device)
-        traj, ego_hidden = planner(bev, vis_hist, ego)
+        traj = planner(bev, vis_hist, ego)
         assert traj.shape == (2, 128)
-        assert ego_hidden.shape == (2, 256)
 
     def test_inference_output_is_finite(self, device):
         planner = FlowMatchingPlanner(embed_dim=256, num_inference_steps=10).to(device)
@@ -89,7 +67,7 @@ class TestFlowMatchingPlanner:
         bev = torch.randn(1, 256, 8, 8, device=device)
         vis_hist = torch.randn(1, 896, device=device)
         ego = torch.randn(1, 256, device=device)
-        traj, _ = planner(bev, vis_hist, ego)
+        traj = planner(bev, vis_hist, ego)
         assert torch.isfinite(traj).all()
 
     def _v_theta(self, planner, bev, vis_hist, ego, u_t, t):
@@ -168,20 +146,19 @@ class TestFlowMatchingPlanner:
         torch.manual_seed(123)
         x0 = torch.randn(1, 128, device=device)
         torch.manual_seed(123)  # same seed — planner draws an identical x0 inside
-        traj, _ = planner(bev, vis_hist, ego)
+        traj = planner(bev, vis_hist, ego)
         assert not torch.allclose(traj, x0, atol=1e-3), \
             "Inference output equals the input noise — ODE did not advance"
 
     def test_gradient_flows(self, device):
+        """Gradients from the integrated trajectory must reach the BEV input
+        and the conditioning (visual_history, egomotion)."""
         planner = FlowMatchingPlanner(embed_dim=256).to(device)
         bev = torch.randn(1, 256, 8, 8, device=device, requires_grad=True)
         vis_hist = torch.randn(1, 896, device=device, requires_grad=True)
         ego = torch.randn(1, 256, device=device, requires_grad=True)
-        target = torch.randn(1, 128, device=device)
-        loss, ego_hidden = planner.compute_planner_loss(
-            bev, vis_hist, ego, target,
-        )
-        (loss + ego_hidden.sum()).backward()
+        traj = planner(bev, vis_hist, ego)
+        traj.pow(2).mean().backward()
         assert bev.grad is not None and bev.grad.abs().max() > 0
         assert vis_hist.grad is not None and vis_hist.grad.abs().max() > 0
         assert ego.grad is not None and ego.grad.abs().max() > 0
@@ -199,28 +176,14 @@ class TestFlowMatchingPlanner:
         gen_b = torch.Generator(device=device).manual_seed(42)
         gen_c = torch.Generator(device=device).manual_seed(7)
 
-        traj_a, _ = planner(bev, vis_hist, ego, generator=gen_a)
-        traj_b, _ = planner(bev, vis_hist, ego, generator=gen_b)
-        traj_c, _ = planner(bev, vis_hist, ego, generator=gen_c)
+        traj_a = planner(bev, vis_hist, ego, generator=gen_a)
+        traj_b = planner(bev, vis_hist, ego, generator=gen_b)
+        traj_c = planner(bev, vis_hist, ego, generator=gen_c)
 
         assert torch.equal(traj_a, traj_b), \
             "same generator seed must produce identical inference trajectories"
         assert not torch.allclose(traj_a, traj_c), \
             "different generator seeds must produce different trajectories"
-
-    def test_compute_planner_loss_wrong_target_shape_raises(self, device):
-        planner = FlowMatchingPlanner(embed_dim=256).to(device)
-        bev = torch.randn(2, 256, 8, 8, device=device)
-        vis_hist = torch.randn(2, 896, device=device)
-        ego = torch.randn(2, 256, device=device)
-        # Wrong batch dim
-        bad_target = torch.randn(3, 128, device=device)
-        with pytest.raises(ValueError, match="trajectory_target must have shape"):
-            planner.compute_planner_loss(bev, vis_hist, ego, bad_target)
-        # Wrong feature dim
-        bad_target2 = torch.randn(2, 64, device=device)
-        with pytest.raises(ValueError, match="trajectory_target must have shape"):
-            planner.compute_planner_loss(bev, vis_hist, ego, bad_target2)
 
     def test_construct_training_data_wrong_target_shape_propagates(self, device):
         """The internal _validate_flow_inputs guard must catch shape regressions
@@ -309,76 +272,58 @@ class TestAutoE2EWithFlowMatching:
     @staticmethod
     def _fm_model(build_mock_model, device):
         return build_mock_model(
-            num_views=8, fusion_mode="bev", device=device,
+            num_views=8, device=device,
             planner_mode="flow_matching",
             planner_kwargs={"num_inference_steps": 4},
         )
-
-    def test_train_mode_returns_scalar_loss(self, build_mock_model, device):
-        """Under the uniform Option-B contract, train mode must return a
-        scalar planner loss — NOT the raw flow-matching velocity tensor.
-        This documents that the velocity-vs-target footgun is gone."""
-        model = self._fm_model(build_mock_model, device)
-        model.train()
-        visual, map_input, vis_hist, ego = make_inputs(2, 8, device)
-        target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(
-            visual, map_input, vis_hist, ego, mode="train", trajectory_target=target,
-        )
-        assert loss.dim() == 0, \
-            "FM train mode must expose a scalar loss, not a [B, T*S] velocity"
-        assert loss.requires_grad
-        assert ego_hidden.shape == (2, 256)
-        assert future is not None and len(future) == 4
 
     def test_infer_mode_returns_trajectory(self, build_mock_model, device):
         model = self._fm_model(build_mock_model, device)
         model.eval()
         visual, map_input, vis_hist, ego = make_inputs(1, 8, device)
-        traj, ego_hidden, future = model(visual, map_input, vis_hist, ego, mode="infer")
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
         assert traj.shape == (1, 128)
-        assert ego_hidden.shape == (1, 256)
-        assert future is None
         assert torch.isfinite(traj).all()
 
-    def test_backward_flows_through_planner_loss(self, build_mock_model, device):
+    def test_train_mode_also_returns_trajectory(self, build_mock_model, device):
+        """Post-refactor the planner forward always returns the trajectory; the
+        loss is the training loop's concern, not AutoE2E.forward's."""
+        model = self._fm_model(build_mock_model, device)
+        model.train()
+        visual, map_input, vis_hist, ego = make_inputs(2, 8, device)
+        traj = model(visual, map_input, vis_hist, ego, mode="train")
+        assert traj.shape == (2, 128)
+
+    def test_backward_flows_through_model(self, build_mock_model, device):
         model = self._fm_model(build_mock_model, device)
         model.train()
         visual, map_input, vis_hist, ego = make_inputs(2, 8, device)
         target = torch.randn(2, 128, device=device)
-        loss, ego_hidden, future = model(
-            visual, map_input, vis_hist, ego, mode="train", trajectory_target=target,
-        )
-        total = loss + ego_hidden.sum() + sum(f.sum() for f in future)
-        total.backward()
+        traj = model(visual, map_input, vis_hist, ego, mode="train")
+        (traj - target).pow(2).mean().backward()
         # At least one Backbone and one TrajectoryPlanner param must see grad.
         backbone_grad = any(
             p.grad is not None and p.grad.abs().max() > 0
-            for n, p in model.named_parameters() if n.startswith("Backbone.")
+            for n, p in model.named_parameters()
+            if n.startswith("Reactive_E2E.Backbone.")
         )
         planner_grad = any(
             p.grad is not None and p.grad.abs().max() > 0
             for n, p in model.named_parameters()
-            if n.startswith("TrajectoryPlanner.")
+            if n.startswith("Reactive_E2E.TrajectoryPlanner.")
         )
         assert backbone_grad and planner_grad
 
-    def test_train_mode_requires_target(self, build_mock_model, device):
-        model = self._fm_model(build_mock_model, device)
-        visual, map_input, vis_hist, ego = make_inputs(1, 8, device)
-        with pytest.raises(ValueError, match="trajectory_target"):
-            model(visual, map_input, vis_hist, ego, mode="train")
-
-    def test_gru_and_fm_interchangeable_at_inference(self, build_mock_model, device):
-        """GRU and FM both produce a [B, T*S] trajectory in inference mode —
-        callers can swap planners with no other code changes."""
-        gru_model = build_mock_model(num_views=8, fusion_mode="concat",
-                                     device=device)
+    def test_bezier_and_fm_interchangeable_at_inference(self, build_mock_model, device):
+        """Bezier and Flow Matching both produce a [B, T*S] trajectory in
+        inference mode — callers can swap planners with no other code changes."""
+        bezier_model = build_mock_model(num_views=8, device=device,
+                                        planner_mode="bezier")
         fm_model = self._fm_model(build_mock_model, device)
-        gru_model.eval()
+        bezier_model.eval()
         fm_model.eval()
 
         visual, map_input, vis_hist, ego = make_inputs(2, 8, device)
-        gru_traj, _, _ = gru_model(visual, map_input, vis_hist, ego, mode="infer")
-        fm_traj, _, _ = fm_model(visual, map_input, vis_hist, ego, mode="infer")
-        assert gru_traj.shape == fm_traj.shape == (2, 128)
+        bezier_traj = bezier_model(visual, map_input, vis_hist, ego, mode="infer")
+        fm_traj = fm_model(visual, map_input, vis_hist, ego, mode="infer")
+        assert bezier_traj.shape == fm_traj.shape == (2, 128)

--- a/Model/tests/test_view_fusion.py
+++ b/Model/tests/test_view_fusion.py
@@ -40,8 +40,8 @@ class TestViewFusion:
         B, V, C, H, W = visual.shape
 
         def fused_features(x):
-            features = model.Backbone(x.reshape(B * V, C, H, W))
-            return model.FeatureFusion(features, B, V)
+            features = model.Reactive_E2E.Backbone(x.reshape(B * V, C, H, W))
+            return model.Reactive_E2E.FeatureFusion(features, B, V)
 
         fused_base = fused_features(visual)
 
@@ -71,8 +71,8 @@ class TestViewFusion:
         B, V, C, H, W = visual.shape
 
         def fused_features(x):
-            features = model.Backbone(x.reshape(B * V, C, H, W))
-            return model.FeatureFusion(features, B, V)
+            features = model.Reactive_E2E.Backbone(x.reshape(B * V, C, H, W))
+            return model.Reactive_E2E.FeatureFusion(features, B, V)
 
         fused_base = fused_features(visual)
 
@@ -113,8 +113,8 @@ class TestViewFusion:
         cam_params[..., 2, 3] = 1.0
 
         def fused_features(x):
-            features = model.Backbone(x.reshape(B * V, C, H, W))
-            return model.FeatureFusion(features, B, V, camera_params=cam_params)
+            features = model.Reactive_E2E.Backbone(x.reshape(B * V, C, H, W))
+            return model.Reactive_E2E.FeatureFusion(features, B, V, camera_params=cam_params)
 
         fused_base = fused_features(visual)
 


### PR DESCRIPTION
### Summary

Closes #88. The #86 refactor (everything moved inside `Reactive_E2E`) changed the model's public contract, but the unit tests still asserted the **old** API, so `make test` was red. This PR brings the whole suite back in line with the refactored architecture and fixes two pre-existing source-level `mypy` errors that also kept CI red.

No production behaviour changes beyond two type-only annotations — this is a test-and-typing repair.

### Root cause (what the refactor changed)

After #86:

- `AutoE2E` is a thin wrapper around `self.Reactive_E2E = ReactiveE2E(...)`; the `Backbone`, `FeatureFusion`, `MapEncoder`/`MapBEVFusion`, `TemporalMemory` and `TrajectoryPlanner` now live **under `Reactive_E2E.*`** (so parameter names are prefixed `Reactive_E2E.`).
- `AutoE2E.forward(...)` returns **only `trajectory`** `[B, num_timesteps*num_signals]`, in every mode. The old 3-tuple `(loss/trajectory, ego_hidden, future_features)` is gone.
- The planner `forward()` is inference-only and returns **just the trajectory** (no `ego_hidden`); the per-planner `compute_planner_loss` was removed (the training objective lives in the training loop).
- View fusion: only **`bev`** is registered now (`FUSION_REGISTRY == {"bev"}`); `concat`/`cross_attn` are gone. The `fusion_mode` kwarg was dropped from `AutoE2E`/`ReactiveE2E` (it is hard-wired to `"bev"` internally); `FeatureFusion` itself still accepts a `fusion_mode` arg.
- The **GRU** planner was removed; `PLANNER_REGISTRY == {flow_matching, bezier}`. `AutoE2E`'s default `planner_mode` is **`bezier`**. (Note: `ReactiveE2E.__init__` still carries a stale `planner_mode="gru"` default that would raise if it were ever constructed directly with defaults — `AutoE2E` always passes `bezier`, so the live path is fine; flagging it as a latent source nit.)
- The `future_features` output was removed from the forward path. `FutureState` is **still constructed** inside `ReactiveE2E` but is **not called** by `forward`, so it produces no output and receives no gradient.

The tests were written against all of the above, so they failed en masse (collection-time and assertion-time).

### What changed, file by file

**Test suite (adapted to the new contract):**

- **`conftest.py`** — `_build_model_with_mock_backbone` patches `model_components.reactive_e2e.Backbone` (was `auto_e2e.Backbone`); always BEV at an 8×8 grid; `model`/`full_model` fixtures parametrised on `["bev"]` only.
- **`test_auto_e2e.py`** — `model(...)` now returns a single `trajectory`; removed the `ego_hidden`/`future_features` shape tests; train-mode calls now return the trajectory (no 3-tuple); gradient/optimizer tests backward through a trajectory MSE and target `Reactive_E2E.{Backbone,FeatureFusion,TrajectoryPlanner}`, excluding the unused `FutureState` and the alpha-gated `MapEncoder`; `num_views` matrix is BEV-only.
- **`test_view_fusion.py`** — read fused features via `model.Reactive_E2E.{Backbone,FeatureFusion}`; registry/BEV-specific tests unchanged.
- **`test_feature_fusion.py`** — `fusion_mode="concat"` → `"bev"` (+ `view_fusion_kwargs={"bev_h":8,"bev_w":8}`).
- **`test_map_encoder.py`** — single-trajectory return; paths via `Reactive_E2E.{MapEncoder,MapBEVFusion}`; gradient checks now drive a trajectory-MSE backward. **`cross_attn` map fusion stays covered** (it is still a valid `map_fusion_mode`).
- **`test_history_encoder.py`** — single-trajectory return; `Reactive_E2E.TemporalMemory`; `one_hz`/`no_memory` paths verified via trajectory backward.
- **`test_causal_reasoning.py`** — asserts the new single-trajectory contract; the (independent) `CausalReasoningModule` is exercised on a 256-d embedding since the planner's internal ego embedding is no longer surfaced.
- **`test_bezier_planner.py`** — planner `forward` returns just the trajectory; removed tests for the deleted `compute_planner_loss`/`trajectory_loss`; default-planner test now asserts **bezier** (GRU removed); AutoE2E tests patch `reactive_e2e.Backbone` and use `Reactive_E2E.TrajectoryPlanner`.
- **`test_trajectory_planning.py`** — Flow-Matching `forward` returns the trajectory; removed the `compute_planner_loss` end-to-end / wrong-shape tests and `test_train_mode_requires_target` (the forward no longer requires a target); gradient test backprops through the integrated trajectory; AutoE2E-with-FM tests use the single-trajectory contract; "interchangeable planners" now compares **bezier vs flow_matching**.
- **`test_integration.py`** — `TestRealArchitectureSmoke` (runs in CI, `is_pretrained=False`) and the `@integration` tier adapted to the single-trajectory contract and `Reactive_E2E.Backbone`.

**Source (type-only `mypy` fixes, no behaviour change):**

- **`losses/trajectory_loss.py`** — class-level annotations `loss_fn: nn.Module` / `temporal_weights: torch.Tensor` so `mypy` resolves them instead of `nn.Module.__getattr__ -> Tensor | Module` (which flagged `self.loss_fn(...)` as "Tensor not callable").
- **`map_encoder/raster_map_encoder.py`** — bind timm's `feature_info` through `Any` to iterate it without a `union-attr` error.

### Tests removed (and why)

Tests for features deleted by #86 were removed rather than left asserting dead behaviour: `concat`/`cross_attn` **view** fusion, the **GRU** planner, the planner `compute_planner_loss`/`trajectory_loss`, and the `ego_hidden`/`future_features` returns. Everything still present (BEV fusion, bezier + flow_matching planners, residual + cross_attn **map** fusion, temporal memory, the reasoning head) stays covered.

### Testing

Run exactly as CI does:

```
ruff check                  # All checks passed
cd Model && mypy .          # Success: no issues found in 74 source files
pytest Model/tests          # 181 passed, 6 deselected
```

The 6 deselected are the `@integration` tier (real pretrained backbones), which `Model/pytest.ini` excludes from the default/CI run via `-m "not integration and not e2e_data"`.

### Notes

- `FutureState` is still constructed inside `ReactiveE2E` but is **not used** by its `forward`, so it receives no gradient; the gradient-coverage tests exclude it intentionally (flagging in case it should be wired in or dropped).
- Net diff is **−172 lines** (12 files, +317/−489) — mostly deleting expectations for removed features.
