### PR TITLE
fix(speed_benchmark): align benchmarks with the Reactive_E2E contract (#92)

### DIFF
--- a/Model/speed_benchmark/planner_benchmark.py
+++ b/Model/speed_benchmark/planner_benchmark.py
@@ -1,4 +1,4 @@
-"""Swappable-planner benchmark harness — gru vs flow_matching vs bezier.
+"""Swappable-planner benchmark harness — flow_matching vs bezier.
 
 Compares the trajectory planners registered in ``PLANNER_REGISTRY`` under
 IDENTICAL conditions (same embed_dim / horizon / inputs / device), as requested
@@ -37,7 +37,10 @@ from model_components.trajectory_planning import PLANNER_REGISTRY, build_planner
 
 CONFIG = dict(embed_dim=256, num_timesteps=64, num_signals=2,
               egomotion_dim=256, visual_history_dim=896)
-PLANNERS = ["gru", "flow_matching", "bezier"]
+# gru was removed from PLANNER_REGISTRY in the Reactive_E2E refactor; the
+# remaining registered planners are flow_matching and bezier. (Any name not in
+# the registry is skipped gracefully in main().)
+PLANNERS = ["flow_matching", "bezier"]
 WARMUP, ITERS, BATCH, H, W = 10, 50, 1, 8, 8
 
 
@@ -74,7 +77,9 @@ def _bench_one(name, device):
             if device.type == "cuda":
                 torch.cuda.synchronize()
             times.append((time.perf_counter() - t0) * 1000.0)
-    jerk, dcurv = _smoothness(out[0])
+    # Planners return the trajectory tensor directly ([B, T*S]) — the old
+    # (trajectory, ...) tuple contract was removed in the Reactive_E2E refactor.
+    jerk, dcurv = _smoothness(out)
     times.sort()
     p50 = times[len(times) // 2]
     p99 = times[min(len(times) - 1, int(round(len(times) * 0.99)) - 1)]

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -11,14 +11,17 @@ sys.path.append('..')
 from model_components.auto_e2e import AutoE2E
 
 
-def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8):
-    
+def run_speed_benchmark(backbone, device, batch_size=1, num_views=8):
+
     print(f"{'='*80}")
-    print(f"  backbone = '{backbone}' | fusion_mode = '{fusion_mode}' | batch={batch_size} | views={num_views}")
+    print(f"  backbone = '{backbone}' | fusion = 'bev' | batch={batch_size} | views={num_views}")
     print(f"{'='*80}\n")
 
-    # Instantiate model
-    model = AutoE2E(backbone=backbone, num_views=num_views, fusion_mode=fusion_mode)
+    # Instantiate model. After the Reactive_E2E refactor the only multi-view
+    # fusion is BEV (concat / cross_attn and the fusion_mode knob were removed);
+    # the BEV grid size is configured via view_fusion_kwargs.
+    model = AutoE2E(backbone=backbone, num_views=num_views,
+                    view_fusion_kwargs={"bev_h": 8, "bev_w": 8})
     model = model.to(device)
     model.eval()
 
@@ -31,19 +34,21 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
     # Egomotion History Input: [batch, 256]
     egomotion_history = torch.randn(batch_size, 256).to(device)
 
-    # Camera parameters: [batch, num_views, 3, 4] projection matrices
-    # Only used by BEV fusion; None triggers learnable pseudo-projection
-    camera_params = None
-    if fusion_mode == "bev":
-        camera_params = torch.randn(batch_size, num_views, 3, 4).to(device)
+    # BEV nav-map image: [batch, 3, H, W]
+    map_input = torch.randn(batch_size, 3, 256, 256).to(device)
+
+    # Camera parameters: [batch, num_views, 3, 4] ego-to-pixel projection
+    # matrices used by BEV fusion (None would trigger the learnable
+    # pseudo-projection fallback; we feed real-shaped matrices here).
+    camera_params = torch.randn(batch_size, num_views, 3, 4).to(device)
 
     # 1. Warm-up Phase (GPU kernel compilation and cache warming)
     num_warmup = 30 if device.type == 'cuda' else 5
     print(f"Warming up ({num_warmup} iterations)...")
     with torch.no_grad():
         for _ in range(num_warmup):
-            _ = model(visual_tiles, visual_history, egomotion_history,
-                       camera_params=camera_params, mode="infer")
+            _ = model(visual_tiles, map_input, visual_history, egomotion_history,
+                      camera_params=camera_params, mode="infer")
 
     # 2. Benchmark Phase
     num_iters = 100 if device.type == 'cuda' else 10
@@ -58,7 +63,7 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
 
             start_time = time.perf_counter()
 
-            _ = model(visual_tiles, visual_history, egomotion_history,
+            _ = model(visual_tiles, map_input, visual_history, egomotion_history,
                       camera_params=camera_params, mode="infer")
 
             if device.type == 'cuda':
@@ -88,7 +93,7 @@ def run_speed_benchmark(backbone, fusion_mode, device, batch_size=1, num_views=8
 
     results = {
         "backbone": backbone,
-        "fusion_mode": fusion_mode,
+        "fusion_mode": "bev",
         "batch_size": batch_size,
         "num_views": num_views,
         "avg_fps": round(avg_fps, 2),
@@ -190,18 +195,17 @@ def main():
 
     all_results = []
 
-    # Test all registered backbones and fusion modes
+    # Test all registered backbones (BEV is the only fusion after the refactor)
     backbones = ["swin_v2_tiny", "conv_next_v2_tiny"]
-    fusion_modes = ["concat", "cross_attn", "bev"]
     batch_sizes = [1, 2, 4]
 
     for backbone in backbones:
-        for fusion_mode in fusion_modes:
-            for batch_size in batch_sizes:
-                torch.cuda.reset_peak_memory_stats() if torch.cuda.is_available() else None
-                result = run_speed_benchmark(backbone, fusion_mode, device, batch_size=batch_size)
-                all_results.append(result)
-                print()
+        for batch_size in batch_sizes:
+            if torch.cuda.is_available():
+                torch.cuda.reset_peak_memory_stats()
+            result = run_speed_benchmark(backbone, device, batch_size=batch_size)
+            all_results.append(result)
+            print()
 
     # Save structured results
     save_results_json(all_results, device)


### PR DESCRIPTION
## Problem

`Model/speed_benchmark/speed_benchmark.py` and `planner_benchmark.py` still assume
the pre-refactor API and crash on the current `main` (post `Reactive_E2E` refactor).

## Fix

- **`speed_benchmark.py`**
  - `AutoE2E` no longer accepts `fusion_mode` (concat / cross_attn and the knob were
    removed; BEV is the only multi-view fusion) → construct with
    `view_fusion_kwargs={"bev_h": 8, "bev_w": 8}` and drop the fusion_mode sweep.
  - `AutoE2E.forward` now takes `map_input` and returns the trajectory tensor
    directly (the `(loss/traj, ego_hidden, future)` 3-tuple was removed) → feed a
    map image and stop unpacking a tuple.
- **`planner_benchmark.py`**
  - `gru` was removed from `PLANNER_REGISTRY` → benchmark `flow_matching` vs `bezier`.
  - planners now return the trajectory directly, so read `out` (not `out[0]`) for the
    smoothness metric.

## Verification

- `planner_benchmark.py` runs end-to-end: bezier jerk ~5e-6 vs flow_matching ~3.4
  (the Bernstein-basis smoothness guarantee holds, as expected).
- `speed_benchmark.py` forward path validated on CPU (`is_pretrained=False`).
- ruff + mypy clean.

Closes #92.
