### PR TITLE
feat(data_parsing): offline pre-extraction of the World Model 1 Hz windows (#16)

### DIFF
--- a/Model/data_parsing/preextract_world_model.py
+++ b/Model/data_parsing/preextract_world_model.py
@@ -1,0 +1,119 @@
+"""Offline pre-extraction of the World Model 1 Hz multi-view windows (#16 / #30).
+
+The online ``L2DDataset(include_world_model_windows=True)`` builds the
+history/future windows by decoding video per frame (~tens of seconds per
+sample) — fine for correctness, far too slow for training. This module
+pre-extracts those windows **once, offline**, so training reads them at disk
+bandwidth (see ``data_parsing/pre_extracted.py``).
+
+Design — *content addressed* (avoids the ~2*N*V x blow-up):
+  Windows overlap heavily under 10 Hz -> 1 Hz subsampling, so we do NOT store
+  ``2*N*V`` images per sample. Instead, for each episode we store every needed
+  1 Hz multi-view frame **once** (keyed by its in-episode frame index), and each
+  training sample keeps only the *list of frame indices* for its history/future
+  window.
+
+This file keeps the planning/assembly logic **pure and dataset-agnostic** (unit
+tested without ``lerobot``): the actual video decode and JPEG I/O are injected as
+callables, exactly like ``world_model_windows.build_windows``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+
+import torch
+
+from .l2d.world_model_windows import required_margins, window_offsets
+
+# A multi-view frame is [V, 3, H, W]; a frame loader maps an in-episode index to one.
+FrameLoader = Callable[[int], torch.Tensor]
+
+
+def plan_episode_windows(
+    episode_len: int,
+    *,
+    num_frames: int = 4,
+    stride: int = 10,
+) -> tuple[list[int], dict[int, tuple[list[int], list[int]]], list[int]]:
+    """Plan which 1 Hz frames to extract for one episode.
+
+    Args:
+        episode_len: number of frames in the episode (local indices ``0..len-1``).
+        num_frames: N past = N future window length (default 4, per WG 24/06).
+        stride: frames between 1 Hz samples (``stride_for_hz(10, 1) == 10``).
+
+    Returns:
+        ``(valid_samples, per_sample, unique_frames)`` where
+        - ``valid_samples``: local indices with a full past+future window,
+        - ``per_sample``: ``{sample_idx: (history_idxs, future_idxs)}`` (local
+          frame indices, oldest→newest, current frame last in history),
+        - ``unique_frames``: sorted list of every frame index to decode **once**.
+
+    Uses the same offsets/margins as the online dataset (``world_model_windows``),
+    so the pre-extracted windows are identical to the on-the-fly ones.
+    """
+    if episode_len < 0:
+        raise ValueError(f"episode_len must be >= 0, got {episode_len}")
+    back, fwd = required_margins(num_frames, stride)
+    hist_off, fut_off = window_offsets(num_frames, stride)
+
+    valid_samples = list(range(back, episode_len - fwd))
+    per_sample: dict[int, tuple[list[int], list[int]]] = {}
+    unique: set[int] = set()
+    for s in valid_samples:
+        history = [s + o for o in hist_off]
+        future = [s + o for o in fut_off]
+        per_sample[s] = (history, future)
+        unique.update(history)
+        unique.update(future)
+    return valid_samples, per_sample, sorted(unique)
+
+
+def extract_episode(
+    load_frame: FrameLoader,
+    episode_len: int,
+    save_frame: Callable[[int, torch.Tensor], None],
+    *,
+    num_frames: int = 4,
+    stride: int = 10,
+) -> tuple[list[int], dict[int, tuple[list[int], list[int]]]]:
+    """Decode each needed 1 Hz frame **once** and hand it to ``save_frame``.
+
+    Args:
+        load_frame: ``frame_idx -> [V, 3, H, W]`` (decode + preprocess one frame).
+        episode_len: frames in the episode.
+        save_frame: ``(frame_idx, [V,3,H,W]) -> None`` sink (e.g. write JPEGs).
+        num_frames, stride: window config (must match the training-time loader).
+
+    Returns:
+        ``(valid_samples, per_sample)`` — the per-sample window index lists to
+        persist alongside the samples (e.g. as ``{key}.wm_windows.json``).
+    """
+    valid_samples, per_sample, unique_frames = plan_episode_windows(
+        episode_len, num_frames=num_frames, stride=stride)
+    for idx in unique_frames:
+        save_frame(idx, load_frame(idx))
+    return valid_samples, per_sample
+
+
+def assemble_window(
+    frame_store: Mapping[int, torch.Tensor] | Callable[[int], torch.Tensor],
+    history_idxs: Sequence[int],
+    future_idxs: Sequence[int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Rebuild a window from a frame store (training time, no video decode).
+
+    Args:
+        frame_store: either a mapping ``idx -> [V,3,H,W]`` or a callable
+            ``idx -> [V,3,H,W]`` (e.g. lazily reading a cached JPEG).
+        history_idxs, future_idxs: the index lists from ``per_sample``.
+
+    Returns:
+        ``(history_frames, future_frames)``, each ``[N, V, 3, H, W]`` (oldest→
+        newest), matching ``world_model_windows.build_windows``' contract.
+    """
+    get = frame_store.__getitem__ if isinstance(frame_store, Mapping) else frame_store
+    history = torch.stack([get(i) for i in history_idxs], dim=0)
+    future = torch.stack([get(i) for i in future_idxs], dim=0)
+    return history, future

--- a/Model/tests/test_preextract_world_model.py
+++ b/Model/tests/test_preextract_world_model.py
@@ -1,0 +1,104 @@
+"""Tests for the offline World Model window pre-extraction (#16 / #30).
+
+Pure planning + assembly; no lerobot, no video decode — a synthetic in-memory
+frame store stands in for the JPEG cache.
+"""
+
+import pytest
+import torch
+
+from data_parsing.preextract_world_model import (
+    assemble_window,
+    extract_episode,
+    plan_episode_windows,
+)
+from data_parsing.l2d.world_model_windows import build_windows, window_offsets
+
+V, H, W = 7, 3, 8  # tiny multi-view frame for tests
+
+
+def _fake_frame(idx: int) -> torch.Tensor:
+    """A [V,3,H,W] frame whose contents encode its own index (for assertions)."""
+    return torch.full((V, 3, H, W), float(idx))
+
+
+# ---- planning --------------------------------------------------------------
+
+def test_plan_valid_range_and_window_indices():
+    valid, per_sample, unique = plan_episode_windows(100, num_frames=4, stride=10)
+    # back=(N-1)*s=30, fwd=N*s=40 → valid = [30, 60)
+    assert valid[0] == 30 and valid[-1] == 59 and len(valid) == 30
+    # current frame is the LAST of the history; future starts at +stride
+    h, f = per_sample[30]
+    assert h == [0, 10, 20, 30] and f == [40, 50, 60, 70]
+    h2, f2 = per_sample[59]
+    assert h2 == [29, 39, 49, 59] and f2 == [69, 79, 89, 99]
+    # every index stays inside the episode
+    assert min(unique) >= 0 and max(unique) <= 99
+
+
+def test_plan_is_content_addressed_not_blown_up():
+    valid, _, unique = plan_episode_windows(100, num_frames=4, stride=10)
+    naive = 2 * 4 * len(valid)          # what storing 2*N frames per sample would cost
+    assert len(unique) <= 100            # bounded by episode length...
+    assert len(unique) < naive           # ...and far below the naive per-sample count
+
+
+def test_plan_too_short_episode_has_no_samples():
+    valid, per_sample, unique = plan_episode_windows(40, num_frames=4, stride=10)
+    assert valid == [] and per_sample == {} and unique == []
+
+
+@pytest.mark.parametrize("num_frames,stride", [(4, 10), (4, 1), (6, 5), (2, 3)])
+def test_plan_indices_consistent_with_window_offsets(num_frames, stride):
+    hist_off, fut_off = window_offsets(num_frames, stride)
+    _, per_sample, _ = plan_episode_windows(200, num_frames=num_frames, stride=stride)
+    s = next(iter(per_sample))
+    h, f = per_sample[s]
+    assert h == [s + o for o in hist_off]
+    assert f == [s + o for o in fut_off]
+
+
+# ---- assembly --------------------------------------------------------------
+
+def test_assemble_shapes_and_order_from_mapping():
+    _, per_sample, _ = plan_episode_windows(100, num_frames=4, stride=10)
+    h_idx, f_idx = per_sample[30]
+    store = {i: _fake_frame(i) for i in (h_idx + f_idx)}
+    history, future = assemble_window(store, h_idx, f_idx)
+    assert history.shape == (4, V, 3, H, W) and future.shape == (4, V, 3, H, W)
+    # frame k must equal the frame stored at h_idx[k] (order preserved)
+    for k, idx in enumerate(h_idx):
+        assert torch.equal(history[k], _fake_frame(idx))
+    for k, idx in enumerate(f_idx):
+        assert torch.equal(future[k], _fake_frame(idx))
+
+
+def test_assemble_accepts_callable_store():
+    _, per_sample, _ = plan_episode_windows(100, num_frames=4, stride=10)
+    h_idx, f_idx = per_sample[45]
+    history, future = assemble_window(_fake_frame, h_idx, f_idx)  # lazy loader
+    assert history.shape == (4, V, 3, H, W)
+    assert torch.equal(history[-1], _fake_frame(45))  # current frame last in history
+
+
+# ---- end-to-end: extract once → assemble matches the online build_windows --
+
+def test_extract_then_assemble_matches_online_build_windows():
+    episode_len = 100
+    store: dict[int, torch.Tensor] = {}
+    valid, per_sample = extract_episode(
+        _fake_frame, episode_len, store.__setitem__, num_frames=4, stride=10)
+
+    # each needed frame was decoded exactly once
+    assert len(store) == len(set(store))
+
+    for s in (valid[0], valid[len(valid) // 2], valid[-1]):
+        h_idx, f_idx = per_sample[s]
+        pre_h, pre_f = assemble_window(store, h_idx, f_idx)
+
+        # the online path (decode every frame on the fly) must give the same thing
+        on_h, on_f = build_windows(
+            load_frame=lambda row: _fake_frame(row),
+            row=s, ep_start=0, ep_end=episode_len, num_frames=4, stride=10)
+        assert torch.equal(pre_h, on_h) and torch.equal(pre_f, on_f)


### PR DESCRIPTION

## What this adds

Training the World Model on real data is bottlenecked by **video decode**: the online `L2DDataset(include_world_model_windows=True)` (#95) builds each 1 Hz history/future window by decoding MP4 frames on the fly (~tens of seconds per sample). This PR adds an **offline pre-extraction** of those windows so training reads them at disk bandwidth instead.

It is **pure windowing logic** (no `lerobot`, no I/O baked in — decode and storage are injected, exactly like `build_windows` in #95), so it is unit-tested in isolation and adds nothing to the default training/inference path.

## Design (`data_parsing/preextract_world_model.py`, new)

Content-addressed, to avoid a ~`2·N·V`× blow-up: the 1 Hz windows of consecutive samples overlap heavily, so instead of storing `2·N·V` frames per sample, each needed 1 Hz frame of an episode is stored **once** and each sample keeps only the **index lists** for its window.

- `plan_episode_windows(episode_len, num_frames=4, stride=10)` → the valid sample indices, each sample's `(history, future)` 1 Hz index lists, and the **set of unique frames to decode once**. Reuses `window_offsets` / `required_margins` from `world_model_windows.py` (#95), so the pre-extracted windows are **identical** to the online ones.
- `extract_episode(load_frame, episode_len, save_frame, …)` → decode each unique frame once → `save_frame` sink.
- `assemble_window(frame_store, history_idxs, future_idxs)` → rebuild `[N, V, 3, H, W]` history/future at train time from a frame store (a mapping or a lazy callable), without decoding video.

## How it fits

Same windows as #95, but precomputed once: `history_frames` feed the `WorldActionModel` (#85) and `future_frames` are the JEPA targets (#13). Motivated by the frame-loading-strategy discussion in #30.

## Scope / not in this PR (kept honest)

This is the first of the small PRs outlined in #16 — **only the windowing logic + its tests**. The next two steps from that plan are deliberately left out to keep this reviewable:
- wiring it into `pre_extracted.py` so the WebDataset loader emits `history_frames` / `future_frames`;
- adding it to the Flyte `data_processing` workflow that writes the shards (with @riita10069, who owns that pipeline).

## Tests

`pytest Model/tests/test_preextract_world_model.py` → **10 passed** (planning ranges, content-addressed dedup, episode boundaries, and **equivalence with the online `build_windows`**); full suite 221 passed; ruff + mypy clean. Off current `main` (`ab3651e`).
