### PR TITLE
feat(evaluation): comfort + off-road metrics, baselines, val splits (#66)

### DIFF
--- a/Model/evaluation/__init__.py
+++ b/Model/evaluation/__init__.py
@@ -1,3 +1,27 @@
-from .metrics import compute_open_loop_metrics, gate_check, integrate_trajectory
+from .metrics import (
+    COMFORT_THRESHOLDS,
+    compute_comfort_metrics,
+    compute_open_loop_metrics,
+    gate_check,
+    integrate_trajectory,
+    offroad_rate,
+)
+from .baselines import constant_velocity_baseline, hold_last_action_baseline
+from .splits import episode_range_split, geographic_holdout_split
 
-__all__ = ["compute_open_loop_metrics", "gate_check", "integrate_trajectory"]
+__all__ = [
+    # existing (open-loop displacement metrics + gate)
+    "compute_open_loop_metrics",
+    "gate_check",
+    "integrate_trajectory",
+    # complementary: comfort + off-road (#66 §2-3)
+    "compute_comfort_metrics",
+    "COMFORT_THRESHOLDS",
+    "offroad_rate",
+    # training-free baselines (#66 §5)
+    "constant_velocity_baseline",
+    "hold_last_action_baseline",
+    # validation splits (#66 §4)
+    "episode_range_split",
+    "geographic_holdout_split",
+]

--- a/Model/evaluation/baselines.py
+++ b/Model/evaluation/baselines.py
@@ -1,0 +1,45 @@
+"""Open-loop evaluation baselines (#66 §5).
+
+Simple, training-free baselines in the model's action space ``(accel, curv)``,
+so they can be scored with the same metrics as AutoE2E. Their purpose is to
+reveal whether the perception pipeline contributes **beyond ego-status
+extrapolation** — if the model barely beats constant-velocity, perception isn't
+helping yet (the ego-status critique of nuScenes planning, Zhai et al. 2023).
+
+The trained "ego-status MLP" baseline from the proposal needs training and is a
+follow-up; these are the zero-training references.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def constant_velocity_baseline(batch_size: int,
+                               num_timesteps: int = 64) -> tuple[np.ndarray, np.ndarray]:
+    """Maintain current speed, drive straight: ``accel = 0``, ``curv = 0``.
+
+    Returns ``(accel, curv)`` each ``(batch_size, num_timesteps)``.
+    """
+    zeros = np.zeros((batch_size, num_timesteps), dtype=np.float64)
+    return zeros, zeros.copy()
+
+
+def hold_last_action_baseline(last_accel: np.ndarray, last_curv: np.ndarray,
+                              num_timesteps: int = 64) -> tuple[np.ndarray, np.ndarray]:
+    """Extrapolate the last observed action forward (ego-status, no perception).
+
+    Holds the most recent ``(accel, curv)`` constant over the horizon — a
+    stronger ego-only baseline than constant-velocity when the ego is mid-
+    manoeuvre.
+
+    Args:
+        last_accel, last_curv: ``(B,)`` last observed action from egomotion.
+    Returns:
+        ``(accel, curv)`` each ``(B, num_timesteps)``.
+    """
+    accel = np.repeat(np.asarray(last_accel, dtype=np.float64)[:, None],
+                      num_timesteps, axis=1)
+    curv = np.repeat(np.asarray(last_curv, dtype=np.float64)[:, None],
+                     num_timesteps, axis=1)
+    return accel, curv

--- a/Model/evaluation/metrics.py
+++ b/Model/evaluation/metrics.py
@@ -128,12 +128,15 @@ def gate_check(
 # (comfort) or no other-agent labels (off-road), which L2D lacks.
 # ---------------------------------------------------------------------------
 
-# nuPlan comfort thresholds (#66 §3).
+# nuPlan comfort bounds (the full set from nuplan-devkit `ego_is_comfortable`).
 COMFORT_THRESHOLDS = {
-    "lon_jerk": 4.13,    # m/s^3
-    "lat_accel": 4.89,   # m/s^2
-    "lat_jerk": 8.37,    # m/s^3
-    "yaw_rate": 0.95,    # rad/s
+    "lon_accel_max": 2.40,    # m/s^2   upper bound on longitudinal accel
+    "lon_accel_min": -4.05,   # m/s^2   lower bound (braking)
+    "lat_accel": 4.89,        # m/s^2   |lateral accel|
+    "yaw_rate": 0.95,         # rad/s   |yaw rate|
+    "yaw_accel": 1.93,        # rad/s^2 |yaw acceleration|
+    "lon_jerk": 4.13,         # m/s^3   |longitudinal jerk|
+    "mag_jerk": 8.37,         # m/s^3   |jerk magnitude| = sqrt(lon_jerk^2 + lat_jerk^2)
 }
 
 
@@ -144,46 +147,85 @@ def compute_comfort_metrics(
     dt: float = 0.1,
     thresholds: dict[str, float] = COMFORT_THRESHOLDS,
 ) -> dict[str, float]:
-    """Comfort metrics straight from the ``(a, κ)`` outputs (#66 §3).
+    """Comfort metrics from the ``(a, κ)`` outputs vs the nuPlan bounds (#66 §3).
 
-    These need no ground truth and are natural for an action-space model. With
-    the per-step speed ``v[t] = v0 + Σ a·dt`` (clamped ≥ 0):
-      * longitudinal jerk ``Δa/dt``
-      * lateral acceleration ``v² κ``
-      * lateral jerk ``Δa_lat/dt``
-      * yaw rate ``v κ``
-    Reports the batch-mean of each per-sample peak plus the **comfort violation
-    rate** (fraction of samples exceeding ANY nuPlan threshold).
+    Mirrors nuplan-devkit's ``ego_is_comfortable`` set — no ground truth needed.
+    With the per-step speed ``v[t] = v0 + Σ a·dt`` (clamped ≥ 0):
+      * longitudinal acceleration ``a``         — two-sided bound ``[min, max]``
+      * lateral acceleration      ``v² κ``       — ``|·|`` bound
+      * yaw rate                  ``v κ``        — ``|·|`` bound
+      * yaw acceleration          ``Δ(v κ)/dt``  — ``|·|`` bound
+      * longitudinal jerk         ``Δa/dt``      — ``|·|`` bound
+      * jerk magnitude            ``√(lon_jerk² + lat_jerk²)`` — bound (this is the
+        8.37 m/s³ threshold; *not* lateral jerk)
+
+    Reports the batch-mean of each per-sample peak, a per-metric violation rate,
+    and the overall ``comfort_violation_rate`` (fraction of samples exceeding ANY
+    bound).
 
     Args:
         pred_accel, pred_curv: ``(B, T)`` predicted action signals.
         initial_speed: ``(B,)`` speed at the prediction start.
     """
-    accel = np.asarray(pred_accel, dtype=np.float64)
-    curv = np.asarray(pred_curv, dtype=np.float64)
+    accel = np.asarray(pred_accel, dtype=np.float64)                 # (B, T)
+    curv = np.asarray(pred_curv, dtype=np.float64)                   # (B, T)
     v0 = np.asarray(initial_speed, dtype=np.float64)[:, None]
 
-    v = np.clip(v0 + np.cumsum(accel, axis=1) * dt, 0.0, None)   # (B, T)
-    lon_jerk = np.abs(np.diff(accel, axis=1)) / dt               # (B, T-1)
-    lat_accel = np.abs(v ** 2 * curv)                            # (B, T)
-    lat_jerk = np.abs(np.diff(v ** 2 * curv, axis=1)) / dt       # (B, T-1)
-    yaw_rate = np.abs(v * curv)                                  # (B, T)
+    v = np.clip(v0 + np.cumsum(accel, axis=1) * dt, 0.0, None)       # (B, T)
+    lat_accel = v ** 2 * curv                                        # (B, T)
+    yaw_rate = v * curv                                              # (B, T)
+    lon_jerk = np.diff(accel, axis=1) / dt                           # (B, T-1)
+    lat_jerk = np.diff(lat_accel, axis=1) / dt                       # (B, T-1)
+    yaw_accel = np.diff(yaw_rate, axis=1) / dt                       # (B, T-1)
+    mag_jerk = np.hypot(lon_jerk, lat_jerk)                          # (B, T-1)
 
-    peaks = {
-        "lon_jerk": lon_jerk.max(axis=1),
-        "lat_accel": lat_accel.max(axis=1),
-        "lat_jerk": lat_jerk.max(axis=1),
-        "yaw_rate": yaw_rate.max(axis=1),
-    }
-    violated = np.zeros(accel.shape[0], dtype=bool)
     out: dict[str, float] = {}
-    for name, peak in peaks.items():
+    violated = np.zeros(accel.shape[0], dtype=bool)
+
+    # Longitudinal acceleration: asymmetric two-sided bound.
+    lon_max, lon_min = accel.max(axis=1), accel.min(axis=1)
+    out["max_lon_accel"] = float(lon_max.mean())
+    out["min_lon_accel"] = float(lon_min.mean())
+    lon_exceed = (lon_max > thresholds["lon_accel_max"]) | (lon_min < thresholds["lon_accel_min"])
+    out["lon_accel_violation_rate"] = float(lon_exceed.mean())
+    violated |= lon_exceed
+
+    # Magnitude-bounded quantities.
+    abs_peaks = {
+        "lat_accel": np.abs(lat_accel).max(axis=1),
+        "yaw_rate": np.abs(yaw_rate).max(axis=1),
+        "yaw_accel": np.abs(yaw_accel).max(axis=1),
+        "lon_jerk": np.abs(lon_jerk).max(axis=1),
+        "mag_jerk": mag_jerk.max(axis=1),
+    }
+    for name, peak in abs_peaks.items():
         out[f"max_{name}"] = float(peak.mean())
         exceed = peak > thresholds[name]
         out[f"{name}_violation_rate"] = float(exceed.mean())
         violated |= exceed
+
     out["comfort_violation_rate"] = float(violated.mean())
     return out
+
+
+def _erode_drivable(mask: np.ndarray, iterations: int) -> np.ndarray:
+    """Shrink the drivable area by ``iterations`` pixels (4-neighbour erosion).
+
+    A cell stays drivable only if it and its 4 neighbours are drivable (cells
+    outside the grid count as non-drivable), so after ``k`` iterations any cell
+    within Manhattan distance ``k`` of the boundary is removed. Pure-numpy, no
+    scipy. Used to require a safety margin from the road edge.
+    """
+    eroded = np.asarray(mask, dtype=bool)
+    for _ in range(max(0, int(iterations))):
+        nb = eroded.copy()
+        nb[1:, :] &= eroded[:-1, :]      # up neighbour
+        nb[:-1, :] &= eroded[1:, :]      # down neighbour
+        nb[:, 1:] &= eroded[:, :-1]      # left neighbour
+        nb[:, :-1] &= eroded[:, 1:]      # right neighbour
+        nb[0, :] = nb[-1, :] = nb[:, 0] = nb[:, -1] = False   # border = off-road
+        eroded = nb
+    return eroded
 
 
 def offroad_rate(
@@ -191,11 +233,18 @@ def offroad_rate(
     drivable_mask: np.ndarray,
     meters_per_pixel: float,
     center_px: tuple[int, int] | None = None,
+    headings: np.ndarray | None = None,
+    ego_size: tuple[float, float] | None = None,
+    dilation_px: int = 0,
 ) -> float:
     """Off-road proxy for collision rate when agents are unlabelled (#66 §2).
 
     L2D has no other-agent annotations, so we use the BEV drivable mask: a
-    trajectory is off-road if any predicted pose falls on a non-drivable cell.
+    trajectory is off-road if it leaves the drivable area. By default this checks
+    the trajectory **centre** point (lightweight). For drivable-area *compliance*
+    the ego footprint matters — a corner can leave the road while the centre stays
+    inside — so pass ``ego_size`` to check the four footprint corners, and/or
+    ``dilation_px`` to require a safety margin from the boundary.
 
     Args:
         positions: ``(B, T, 2)`` integrated ``(x_forward, y_left)`` in metres.
@@ -204,21 +253,53 @@ def offroad_rate(
         center_px: ego pixel ``(row, col)``; defaults to the grid centre.
             Convention (matches the repo's BEV rendering): forward +x → up
             (decreasing row), left +y → left (decreasing col).
+        headings: optional ``(B, T)`` heading per pose (rad) to orient the
+            footprint. If ``None`` and ``ego_size`` is given, heading is taken
+            from the finite-difference travel direction.
+        ego_size: optional ``(length, width)`` in metres. When given, the four
+            footprint corners are checked instead of only the centre.
+        dilation_px: erode the drivable mask by this many pixels first (require a
+            margin from the boundary). 0 = off.
 
     Returns:
         Fraction of trajectories that leave the drivable area.
     """
-    H, W = drivable_mask.shape
+    mask = _erode_drivable(drivable_mask, dilation_px) if dilation_px > 0 \
+        else np.asarray(drivable_mask, dtype=bool)
+    H, W = mask.shape
     cr, cc = center_px if center_px is not None else (H // 2, W // 2)
-    B = positions.shape[0]
+    pos = np.asarray(positions, dtype=np.float64)
+    B, T, _ = pos.shape
+
+    if ego_size is None:
+        query = pos[:, :, None, :]                                   # (B, T, 1, 2)
+    else:
+        length, width = ego_size
+        corners = np.array([                                         # ego frame
+            [length / 2, width / 2], [length / 2, -width / 2],
+            [-length / 2, width / 2], [-length / 2, -width / 2],
+        ])                                                           # (4, 2)
+        if headings is not None:
+            theta = np.asarray(headings, dtype=np.float64)
+        elif T >= 2:
+            d = np.diff(pos, axis=1)
+            d = np.concatenate([d[:, :1, :], d], axis=1)             # (B, T, 2)
+            theta = np.arctan2(d[..., 1], d[..., 0])                 # (B, T)
+        else:
+            theta = np.zeros((B, T))
+        cos, sin = np.cos(theta), np.sin(theta)                      # (B, T)
+        cx, cy = corners[:, 0], corners[:, 1]                        # (4,)
+        qx = pos[..., 0:1] + cos[..., None] * cx - sin[..., None] * cy   # (B, T, 4)
+        qy = pos[..., 1:2] + sin[..., None] * cx + cos[..., None] * cy   # (B, T, 4)
+        query = np.stack([qx, qy], axis=-1)                          # (B, T, 4, 2)
+
     offroad = 0
     for i in range(B):
-        rows = np.round(cr - positions[i, :, 0] / meters_per_pixel).astype(int)
-        cols = np.round(cc - positions[i, :, 1] / meters_per_pixel).astype(int)
+        rows = np.round(cr - query[i, ..., 0] / meters_per_pixel).astype(int)
+        cols = np.round(cc - query[i, ..., 1] / meters_per_pixel).astype(int)
         inside = (rows >= 0) & (rows < H) & (cols >= 0) & (cols < W)
-        # Outside the grid counts as off-road; inside, check the mask.
-        on_road = inside.copy()
-        on_road[inside] = drivable_mask[rows[inside], cols[inside]]
+        on_road = inside.copy()                                      # OOB = off-road
+        on_road[inside] = mask[rows[inside], cols[inside]]
         if not on_road.all():
             offroad += 1
     return offroad / max(B, 1)

--- a/Model/evaluation/metrics.py
+++ b/Model/evaluation/metrics.py
@@ -119,3 +119,106 @@ def gate_check(
         if metrics.get(key, float("inf")) > max_val:
             return False
     return True
+
+
+# ---------------------------------------------------------------------------
+# Complementary metrics (#66 §2-3) — comfort and an off-road proxy.
+# These extend the displacement metrics already provided by
+# ``compute_open_loop_metrics`` above; they need no ground-truth trajectory
+# (comfort) or no other-agent labels (off-road), which L2D lacks.
+# ---------------------------------------------------------------------------
+
+# nuPlan comfort thresholds (#66 §3).
+COMFORT_THRESHOLDS = {
+    "lon_jerk": 4.13,    # m/s^3
+    "lat_accel": 4.89,   # m/s^2
+    "lat_jerk": 8.37,    # m/s^3
+    "yaw_rate": 0.95,    # rad/s
+}
+
+
+def compute_comfort_metrics(
+    pred_accel: np.ndarray,
+    pred_curv: np.ndarray,
+    initial_speed: np.ndarray,
+    dt: float = 0.1,
+    thresholds: dict[str, float] = COMFORT_THRESHOLDS,
+) -> dict[str, float]:
+    """Comfort metrics straight from the ``(a, κ)`` outputs (#66 §3).
+
+    These need no ground truth and are natural for an action-space model. With
+    the per-step speed ``v[t] = v0 + Σ a·dt`` (clamped ≥ 0):
+      * longitudinal jerk ``Δa/dt``
+      * lateral acceleration ``v² κ``
+      * lateral jerk ``Δa_lat/dt``
+      * yaw rate ``v κ``
+    Reports the batch-mean of each per-sample peak plus the **comfort violation
+    rate** (fraction of samples exceeding ANY nuPlan threshold).
+
+    Args:
+        pred_accel, pred_curv: ``(B, T)`` predicted action signals.
+        initial_speed: ``(B,)`` speed at the prediction start.
+    """
+    accel = np.asarray(pred_accel, dtype=np.float64)
+    curv = np.asarray(pred_curv, dtype=np.float64)
+    v0 = np.asarray(initial_speed, dtype=np.float64)[:, None]
+
+    v = np.clip(v0 + np.cumsum(accel, axis=1) * dt, 0.0, None)   # (B, T)
+    lon_jerk = np.abs(np.diff(accel, axis=1)) / dt               # (B, T-1)
+    lat_accel = np.abs(v ** 2 * curv)                            # (B, T)
+    lat_jerk = np.abs(np.diff(v ** 2 * curv, axis=1)) / dt       # (B, T-1)
+    yaw_rate = np.abs(v * curv)                                  # (B, T)
+
+    peaks = {
+        "lon_jerk": lon_jerk.max(axis=1),
+        "lat_accel": lat_accel.max(axis=1),
+        "lat_jerk": lat_jerk.max(axis=1),
+        "yaw_rate": yaw_rate.max(axis=1),
+    }
+    violated = np.zeros(accel.shape[0], dtype=bool)
+    out: dict[str, float] = {}
+    for name, peak in peaks.items():
+        out[f"max_{name}"] = float(peak.mean())
+        exceed = peak > thresholds[name]
+        out[f"{name}_violation_rate"] = float(exceed.mean())
+        violated |= exceed
+    out["comfort_violation_rate"] = float(violated.mean())
+    return out
+
+
+def offroad_rate(
+    positions: np.ndarray,
+    drivable_mask: np.ndarray,
+    meters_per_pixel: float,
+    center_px: tuple[int, int] | None = None,
+) -> float:
+    """Off-road proxy for collision rate when agents are unlabelled (#66 §2).
+
+    L2D has no other-agent annotations, so we use the BEV drivable mask: a
+    trajectory is off-road if any predicted pose falls on a non-drivable cell.
+
+    Args:
+        positions: ``(B, T, 2)`` integrated ``(x_forward, y_left)`` in metres.
+        drivable_mask: ``(H, W)`` boolean BEV; True = drivable.
+        meters_per_pixel: BEV resolution.
+        center_px: ego pixel ``(row, col)``; defaults to the grid centre.
+            Convention (matches the repo's BEV rendering): forward +x → up
+            (decreasing row), left +y → left (decreasing col).
+
+    Returns:
+        Fraction of trajectories that leave the drivable area.
+    """
+    H, W = drivable_mask.shape
+    cr, cc = center_px if center_px is not None else (H // 2, W // 2)
+    B = positions.shape[0]
+    offroad = 0
+    for i in range(B):
+        rows = np.round(cr - positions[i, :, 0] / meters_per_pixel).astype(int)
+        cols = np.round(cc - positions[i, :, 1] / meters_per_pixel).astype(int)
+        inside = (rows >= 0) & (rows < H) & (cols >= 0) & (cols < W)
+        # Outside the grid counts as off-road; inside, check the mask.
+        on_road = inside.copy()
+        on_road[inside] = drivable_mask[rows[inside], cols[inside]]
+        if not on_road.all():
+            offroad += 1
+    return offroad / max(B, 1)

--- a/Model/evaluation/splits.py
+++ b/Model/evaluation/splits.py
@@ -5,6 +5,11 @@ val split. The recommended design is a **geographic holdout** (reserve whole
 cities) to avoid the geographic/temporal leakage that inflates nuScenes
 planning numbers (Lilja et al., CVPR 2024); a simple episode-range split is an
 acceptable early-experiment fallback (per the proposal).
+
+Both helpers operate on plain indices / labels supplied by the caller — they do
+**not** read L2D metadata themselves. Pulling per-episode city labels from the
+dataset (for :func:`geographic_holdout_split`) is a separate metadata step and a
+follow-up; these functions just turn that information into train/val indices.
 """
 
 from __future__ import annotations
@@ -17,11 +22,20 @@ def episode_range_split(num_episodes: int,
     """Reserve the last ``val_fraction`` of episode indices for validation.
 
     Simple, leakage-prone (adjacent frames/locations) — for early experiments
-    only; prefer :func:`geographic_holdout_split`.
+    only; prefer :func:`geographic_holdout_split`. Guarantees a non-empty train
+    and val split.
+
+    Raises:
+        ValueError: if ``num_episodes < 2`` (can't form two non-empty splits) or
+            ``val_fraction`` is not in ``(0, 1)``.
     """
+    if num_episodes < 2:
+        raise ValueError(
+            f"need >= 2 episodes to form non-empty train/val splits, got {num_episodes}")
     if not 0.0 < val_fraction < 1.0:
         raise ValueError(f"val_fraction must be in (0,1), got {val_fraction}")
-    n_val = max(1, int(round(num_episodes * val_fraction)))
+    # at least 1 val, and at least 1 train (cap val at num_episodes - 1)
+    n_val = min(max(1, int(round(num_episodes * val_fraction))), num_episodes - 1)
     cut = num_episodes - n_val
     return list(range(cut)), list(range(cut, num_episodes))
 
@@ -32,15 +46,27 @@ def geographic_holdout_split(
 ) -> tuple[list[int], list[int]]:
     """Hold out whole cities for validation (recommended, leakage-safe).
 
+    This is a **helper that requires episode-level city labels** supplied by the
+    caller (`episode_cities`, index-aligned with the dataset). Extracting those
+    labels from L2D metadata is a separate step (follow-up), not done here.
+
     Args:
         episode_cities: city label per episode (index-aligned).
         holdout_cities: cities to reserve for validation.
     Returns:
         ``(train_indices, val_indices)``.
+    Raises:
+        ValueError: if the holdout leaves the train or val split empty (e.g. none
+            of ``holdout_cities`` appear, or they cover every episode).
     """
     holdout = set(holdout_cities)
     train: list[int] = []
     val: list[int] = []
     for i, city in enumerate(episode_cities):
         (val if city in holdout else train).append(i)
+    if not val:
+        raise ValueError(
+            f"holdout_cities {sorted(holdout)} match no episodes — val split is empty")
+    if not train:
+        raise ValueError("holdout_cities cover every episode — train split is empty")
     return train, val

--- a/Model/evaluation/splits.py
+++ b/Model/evaluation/splits.py
@@ -1,0 +1,46 @@
+"""Validation-split helpers for open-loop evaluation (#66 §4).
+
+L2D ships all episodes in a single "train" partition, so we define our own
+val split. The recommended design is a **geographic holdout** (reserve whole
+cities) to avoid the geographic/temporal leakage that inflates nuScenes
+planning numbers (Lilja et al., CVPR 2024); a simple episode-range split is an
+acceptable early-experiment fallback (per the proposal).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def episode_range_split(num_episodes: int,
+                        val_fraction: float = 0.1) -> tuple[list[int], list[int]]:
+    """Reserve the last ``val_fraction`` of episode indices for validation.
+
+    Simple, leakage-prone (adjacent frames/locations) — for early experiments
+    only; prefer :func:`geographic_holdout_split`.
+    """
+    if not 0.0 < val_fraction < 1.0:
+        raise ValueError(f"val_fraction must be in (0,1), got {val_fraction}")
+    n_val = max(1, int(round(num_episodes * val_fraction)))
+    cut = num_episodes - n_val
+    return list(range(cut)), list(range(cut, num_episodes))
+
+
+def geographic_holdout_split(
+    episode_cities: Sequence[str],
+    holdout_cities: Sequence[str],
+) -> tuple[list[int], list[int]]:
+    """Hold out whole cities for validation (recommended, leakage-safe).
+
+    Args:
+        episode_cities: city label per episode (index-aligned).
+        holdout_cities: cities to reserve for validation.
+    Returns:
+        ``(train_indices, val_indices)``.
+    """
+    holdout = set(holdout_cities)
+    train: list[int] = []
+    val: list[int] = []
+    for i, city in enumerate(episode_cities):
+        (val if city in holdout else train).append(i)
+    return train, val

--- a/Model/tests/test_evaluation_complementary.py
+++ b/Model/tests/test_evaluation_complementary.py
@@ -2,8 +2,8 @@
 
 These cover only what this PR *adds* on top of the existing
 ``compute_open_loop_metrics`` / ``gate_check`` already in ``evaluation``:
-comfort metrics from (a,κ), an off-road proxy, training-free baselines, and
-validation splits. Pure-numpy, no model or dataset needed.
+nuPlan-aligned comfort metrics, an ego-footprint off-road proxy, training-free
+baselines, and validation splits. Pure-numpy, no model or dataset needed.
 """
 
 import numpy as np
@@ -27,33 +27,54 @@ def _zeros():
     return np.zeros((B, T)), np.zeros((B, T))
 
 
-# ---- comfort (#66 §3) ------------------------------------------------------
+# ---- comfort vs nuPlan bounds (#66 §3) ------------------------------------
+
+def test_comfort_reports_full_nuplan_key_set():
+    a, k = _zeros()
+    m = compute_comfort_metrics(a, k, np.full(B, 10.0))
+    for key in ("max_lon_accel", "min_lon_accel", "max_lat_accel", "max_yaw_rate",
+                "max_yaw_accel", "max_lon_jerk", "max_mag_jerk",
+                "comfort_violation_rate"):
+        assert key in m
+
 
 def test_comfort_smooth_trajectory_no_violations():
     a, k = _zeros()
     m = compute_comfort_metrics(a, k, np.full(B, 10.0))
     assert m["comfort_violation_rate"] == 0.0
     assert m["max_lon_jerk"] == 0.0 and m["max_yaw_rate"] == 0.0
+    assert m["max_mag_jerk"] == 0.0
 
 
-def test_comfort_aggressive_trajectory_violates():
-    # Alternating hard accel → huge longitudinal jerk.
+def test_comfort_aggressive_jerk_violates():
+    # Alternating hard accel → huge longitudinal jerk and jerk magnitude.
     a = np.tile(np.array([5.0, -5.0]), (B, T // 2))
     k = np.zeros((B, T))
     m = compute_comfort_metrics(a, k, np.full(B, 10.0))
     assert m["max_lon_jerk"] > COMFORT_THRESHOLDS["lon_jerk"]
-    assert m["lon_jerk_violation_rate"] == 1.0
+    assert m["max_mag_jerk"] > COMFORT_THRESHOLDS["mag_jerk"]
     assert m["comfort_violation_rate"] == 1.0
 
 
-def test_comfort_high_curvature_violates_lateral():
+def test_comfort_hard_braking_violates_lon_accel_bound():
+    # Constant hard braking: no jerk, but below the -4.05 m/s^2 lower bound.
+    a = np.full((B, T), -5.0)
+    k = np.zeros((B, T))
+    m = compute_comfort_metrics(a, k, np.full(B, 12.0))
+    assert m["min_lon_accel"] < COMFORT_THRESHOLDS["lon_accel_min"]
+    assert m["lon_accel_violation_rate"] == 1.0
+    assert m["max_lon_jerk"] == 0.0          # constant accel → no jerk
+    assert m["comfort_violation_rate"] == 1.0
+
+
+def test_comfort_high_curvature_violates_lateral_and_yaw():
     a, k = np.zeros((B, T)), np.full((B, T), 0.2)   # tight curve at speed
     m = compute_comfort_metrics(a, k, np.full(B, 10.0))
     assert m["max_lat_accel"] > COMFORT_THRESHOLDS["lat_accel"]
     assert m["max_yaw_rate"] > COMFORT_THRESHOLDS["yaw_rate"]
 
 
-# ---- off-road proxy (#66 §2) ----------------------------------------------
+# ---- off-road proxy: centre, footprint, dilation (#66 §2) -----------------
 
 def test_offroad_rate_all_drivable_is_zero():
     positions = np.random.randn(B, T, 2) * 2.0
@@ -65,6 +86,24 @@ def test_offroad_rate_nondrivable_is_one():
     positions = np.ones((B, T, 2)) * 5.0            # drive well forward/left
     mask = np.zeros((64, 64), dtype=bool)           # nothing drivable
     assert offroad_rate(positions, mask, meters_per_pixel=0.5) == 1.0
+
+
+def test_offroad_footprint_catches_corner_off_road():
+    # Centre stays drivable, but a forward footprint corner crosses a non-drivable
+    # line ahead → only the footprint check flags it.
+    mask = np.ones((64, 64), dtype=bool)
+    mask[22, :] = False                              # non-drivable line ahead
+    positions = np.zeros((1, 1, 2))                  # ego at the (drivable) centre
+    assert offroad_rate(positions, mask, 0.5) == 0.0
+    assert offroad_rate(positions, mask, 0.5, ego_size=(10.0, 4.0)) == 1.0
+
+
+def test_offroad_dilation_requires_margin():
+    mask = np.ones((64, 64), dtype=bool)
+    mask[:10, :] = False                             # top rows non-drivable
+    positions = np.array([[[10.5, 0.0]]])            # centre at row 11 (just inside)
+    assert offroad_rate(positions, mask, 0.5) == 0.0
+    assert offroad_rate(positions, mask, 0.5, dilation_px=2) == 1.0
 
 
 # ---- baselines (#66 §5) ----------------------------------------------------
@@ -96,11 +135,27 @@ def test_episode_range_split():
     assert len(val) == 10 and len(train) == 90
     assert set(train).isdisjoint(val)
     assert max(train) < min(val)              # val is the tail
+
+
+def test_episode_range_split_guards():
+    with pytest.raises(ValueError):
+        episode_range_split(1)                # too few episodes
     with pytest.raises(ValueError):
         episode_range_split(100, val_fraction=1.5)
+    # an extreme val_fraction must still leave a non-empty train split
+    train, val = episode_range_split(10, val_fraction=0.99)
+    assert len(train) >= 1 and len(val) >= 1
 
 
 def test_geographic_holdout_split():
     cities = ["berlin", "munich", "berlin", "hamburg", "munich"]
     train, val = geographic_holdout_split(cities, holdout_cities=["munich"])
     assert val == [1, 4] and train == [0, 2, 3]    # all munich episodes held out
+
+
+def test_geographic_holdout_empty_splits_raise():
+    cities = ["berlin", "hamburg"]
+    with pytest.raises(ValueError):
+        geographic_holdout_split(cities, holdout_cities=["paris"])      # no match → val empty
+    with pytest.raises(ValueError):
+        geographic_holdout_split(cities, holdout_cities=["berlin", "hamburg"])  # all held → train empty

--- a/Model/tests/test_evaluation_complementary.py
+++ b/Model/tests/test_evaluation_complementary.py
@@ -1,0 +1,106 @@
+"""Tests for the complementary open-loop evaluation pieces (#66).
+
+These cover only what this PR *adds* on top of the existing
+``compute_open_loop_metrics`` / ``gate_check`` already in ``evaluation``:
+comfort metrics from (a,κ), an off-road proxy, training-free baselines, and
+validation splits. Pure-numpy, no model or dataset needed.
+"""
+
+import numpy as np
+import pytest
+
+from evaluation import (
+    COMFORT_THRESHOLDS,
+    compute_comfort_metrics,
+    compute_open_loop_metrics,
+    constant_velocity_baseline,
+    episode_range_split,
+    geographic_holdout_split,
+    hold_last_action_baseline,
+    offroad_rate,
+)
+
+B, T = 4, 64
+
+
+def _zeros():
+    return np.zeros((B, T)), np.zeros((B, T))
+
+
+# ---- comfort (#66 §3) ------------------------------------------------------
+
+def test_comfort_smooth_trajectory_no_violations():
+    a, k = _zeros()
+    m = compute_comfort_metrics(a, k, np.full(B, 10.0))
+    assert m["comfort_violation_rate"] == 0.0
+    assert m["max_lon_jerk"] == 0.0 and m["max_yaw_rate"] == 0.0
+
+
+def test_comfort_aggressive_trajectory_violates():
+    # Alternating hard accel → huge longitudinal jerk.
+    a = np.tile(np.array([5.0, -5.0]), (B, T // 2))
+    k = np.zeros((B, T))
+    m = compute_comfort_metrics(a, k, np.full(B, 10.0))
+    assert m["max_lon_jerk"] > COMFORT_THRESHOLDS["lon_jerk"]
+    assert m["lon_jerk_violation_rate"] == 1.0
+    assert m["comfort_violation_rate"] == 1.0
+
+
+def test_comfort_high_curvature_violates_lateral():
+    a, k = np.zeros((B, T)), np.full((B, T), 0.2)   # tight curve at speed
+    m = compute_comfort_metrics(a, k, np.full(B, 10.0))
+    assert m["max_lat_accel"] > COMFORT_THRESHOLDS["lat_accel"]
+    assert m["max_yaw_rate"] > COMFORT_THRESHOLDS["yaw_rate"]
+
+
+# ---- off-road proxy (#66 §2) ----------------------------------------------
+
+def test_offroad_rate_all_drivable_is_zero():
+    positions = np.random.randn(B, T, 2) * 2.0
+    mask = np.ones((64, 64), dtype=bool)
+    assert offroad_rate(positions, mask, meters_per_pixel=0.5) == 0.0
+
+
+def test_offroad_rate_nondrivable_is_one():
+    positions = np.ones((B, T, 2)) * 5.0            # drive well forward/left
+    mask = np.zeros((64, 64), dtype=bool)           # nothing drivable
+    assert offroad_rate(positions, mask, meters_per_pixel=0.5) == 1.0
+
+
+# ---- baselines (#66 §5) ----------------------------------------------------
+
+def test_constant_velocity_baseline_is_zeros():
+    a, k = constant_velocity_baseline(B, T)
+    assert a.shape == (B, T) and np.all(a == 0) and np.all(k == 0)
+
+
+def test_hold_last_action_baseline_tiles():
+    a, k = hold_last_action_baseline(np.array([1.0, -2.0]), np.array([0.1, 0.0]), T)
+    assert a.shape == (2, T)
+    assert np.all(a[0] == 1.0) and np.all(a[1] == -2.0)
+    assert np.all(k[0] == 0.1)
+
+
+def test_baseline_scored_by_existing_metrics_runs():
+    # Baselines must plug straight into the existing compute_open_loop_metrics.
+    a, k = constant_velocity_baseline(B, T)
+    gt_a, gt_k = np.full((B, T), 0.3), np.zeros((B, T))
+    m = compute_open_loop_metrics(a, k, gt_a, gt_k, np.full(B, 6.0))
+    assert m["ADE@6.4s"] > 0.0  # const-vel diverges from an accelerating gt
+
+
+# ---- splits (#66 §4) -------------------------------------------------------
+
+def test_episode_range_split():
+    train, val = episode_range_split(100, val_fraction=0.1)
+    assert len(val) == 10 and len(train) == 90
+    assert set(train).isdisjoint(val)
+    assert max(train) < min(val)              # val is the tail
+    with pytest.raises(ValueError):
+        episode_range_split(100, val_fraction=1.5)
+
+
+def test_geographic_holdout_split():
+    cities = ["berlin", "munich", "berlin", "hamburg", "munich"]
+    train, val = geographic_holdout_split(cities, holdout_cities=["munich"])
+    assert val == [1, 4] and train == [0, 2, 3]    # all munich episodes held out


### PR DESCRIPTION
## What this adds (complements the existing eval, doesn't change it)

`Model/evaluation/` already provides `compute_open_loop_metrics` (multi-horizon
ADE/FDE + signal MAE) and `gate_check` (thanks @riita10069, via #78). This PR
adds the **remaining pieces of #66** on top, without touching those functions:

- **`metrics.py`**
  - `compute_comfort_metrics(pred_accel, pred_curv, initial_speed)` — longitudinal
    jerk, lateral acceleration, lateral jerk and yaw rate derived from the `(a, κ)`
    outputs, compared against **nuPlan comfort thresholds**, plus a
    `comfort_violation_rate`. Needs **no ground truth**.
  - `offroad_rate(positions, drivable_mask, meters_per_pixel)` — an off-road proxy
    for collision rate using the BEV **drivable mask**, since L2D has no
    other-agent labels.
- **`baselines.py`** — training-free `constant_velocity_baseline` and
  `hold_last_action_baseline` in the `(accel, curv)` action space, so they're
  scored by the **existing** `compute_open_loop_metrics`. These check whether
  perception actually beats ego-status extrapolation (the nuScenes ego-status
  critique, Zhai et al. 2023).
- **`splits.py`** — `geographic_holdout_split` (reserve whole cities, leakage-safe;
  Lilja et al., CVPR 2024) and a simple `episode_range_split` fallback.

## Notes

- Pure-numpy, additive, opt-in: `compute_open_loop_metrics` / `gate_check` and
  their exports are unchanged; this only appends new functions and two small
  modules.
- The displacement metrics from my earlier draft were intentionally **dropped**
  as redundant — `compute_open_loop_metrics` already covers ADE/FDE.
- 10 tests (`test_evaluation_complementary.py`); ruff + mypy clean.

@riita10069 since this sits directly on top of your evaluation module, happy to
fold any of it into your structure / Flyte workflow however you prefer.

Addresses #66 (comfort, off-road, baselines, splits).
