### PR TITLE
feat(world action model): view attention pool to encode multi camera views for wam

### DIFF
--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -39,10 +39,11 @@ class AutoE2E(nn.Module):
         if enable_world_model:
             wmk = dict(world_model_kwargs or {})
             history_len = wmk.pop("history_len", 4)
+            wmk.setdefault("view_aggregator", "attention")
             self.World_Action_Model_E2E = WorldActionModel(
                 backbone=self.Reactive_E2E.Backbone,
                 frame_embed_dim=visual_history_dim // history_len,
-                history_len=history_len, **wmk,
+                history_len=history_len, num_views=num_views, **wmk,
             )
             self.visual_history_buffer = RollingHistoryBuffer(history_len=history_len)
 

--- a/Model/model_components/world_action_model.py
+++ b/Model/model_components/world_action_model.py
@@ -24,11 +24,45 @@ loop. Reuses the merged building blocks (JepaTargetEncoder,
 FeatureReconstructionLoss).
 """
 
+import logging
 import torch
 import torch.nn as nn
 
 from .jepa_target_encoder import JepaTargetEncoder, compute_jepa_loss
 from .losses.feature_reconstruction_loss import FeatureReconstructionLoss
+
+logger = logging.getLogger(__name__)
+
+
+class ViewAttentionPool(nn.Module):
+    """Learnable multi-camera combiner: [B, V, C] -> [B, C].
+
+    Opt-in replacement for the equal-weight mean over views: a single learned
+    query cross-attends over the V per-view tokens (+ camera-id embeddings),
+    so cameras are weighted by relevance instead of averaged.
+    """
+
+    def __init__(self, embed_dim: int = 768, num_views: int = 7, num_heads: int = 4):
+        super().__init__()
+        self.view_embed = nn.Parameter(torch.randn(1, num_views, embed_dim) * 0.02)
+        self.query = nn.Parameter(torch.randn(1, 1, embed_dim) * 0.02)
+        self.attn = nn.MultiheadAttention(embed_dim, num_heads, batch_first=True)
+        self.norm = nn.LayerNorm(embed_dim)
+
+    def forward(self, view_tokens: torch.Tensor) -> torch.Tensor:
+        # view_tokens: [B, V, C]   (C = embed_dim = 768)
+        B, V, C = view_tokens.shape
+        # Handle dynamic view sizes by slicing or repeating positional embeddings
+        if V <= self.view_embed.shape[1]:
+            v_embed = self.view_embed[:, :V]
+        else:
+            extra = V - self.view_embed.shape[1]
+            v_embed = torch.cat([self.view_embed, self.view_embed[:, :extra]], dim=1)
+            
+        tok = view_tokens + v_embed
+        q = self.query.expand(B, -1, -1)
+        out, _ = self.attn(q, tok, tok)
+        return self.norm(out.squeeze(1))
 
 
 class FrameEncoder(nn.Module):
@@ -38,22 +72,43 @@ class FrameEncoder(nn.Module):
     """
 
     def __init__(self, backbone: nn.Module, feature_channels: int = 768,
-                 frame_embed_dim: int = 224):
+                 frame_embed_dim: int = 224, view_aggregator: str = "attention",
+                 num_views: int = 7):
         super().__init__()
         self.backbone = backbone
         self.proj = nn.Linear(feature_channels, frame_embed_dim)
+        if num_views == 1 and view_aggregator == "attention":
+            logger.warning(
+                "num_views is 1; falling back view_aggregator from 'attention' to 'mean' "
+                "to avoid unnecessary attention overhead."
+            )
+            view_aggregator = "mean"
+
+        self.view_aggregator = view_aggregator
+        
+        if view_aggregator not in ("mean", "attention"):
+            raise ValueError(f"Unknown view_aggregator {view_aggregator!r}. Available: 'mean', 'attention'.")
+            
+        if view_aggregator == "attention":
+            self.view_pool = ViewAttentionPool(embed_dim=feature_channels, num_views=num_views)
 
     def forward(self, frame: torch.Tensor) -> torch.Tensor:
         """``[B, 3, H, W]`` or multi-view ``[B, V, 3, H, W]`` -> ``[B, embed]``.
 
         For multi-view input each camera is encoded and the per-view embeddings
-        are mean-pooled into a single per-frame embedding.
+        are aggregated (via mean or attention) into a single per-frame embedding.
         """
         if frame.dim() == 5:                       # [B, V, 3, H, W]
             B, V = frame.shape[:2]
             feats = self.backbone(frame.reshape(B * V, *frame.shape[2:]))
             m = feats[-1] if isinstance(feats, (list, tuple)) else feats
-            m = m.mean(dim=(2, 3)).reshape(B, V, -1).mean(dim=1)  # GAP + pool views
+            m = m.mean(dim=(2, 3)).reshape(B, V, -1)             # [B, V, feature_channels]
+            
+            if self.view_aggregator == "attention":
+                m = self.view_pool(m)                            # [B, feature_channels]
+            else:
+                m = m.mean(dim=1)                                # [B, feature_channels]
+                
             return self.proj(m)                                  # [B, embed]
         feats = self.backbone(frame)               # [B, 3, H, W]
         m = feats[-1] if isinstance(feats, (list, tuple)) else feats
@@ -193,7 +248,8 @@ class WorldActionModel(nn.Module):
     def __init__(self, backbone: nn.Module, feature_channels: int = 768,
                  frame_embed_dim: int = 224, history_len: int = 4,
                  num_future_steps: int = 4, loss_type: str = "l1",
-                 history_aggregator: str = "concat", feature_hw: int = 8):
+                 history_aggregator: str = "concat", feature_hw: int = 8,
+                 view_aggregator: str = "attention", num_views: int = 7):
         super().__init__()
         if history_aggregator not in ("concat", "attention"):
             raise ValueError(
@@ -215,7 +271,10 @@ class WorldActionModel(nn.Module):
             if history_aggregator == "attention" else None)
 
         # Online per-frame encoder (shared backbone, trainable) -> 224 history embedding.
-        self.encoder = FrameEncoder(backbone, feature_channels, frame_embed_dim)
+        self.encoder = FrameEncoder(
+            backbone, feature_channels, frame_embed_dim,
+            view_aggregator=view_aggregator, num_views=num_views
+        )
         # JEPA target: a FROZEN, stop-gradient copy of the backbone FEATURE MAP
         # extractor (#1). Per Zain's #85 review (30/06) the JEPA reconstructs the
         # future backbone feature maps [B, C, hw, hw], not a pooled vector.

--- a/Model/model_components/world_action_model.py
+++ b/Model/model_components/world_action_model.py
@@ -35,11 +35,12 @@ logger = logging.getLogger(__name__)
 
 
 class ViewAttentionPool(nn.Module):
-    """Learnable multi-camera combiner: [B, V, C] -> [B, C].
+    """Default multi-camera fusion via cross-attention: ``[B, V, C] -> [B, C]``.
 
-    Opt-in replacement for the equal-weight mean over views: a single learned
-    query cross-attends over the V per-view tokens (+ camera-id embeddings),
-    so cameras are weighted by relevance instead of averaged.
+    A single learned query attends over the per-view tokens with learnable camera-
+    position embeddings, weighting cameras by relevance.
+    Used by default in ``FrameEncoder`` (``view_aggregator="attention"``); set
+    ``view_aggregator="mean"`` to revert to the equal-weight mean.
     """
 
     def __init__(self, embed_dim: int = 768, num_views: int = 7, num_heads: int = 4):

--- a/Model/tests/test_world_action_model.py
+++ b/Model/tests/test_world_action_model.py
@@ -58,6 +58,43 @@ def test_frame_encoder_shape(device):
     assert enc(_frame(2, device)).shape == (2, 224)
 
 
+def test_frame_encoder_view_aggregators(device):
+    # test default (attention)
+    enc_attn = FrameEncoder(_MockBackbone(), feature_channels=CH,
+                            frame_embed_dim=224).to(device)
+    assert enc_attn.view_aggregator == "attention"
+    assert hasattr(enc_attn, "view_pool")
+    assert enc_attn(_window(2, 6, device)).shape == (2, 224)
+    
+    # test mean
+    enc_mean = FrameEncoder(_MockBackbone(), feature_channels=CH,
+                            frame_embed_dim=224, view_aggregator="mean").to(device)
+    assert enc_mean.view_aggregator == "mean"
+    assert not hasattr(enc_mean, "view_pool")
+    assert enc_mean(_window(2, 6, device)).shape == (2, 224)
+
+
+def test_world_action_model_view_aggregator(device, caplog):
+    m_mean = _wam(device, view_aggregator="mean")
+    assert m_mean.encoder.view_aggregator == "mean"
+    
+    m_attn = _wam(device, view_aggregator="attention")
+    assert m_attn.encoder.view_aggregator == "attention"
+    assert m_attn.encoder.view_pool.view_embed.shape[1] > 0
+
+    # test custom num_views configuration
+    m_attn_6 = _wam(device, view_aggregator="attention", num_views=6)
+    assert m_attn_6.encoder.view_pool.view_embed.shape[1] == 6
+
+    # test fallback warning when num_views=1 and view_aggregator="attention"
+    import logging
+    with caplog.at_level(logging.WARNING):
+        m_attn_1 = _wam(device, view_aggregator="attention", num_views=1)
+    assert any("num_views is 1" in record.message for record in caplog.records)
+    assert m_attn_1.encoder.view_aggregator == "mean"
+    assert not hasattr(m_attn_1.encoder, "view_pool")
+
+
 def test_forward_per_tick_returns_embedding_and_future(device):
     """Zain's API: visual_embedding, future_state_pred = WAM(frame, visual_history)."""
     m = _wam(device)


### PR DESCRIPTION
## feat(world action model): Multi-Camera View Attention Pooling as default

### Motivation & Architectural Context

Currently multi-camera features were aggregated by taking a naive arithmetic mean across the view dimension (`.mean(dim=1)`) (related to #85). While computationally cheap, mean-pooling might  have the limitation of not being able to preserve the information of each view for spatial representations as the mean  will blends all camera views equally.

In this PR we introduce a flexible, parameterized **Cross-Attention Pooling** mechanism. By anchoring camera views with explicit slot-based positional embeddings, the network preserves the unique spatial signature of each camera angle, enabling the World Action Model (WAM) to learn direction-aware representations during self-supervised JEPA training.

### Summary of Changes

#### 1. View Attention Pooling & Parameter Propagation

`num_views` is now propagated dynamically from the high-level `AutoE2E` architecture down through `WorldActionModel`, `FrameEncoder`, and `ViewAttentionPool`. This allows the learnable positional embeddings to adapt automatically to different sensor layouts (e.g., switching between 6-camera and 7-camera vehicle configurations) without code changes.

**`auto_e2e.py`**
```python
self.World_Action_Model_E2E = WorldActionModel(
    backbone=self.Reactive_E2E.Backbone,
    frame_embed_dim=visual_history_dim // history_len,
    history_len=history_len,
    num_views=num_views,
    **wmk,
)
```

#### 2. Single-View Fallback Optimization

When only one camera view is configured (`num_views == 1`), running a single token through a cross-attention block adds unnecessary computation overhead. In this case, the initialization pipeline automatically falls back to a lightweight "mean" aggregator (effectively a squeeze operation) and logs a warning so the behavior stays visible.

**`world_action_model.py`**
```python
if num_views == 1 and view_aggregator == "attention":
    logger.warning(
        "num_views is 1; falling back view_aggregator from 'attention' to 'mean' "
        "to avoid unnecessary attention overhead."
    )
    view_aggregator = "mean"
```

#### 3. Unit Test Updates
Added new cases to cover dynamic positional-embedding sizing and verify the single-view warning and fallback logic.

**`test_world_action_model.py`**
```python
def test_world_action_model_view_aggregator(device, caplog):
    m_mean = _wam(device, view_aggregator="mean")
    assert m_mean.encoder.view_aggregator == "mean"

    m_attn = _wam(device, view_aggregator="attention")
    assert m_attn.encoder.view_aggregator == "attention"
    assert m_attn.encoder.view_pool.view_embed.shape[1] > 0

    # Custom num_views configuration
    m_attn_6 = _wam(device, view_aggregator="attention", num_views=6)
    assert m_attn_6.encoder.view_pool.view_embed.shape[1] == 6

    # Fallback warning when num_views=1 and view_aggregator="attention"
    import logging
    with caplog.at_level(logging.WARNING):
        m_attn_1 = _wam(device, view_aggregator="attention", num_views=1)
    assert any("num_views is 1" in record.message for record in caplog.records)
    assert m_attn_1.encoder.view_aggregator == "mean"
    assert not hasattr(m_attn_1.encoder, "view_pool")
```

---

### Verification 

- **Core functionality:** Confirmed multi-view arrays aggregate correctly with no feature-map shape corruption.
- **Fallback behavior:** Verified via log capture that `num_views=1` correctly triggers the performance bypass.
- **Regression tests:** Confirmed downstream reactive-planner expectations for the `[B, 896]` history output dimension remain unaffected.

Closes #93