### PR TITLE
feat(reasoning): scenario-classification band with zero-init planner gate and per-horizon confidence (#98)

### DIFF
--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -1,4 +1,7 @@
+from typing import Any, Dict, Optional
+
 import torch.nn as nn
+
 from .reactive_e2e import ReactiveE2E
 from .world_action_model import RollingHistoryBuffer, WorldActionModel
 
@@ -13,7 +16,9 @@ class AutoE2E(nn.Module):
                  map_fusion_mode="residual", map_fusion_kwargs=None,
                  temporal_memory_mode="no_memory", temporal_memory_kwargs=None,
                  planner_mode="bezier", planner_kwargs=None,
-                 enable_world_model=False, world_model_kwargs=None):
+                 enable_world_model=False, world_model_kwargs=None,
+                 enable_reasoning_band=False,
+                 reasoning_kwargs: Optional[Dict[str, Any]] = None):
         super(AutoE2E, self).__init__()
 
         # Reactive model which runs at 10Hz and processes multi-camera inputs
@@ -34,8 +39,8 @@ class AutoE2E(nn.Module):
         # future visual features (JEPA). Reuses the reactive backbone (one shared
         # backbone; the JEPA target is a frozen copy of it). Opt-in (default OFF)
         # so the reactive-only default is byte-identical.
-        self.World_Action_Model_E2E = None
-        self.visual_history_buffer = None
+        self.World_Action_Model_E2E: Optional[WorldActionModel] = None
+        self.visual_history_buffer: Optional[RollingHistoryBuffer] = None
         if enable_world_model:
             wmk = dict(world_model_kwargs or {})
             history_len = wmk.pop("history_len", 4)
@@ -45,6 +50,20 @@ class AutoE2E(nn.Module):
                 history_len=history_len, **wmk,
             )
             self.visual_history_buffer = RollingHistoryBuffer(history_len=history_len)
+
+        # Reasoning Band (slow, ~1Hz): classifies the current (and in training,
+        # future) scenario across multi-label taxonomy groups, supervised by
+        # the student/teacher loss, and feeds the trajectory planner through a
+        # ZERO-INIT gate that modulates the visual history (#98/#103) — a
+        # strict no-op at initialisation, so with the gate untrained the
+        # reactive baseline is unchanged.  Opt-in (default OFF) so the
+        # reactive-only baseline is byte-for-byte unchanged when disabled.
+        self.Reasoning_Band: Optional[nn.Module] = None
+        if enable_reasoning_band:
+            from .reasoning.reasoning_band import ReasoningBand  # local import — lazy
+            rkw = dict(reasoning_kwargs or {})
+            rkw.setdefault("visual_history_dim", visual_history_dim)
+            self.Reasoning_Band = ReasoningBand(**rkw)
 
     def reset_visual_history(self):
         """Clear the World Model's rolling buffer (call between sequences)."""
@@ -104,21 +123,40 @@ class AutoE2E(nn.Module):
             # Encode the current 1 Hz multi-view frame; push a detached copy so the
             # planner's history is a pure rolling memory (no graph across steps).
             visual_embedding, _ = wam(camera_tiles)
-            self.visual_history_buffer.push(visual_embedding.detach())
+            self.visual_history_buffer.push(visual_embedding.detach())  # type: ignore[union-attr]
             # The planner and the future prediction read the SAME history (post-push,
             # i.e. including the current frame) so the JEPA context stays aligned
             # with what the planner actually sees.
             visual_history = wam.aggregate_history(
-                self.visual_history_buffer.visual_history())
+                self.visual_history_buffer.visual_history())  # type: ignore[union-attr]
             if mode == "train":
                 future_state_pred = wam.predict_future(visual_history)
+
+        # Reasoning Band (1Hz): classify the current scenario (and, in training,
+        # future horizons), then condition the planner through the band's
+        # zero-init gate: the planner receives the MODULATED visual history,
+        # which at initialisation is identical to the input (strict no-op) and
+        # only diverges as training moves the gate (#98/#103).
+        reasoning_pred = None
+        if self.Reasoning_Band is not None:
+            reasoning_pred = self.Reasoning_Band(visual_history, mode=mode)
+            visual_history = reasoning_pred.modulated_visual_history
 
         trajectory = self.Reactive_E2E(camera_tiles, map_input, visual_history, egomotion_history,
         camera_params=camera_params, mode=mode, trajectory_target=trajectory_target, **kwargs)
 
-        # Inference: just the trajectory. Training with the World Model on: also
-        # return the predicted future state (the differentiable JEPA loss itself is
-        # computed in the training loop via the windowed WorldActionModel path).
+        # Return contract:
+        #   * Reasoning band OFF, World Model OFF → same as before (scalar / trajectory).
+        #   * World Model ON, mode="train" → (trajectory, future_state_pred)       [existing]
+        #   * Reasoning Band ON, mode="train" → (trajectory, future_state_pred, reasoning_pred)
+        #   * Reasoning Band ON, mode!="train" → same as World-Model-only path
+        #
+        # The reasoning_pred follows the same pattern as future_state_pred: only
+        # returned in mode="train" (with the future horizons) for the training
+        # loop to compute the reasoning loss.  It is a ReasoningPrediction
+        # (per-group logits + per-horizon confidence + the modulated history).
+        if self.Reasoning_Band is not None and mode == "train":
+            return trajectory, future_state_pred, reasoning_pred
         if self.World_Action_Model_E2E is not None and mode == "train":
             return trajectory, future_state_pred
         return trajectory

--- a/Model/model_components/reasoning/__init__.py
+++ b/Model/model_components/reasoning/__init__.py
@@ -1,0 +1,10 @@
+"""Reasoning band — scenario classification head for AutoE2E (issue #98).
+
+This package is opt-in (default OFF); importing it never pulls heavy
+dependencies (the Qwen2-VL backend uses a lazy import inside its module).
+"""
+
+from .scenario_taxonomy import ScenarioTaxonomy, TaxonomyGroup
+from .reasoning_band import ReasoningBand
+
+__all__ = ["ScenarioTaxonomy", "TaxonomyGroup", "ReasoningBand"]

--- a/Model/model_components/reasoning/reasoning_band.py
+++ b/Model/model_components/reasoning/reasoning_band.py
@@ -1,0 +1,233 @@
+"""Reasoning Band — multi-label, multi-horizon scenario classification (issue #98).
+
+The band consumes the 896-dim Encoded Visual History (the same vector the World
+Action Model produces via :meth:`WorldActionModel.aggregate_history`) and
+decodes it into per-group sigmoid classification heads for the current scenario
+and — in training — four future horizons at +1 … +4 s (@1 Hz).
+
+Its scenario prediction is supervised by the Video-Language-Model loss
+(student/teacher, see ``Model/training/losses/reasoning_loss.py``).  In
+addition, the band feeds the trajectory planner through a **zero-init gate**
+(agreed in issues #98/#103): the current-scenario probabilities modulate the
+visual history via a FiLM-style transform whose weights start at zero, so the
+reactive baseline is byte-identical at initialisation and the coupling only
+takes effect as training pushes the gate away from zero.  A per-horizon
+**confidence head** (issue #103, temporal-first) accompanies the class logits.
+
+Architecture summary:
+
+    896-dim visual_history
+        ├── trunk (shared MLP)
+        │       ├── per-group × per-horizon sigmoid heads → multi-label logits
+        │       └── confidence head                       → [B, horizons]
+        └── zero-init gate (conditioned on current-scenario probabilities)
+                └── modulated visual_history              → trajectory planner
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+from .scenario_taxonomy import ScenarioTaxonomy, DEFAULT_TAXONOMY
+
+
+# ---------------------------------------------------------------------------
+# Typed output containers
+# ---------------------------------------------------------------------------
+
+# ReasoningOutput[group_name][horizon_index] = raw logits [B, num_classes]
+ReasoningOutput = Dict[str, List[torch.Tensor]]
+
+
+@dataclass
+class ReasoningPrediction:
+    """Typed result of one reasoning-band forward pass (1 Hz tick).
+
+    Fields:
+        logits: dict mapping each taxonomy group to a list of per-horizon raw
+            logits ``[B, num_classes]`` (apply ``torch.sigmoid`` for
+            probabilities).  Train mode: ``1 + num_future_horizons`` entries;
+            other modes: 1 (current scenario only).
+        confidence: ``[B, num_horizons]`` raw logits for the per-horizon
+            confidence (issue #103, temporal-first).  Same horizon count as
+            ``logits``.
+        modulated_visual_history: ``[B, visual_history_dim]`` — the visual
+            history after the zero-init gate.  Identical to the input at
+            initialisation (strict no-op) so the reactive baseline is
+            unchanged until training moves the gate.
+    """
+
+    logits: ReasoningOutput
+    confidence: torch.Tensor
+    modulated_visual_history: torch.Tensor
+
+
+# ---------------------------------------------------------------------------
+# Zero-init gate (planner coupling, issues #98/#103)
+# ---------------------------------------------------------------------------
+
+
+class ZeroInitGate(nn.Module):
+    """FiLM-style gate that modulates the visual history with scenario probs.
+
+    ``output = visual_history * (1 + gamma) + beta`` where ``gamma`` and
+    ``beta`` are linear projections of the current-scenario probability
+    vector.  Both projections are zero-initialised (weights AND biases), so at
+    initialisation the gate is a strict no-op — the same alpha=0 pattern the
+    repo uses in ``ResidualMapFusion``.  Gradients move the gate away from
+    zero only where the scenario signal helps the trajectory.
+
+    Args:
+        scenario_dim: size of the conditioning vector (total classes across
+            all taxonomy groups).
+        visual_history_dim: dimensionality of the visual history (default 896).
+    """
+
+    def __init__(self, scenario_dim: int, visual_history_dim: int) -> None:
+        super().__init__()
+        self.gamma = nn.Linear(scenario_dim, visual_history_dim)
+        self.beta = nn.Linear(scenario_dim, visual_history_dim)
+        nn.init.zeros_(self.gamma.weight)
+        nn.init.zeros_(self.gamma.bias)
+        nn.init.zeros_(self.beta.weight)
+        nn.init.zeros_(self.beta.bias)
+
+    def forward(
+        self, visual_history: torch.Tensor, scenario_probs: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply the gate.
+
+        Args:
+            visual_history: ``[B, visual_history_dim]``.
+            scenario_probs: ``[B, scenario_dim]`` current-scenario
+                probabilities in ``[0, 1]``.
+
+        Returns:
+            Modulated ``[B, visual_history_dim]`` (equal to the input at init).
+        """
+        gamma = self.gamma(scenario_probs)
+        beta = self.beta(scenario_probs)
+        return visual_history * (1.0 + gamma) + beta
+
+
+# ---------------------------------------------------------------------------
+# Main module
+# ---------------------------------------------------------------------------
+
+
+class ReasoningBand(nn.Module):
+    """Multi-label, multi-horizon scenario classification band for AutoE2E.
+
+    Consumes the 896-dim Encoded Visual History produced by the World Action
+    Model and outputs, per taxonomy group, sigmoid classification logits for
+    the current scene and (in training) four future horizons at +1 … +4 s,
+    plus a per-horizon confidence (issue #103).  The current-scenario
+    probabilities feed the trajectory planner through a zero-init gate.
+
+    Args:
+        visual_history_dim: input dimensionality (must match the Encoded
+            Visual History dimension, default 896).
+        hidden_dim: width of the shared trunk (default 256).
+        num_future_horizons: future horizons predicted in training
+            (default 4, for h=+1..+4 s at 1 Hz).
+        taxonomy: scenario label registry (defaults to
+            :data:`DEFAULT_TAXONOMY`).
+
+    Example::
+
+        band = ReasoningBand()
+        pred = band(visual_history, mode="train")   # visual_history: [B, 896]
+        pred.logits["maneuver"]          # list of 5 tensors [B, 7] (h=0..4)
+        pred.confidence                  # [B, 5]
+        pred.modulated_visual_history    # [B, 896] (== input at init)
+    """
+
+    def __init__(
+        self,
+        visual_history_dim: int = 896,
+        hidden_dim: int = 256,
+        num_future_horizons: int = 4,
+        taxonomy: Optional[ScenarioTaxonomy] = None,
+    ) -> None:
+        super().__init__()
+        self.visual_history_dim = visual_history_dim
+        self.num_future_horizons = num_future_horizons
+        self.taxonomy = taxonomy if taxonomy is not None else DEFAULT_TAXONOMY
+
+        # Shared trunk: project the visual history into a compact representation.
+        self.trunk = nn.Sequential(
+            nn.Linear(visual_history_dim, hidden_dim),
+            nn.GELU(),
+            nn.LayerNorm(hidden_dim),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.GELU(),
+        )
+
+        # One linear head per (group, horizon): h=0 (current) plus
+        # h=1..num_future_horizons (future, train mode only).
+        total_horizons = 1 + num_future_horizons
+        self.heads = nn.ModuleDict(
+            {
+                f"{group.name}_h{h}": nn.Linear(hidden_dim, len(group))
+                for group in self.taxonomy.groups
+                for h in range(total_horizons)
+            }
+        )
+
+        # Per-horizon confidence (raw logits; issue #103, temporal-first).
+        self.confidence_head = nn.Linear(hidden_dim, total_horizons)
+
+        # Planner coupling: zero-init gate conditioned on the current-scenario
+        # probability vector (all groups concatenated).
+        self.gate = ZeroInitGate(
+            scenario_dim=self.taxonomy.total_classes(),
+            visual_history_dim=visual_history_dim,
+        )
+
+    def forward(
+        self,
+        visual_history: torch.Tensor,
+        mode: str = "infer",
+        images: Optional[torch.Tensor] = None,
+    ) -> ReasoningPrediction:
+        """Run the reasoning band.
+
+        Args:
+            visual_history: ``[B, visual_history_dim]`` — the Encoded Visual
+                History from :meth:`WorldActionModel.aggregate_history`.
+            mode: ``"train"`` produces all ``1 + num_future_horizons``
+                horizons; any other value produces only the current horizon.
+            images: unused by this variant (present so the frozen-VLM variant
+                can share the same call signature in ``AutoE2E``).
+
+        Returns:
+            A :class:`ReasoningPrediction`.
+        """
+        del images  # only the frozen-VLM variant consumes raw frames
+        features = self.trunk(visual_history)
+        num_horizons = 1 + self.num_future_horizons if mode == "train" else 1
+
+        logits: ReasoningOutput = {}
+        for group in self.taxonomy.groups:
+            logits[group.name] = [
+                self.heads[f"{group.name}_h{h}"](features)
+                for h in range(num_horizons)
+            ]
+
+        confidence = self.confidence_head(features)[:, :num_horizons]
+
+        current_probs = torch.cat(
+            [torch.sigmoid(logits[g.name][0]) for g in self.taxonomy.groups],
+            dim=1,
+        )
+        modulated = self.gate(visual_history, current_probs)
+
+        return ReasoningPrediction(
+            logits=logits,
+            confidence=confidence,
+            modulated_visual_history=modulated,
+        )

--- a/Model/model_components/reasoning/scenario_taxonomy.py
+++ b/Model/model_components/reasoning/scenario_taxonomy.py
@@ -1,0 +1,215 @@
+"""Single source of truth for the scenario label space (issue #98).
+
+Three independent axes, each MULTI-LABEL (several labels can be active
+simultaneously across and within axes):
+
+* **maneuver** — normal driving manoeuvres (7 classes).
+* **edge_case** — edge-case / long-tail manoeuvres (6 classes).
+* **weather_env** — weather × time-of-day combinations (8 classes).
+
+The registry is extensible: call :meth:`ScenarioTaxonomy.register_group` to
+add a new axis (e.g. KIT high-level labels) without changing existing group
+indices or breaking the loss contract.  Index ordering within each group is
+stable and part of the loss contract — do NOT reorder entries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence
+
+
+@dataclass
+class TaxonomyGroup:
+    """One axis in the scenario taxonomy.
+
+    Args:
+        name: unique identifier (e.g. ``"maneuver"``).
+        labels: ordered tuple of class names.  Index order is part of the
+            loss contract — append only, never insert or reorder.
+    """
+
+    name: str
+    labels: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if len(set(self.labels)) != len(self.labels):
+            raise ValueError(
+                f"TaxonomyGroup '{self.name}' contains duplicate labels: "
+                f"{self.labels}"
+            )
+
+    def __len__(self) -> int:
+        return len(self.labels)
+
+    def index(self, label: str) -> int:
+        """Return the stable index of *label* (raises ``KeyError`` if absent)."""
+        try:
+            return self.labels.index(label)
+        except ValueError:
+            raise KeyError(
+                f"Label '{label}' not found in group '{self.name}'. "
+                f"Known labels: {self.labels}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Canonical label sets (do NOT reorder — index is part of the loss contract)
+# ---------------------------------------------------------------------------
+
+_MANEUVER_LABELS: tuple[str, ...] = (
+    "continue_straight",
+    "curve_left",
+    "curve_right",
+    "change_lane_left",
+    "change_lane_right",
+    "turn_left",
+    "turn_right",
+)
+
+_EDGE_CASE_LABELS: tuple[str, ...] = (
+    "nudge_out",
+    "give_way",
+    "stop_for_object_in_path",
+    "close_to_vru",
+    "avoid_roadworks",
+    "stop_for_emergency_vehicle",
+)
+
+_WEATHER_ENV_LABELS: tuple[str, ...] = (
+    "fair_day",
+    "fair_night",
+    "rain_day",
+    "rain_night",
+    "snow_day",
+    "snow_night",
+    "fog_day",
+    "fog_night",
+)
+
+
+class ScenarioTaxonomy:
+    """Registry of scenario label groups.
+
+    The three canonical groups are registered at construction time.
+    Additional groups (e.g. KIT high-level labels) can be added later via
+    :meth:`register_group` or :meth:`extend` without breaking any existing
+    group's index contract.
+
+    Example::
+
+        taxonomy = ScenarioTaxonomy()
+        g = taxonomy["maneuver"]
+        idx = g.index("turn_left")   # → 6  (stable)
+
+        # Extend with KIT labels (append-only within the new group):
+        taxonomy.register_group("kit_context", ["intersection", "construction_zone"])
+
+    """
+
+    def __init__(self) -> None:
+        self._groups: Dict[str, TaxonomyGroup] = {}
+
+        # Register the three canonical axes in a fixed order so that
+        # ``groups`` always starts with {maneuver, edge_case, weather_env}.
+        self.register_group("maneuver", list(_MANEUVER_LABELS))
+        self.register_group("edge_case", list(_EDGE_CASE_LABELS))
+        self.register_group("weather_env", list(_WEATHER_ENV_LABELS))
+
+    # ------------------------------------------------------------------
+    # Extension API
+    # ------------------------------------------------------------------
+
+    def register_group(self, name: str, labels: Sequence[str]) -> TaxonomyGroup:
+        """Register a new label group.
+
+        Args:
+            name: unique group identifier.
+            labels: ordered list of class names.  Index order is stable once
+                registered — append-only semantics are the caller's
+                responsibility for subsequent :meth:`extend` calls.
+
+        Returns:
+            The newly created :class:`TaxonomyGroup`.
+
+        Raises:
+            ValueError: if *name* is already registered.
+        """
+        if name in self._groups:
+            raise ValueError(
+                f"Group '{name}' is already registered. "
+                "Use extend() to append labels to an existing group."
+            )
+        group = TaxonomyGroup(name=name, labels=tuple(labels))
+        self._groups[name] = group
+        return group
+
+    def extend(self, name: str, new_labels: Sequence[str]) -> TaxonomyGroup:
+        """Append *new_labels* to an existing group (append-only).
+
+        This is the only sanctioned way to grow a group's label set so that
+        existing indices remain stable.
+
+        Args:
+            name: group to extend.
+            new_labels: labels to append (must not overlap with current set).
+
+        Returns:
+            The updated :class:`TaxonomyGroup`.
+        """
+        if name not in self._groups:
+            raise KeyError(
+                f"Group '{name}' is not registered. "
+                "Call register_group() first."
+            )
+        existing = self._groups[name]
+        overlap = set(new_labels) & set(existing.labels)
+        if overlap:
+            raise ValueError(
+                f"Labels {sorted(overlap)} already exist in group '{name}'."
+            )
+        updated_labels = existing.labels + tuple(new_labels)
+        self._groups[name] = TaxonomyGroup(name=name, labels=updated_labels)
+        return self._groups[name]
+
+    # ------------------------------------------------------------------
+    # Read API
+    # ------------------------------------------------------------------
+
+    def __getitem__(self, name: str) -> TaxonomyGroup:
+        try:
+            return self._groups[name]
+        except KeyError:
+            raise KeyError(
+                f"Group '{name}' not found. "
+                f"Registered groups: {list(self._groups)}"
+            )
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._groups
+
+    @property
+    def groups(self) -> List[TaxonomyGroup]:
+        """All registered groups in insertion order."""
+        return list(self._groups.values())
+
+    @property
+    def group_names(self) -> List[str]:
+        """Names of all registered groups in insertion order."""
+        return list(self._groups.keys())
+
+    def num_classes(self, name: str) -> int:
+        """Number of classes in group *name*."""
+        return len(self[name])
+
+    def total_classes(self) -> int:
+        """Total number of classes across all groups.
+
+        Used as the conditioning dimension of the planner gate (the
+        current-scenario probabilities of every group, concatenated).
+        """
+        return sum(len(g) for g in self._groups.values())
+
+
+# Module-level default taxonomy instance — shared across the package.
+DEFAULT_TAXONOMY: ScenarioTaxonomy = ScenarioTaxonomy()

--- a/Model/model_components/reasoning/teachers/__init__.py
+++ b/Model/model_components/reasoning/teachers/__init__.py
@@ -1,0 +1,30 @@
+"""Teacher backends for reasoning-band pseudo-label generation (issue #98).
+
+Teachers are TRAIN-ONLY offline autolabellers — they are never part of the
+inference loop.  For CI and unit tests use :class:`DeterministicTeacher`
+(no GPU, no network); real VLM backends (Qwen2-VL, VideoLLaMA3) plug in as
+follow-up work through the same registry.
+
+Extension point: to add a new teacher backend (e.g. an Alpamayo CoC
+autolabeller), subclass :class:`VLMTeacher` from ``base.py`` and register the
+class in ``_TEACHER_REGISTRY`` below.
+
+    from model_components.reasoning.teachers.base import VLMTeacher
+
+    class MyTeacher(VLMTeacher):
+        ...
+
+    # Optional: register so consumers can look it up by name.
+    _TEACHER_REGISTRY["my_teacher"] = MyTeacher
+"""
+
+from .base import VLMTeacher
+from .deterministic import DeterministicTeacher
+
+__all__ = ["VLMTeacher", "DeterministicTeacher"]
+
+# Registry: maps a string key to a teacher class.  Populated lazily so that
+# importing this package never requires heavy dependencies.
+_TEACHER_REGISTRY: dict[str, type[VLMTeacher]] = {
+    "deterministic": DeterministicTeacher,
+}

--- a/Model/model_components/reasoning/teachers/base.py
+++ b/Model/model_components/reasoning/teachers/base.py
@@ -1,0 +1,76 @@
+"""Abstract teacher interface for reasoning-band pseudo-label generation (issue #98).
+
+Teachers are TRAIN-ONLY, offline autolabellers.  They are never instantiated
+at inference time and must not appear in the model's forward pass.
+
+Usage pattern in a training loop::
+
+    teacher = Qwen2VLTeacher(taxonomy)
+    # … for each batch …
+    targets = teacher.label(frames, num_future_horizons=4)
+    # targets["maneuver"][0] is a [B, 7] float tensor (multi-label, 0/1 or soft)
+    loss = reasoning_loss(student_logits, targets, weight=1.0)
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Sequence
+
+import torch
+
+from ..scenario_taxonomy import ScenarioTaxonomy, DEFAULT_TAXONOMY
+
+# ReasoningTargets[group_name][horizon_index] = float target tensor [B, num_classes]
+# Values in [0, 1]: hard (0/1) for deterministic / soft for VLM confidence scores.
+ReasoningTargets = Dict[str, List[torch.Tensor]]
+
+
+class VLMTeacher(ABC):
+    """Abstract base class for scenario pseudo-label teachers.
+
+    All teachers share the same :meth:`label` interface so the training loop
+    can swap backends without code changes.
+
+    Args:
+        taxonomy: the label registry used to determine group names and class
+            counts.  Defaults to :data:`DEFAULT_TAXONOMY`.
+
+    Extension point — Alpamayo CoC autolabeller (v2):
+        Implement a subclass that calls the NVlabs CoC autolabeller API,
+        mapping its chain-of-causation output onto the taxonomy groups.
+        Register the class in
+        ``model_components.reasoning.teachers._TEACHER_REGISTRY`` under the
+        key ``"alpamayo_coc"`` so users can select it via a config string.
+        **Do NOT implement CoC here** — this extension point is intentionally
+        left as a docstring-only placeholder for a future contributor.
+    """
+
+    def __init__(
+        self, taxonomy: Optional[ScenarioTaxonomy] = None
+    ) -> None:
+        self.taxonomy = taxonomy if taxonomy is not None else DEFAULT_TAXONOMY
+
+    @abstractmethod
+    def label(
+        self,
+        frames: Sequence[torch.Tensor],
+        num_future_horizons: int = 4,
+    ) -> ReasoningTargets:
+        """Produce multi-label targets for the current scene and future horizons.
+
+        Args:
+            frames: sequence of image tensors representing the current and
+                (optionally) future front-camera frames.  The first element
+                is the current frame; subsequent elements correspond to future
+                horizons.  Each tensor is ``[B, C, H, W]`` or ``[B, 3, H, W]``.
+            num_future_horizons: number of future horizons to label (must be
+                consistent with the reasoning band's configuration).
+
+        Returns:
+            :data:`ReasoningTargets` — a dict mapping each group name to a
+            list of ``1 + num_future_horizons`` float tensors of shape
+            ``[B, num_classes]`` in ``[0, 1]``.  Hard labels use 0.0 / 1.0;
+            soft labels from a VLM use confidence scores.
+        """
+        raise NotImplementedError

--- a/Model/model_components/reasoning/teachers/deterministic.py
+++ b/Model/model_components/reasoning/teachers/deterministic.py
@@ -1,0 +1,99 @@
+"""Deterministic (keyword-rule) teacher for CI and offline testing (issue #98).
+
+This teacher uses only CPU arithmetic — no neural network, no GPU, no heavy
+dependencies.  It is the recommended backend for unit tests and CI pipelines.
+
+The label logic is purely keyword-based: the caller supplies a dict of active
+label names per group (``active_labels``), and the teacher constructs the
+corresponding one-hot target tensors.  If no active labels are provided for
+a group, the teacher returns all-zero targets (no class active).
+
+This deterministic behaviour makes it trivial to construct expected outputs
+in test assertions.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence
+
+import torch
+
+from ..scenario_taxonomy import ScenarioTaxonomy
+from .base import VLMTeacher, ReasoningTargets
+
+
+class DeterministicTeacher(VLMTeacher):
+    """Keyword/rule-based teacher that produces deterministic multi-label targets.
+
+    Args:
+        taxonomy: label registry.  Defaults to :data:`DEFAULT_TAXONOMY`.
+        active_labels: dict mapping group names to lists of label strings that
+            should be set to 1.0 in the target tensor.  Any group not present
+            defaults to all-zero targets.  Labels not in the taxonomy group
+            raise a ``KeyError``.
+
+    Example::
+
+        teacher = DeterministicTeacher(
+            active_labels={
+                "maneuver": ["turn_left"],
+                "edge_case": ["avoid_roadworks"],
+                "weather_env": ["rain_night"],
+            }
+        )
+        # Returns the same targets regardless of the frames argument.
+        targets = teacher.label(frames=[frame], num_future_horizons=4)
+    """
+
+    def __init__(
+        self,
+        taxonomy: Optional[ScenarioTaxonomy] = None,
+        active_labels: Optional[Dict[str, List[str]]] = None,
+    ) -> None:
+        super().__init__(taxonomy)
+        self.active_labels: Dict[str, List[str]] = active_labels or {}
+
+        # Validate at construction time so errors surface early.
+        for group_name, labels in self.active_labels.items():
+            group = self.taxonomy[group_name]
+            for label in labels:
+                group.index(label)  # raises KeyError if not found
+
+    def label(
+        self,
+        frames: Sequence[torch.Tensor],
+        num_future_horizons: int = 4,
+    ) -> ReasoningTargets:
+        """Return deterministic targets derived from ``active_labels``.
+
+        The targets are identical for all horizons and for all frames in the
+        batch (keyword rules do not depend on image content).
+
+        Args:
+            frames: sequence of image tensors.  Shape ``[B, C, H, W]`` for
+                each frame.  Only the batch size is read; pixel values are
+                ignored.
+            num_future_horizons: number of future horizons.
+
+        Returns:
+            :data:`ReasoningTargets` with ``1 + num_future_horizons`` horizon
+            entries per group, each a ``[B, num_classes]`` float tensor in
+            ``{0.0, 1.0}``.
+        """
+        if not frames:
+            raise ValueError("frames must be non-empty.")
+
+        B = frames[0].shape[0]
+        device = frames[0].device
+        total_horizons = 1 + num_future_horizons
+
+        out: ReasoningTargets = {}
+        for group in self.taxonomy.groups:
+            active = self.active_labels.get(group.name, [])
+            target = torch.zeros(B, len(group), device=device)
+            for label in active:
+                idx = group.index(label)
+                target[:, idx] = 1.0
+            out[group.name] = [target.clone() for _ in range(total_horizons)]
+
+        return out

--- a/Model/tests/test_reasoning_band.py
+++ b/Model/tests/test_reasoning_band.py
@@ -1,0 +1,621 @@
+"""Tests for the Reasoning Band (issue #98).
+
+All tests use synthetic tensors — no GPU required, no network calls.
+Mirrors the style of test_world_action_model.py.
+
+Covered:
+    * I/O shapes of ScenarioTaxonomy, ReasoningBand, DeterministicTeacher,
+      ReasoningLoss.
+    * Planner coupling (#98/#103): forward returns a ReasoningPrediction whose
+      zero-init gate is a strict no-op at initialisation (modulated history ==
+      input) and only diverges once trained; per-horizon confidence included.
+    * Taxonomy is extensible: adding a KIT label does not change existing indices.
+    * Multi-label: several classes can be active simultaneously.
+    * Multi-horizon: train mode returns 5 horizons; infer mode returns 1.
+    * DeterministicTeacher is deterministic.
+    * ReasoningLoss decreases toward trivial targets (sigmoid(0) → 0.5 ≠ 1.0;
+      sigmoid(10) → ~1.0 ≈ 1.0 → near-zero loss).
+    * AutoE2E with enable_reasoning_band=False is byte-identical to baseline.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+import torch
+import torch.nn as nn
+
+from model_components.reasoning.scenario_taxonomy import (
+    ScenarioTaxonomy,
+    TaxonomyGroup,
+    DEFAULT_TAXONOMY,
+)
+from model_components.reasoning.reasoning_band import ReasoningBand, ReasoningPrediction
+from model_components.reasoning.teachers.deterministic import DeterministicTeacher
+from training.losses.reasoning_loss import ReasoningLoss
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+B = 2      # batch size used throughout
+VH_DIM = 896  # Encoded Visual History dimension
+
+
+def _vh(device: torch.device) -> torch.Tensor:
+    """Synthetic visual history [B, 896]."""
+    return torch.randn(B, VH_DIM, device=device)
+
+
+def _band(device: torch.device, **kw) -> ReasoningBand:
+    return ReasoningBand(visual_history_dim=VH_DIM, hidden_dim=64, **kw).to(device)
+
+
+# ---------------------------------------------------------------------------
+# ScenarioTaxonomy
+# ---------------------------------------------------------------------------
+
+class TestScenarioTaxonomy:
+    def test_default_groups_present(self):
+        t = ScenarioTaxonomy()
+        assert "maneuver" in t
+        assert "edge_case" in t
+        assert "weather_env" in t
+
+    def test_default_group_sizes(self):
+        t = ScenarioTaxonomy()
+        assert t.num_classes("maneuver") == 7
+        assert t.num_classes("edge_case") == 6
+        assert t.num_classes("weather_env") == 8
+
+    def test_stable_index_ordering(self):
+        """Index is part of the loss contract — must not change."""
+        t = ScenarioTaxonomy()
+        assert t["maneuver"].index("continue_straight") == 0
+        assert t["maneuver"].index("turn_right") == 6
+        assert t["edge_case"].index("nudge_out") == 0
+        assert t["weather_env"].index("fair_day") == 0
+        assert t["weather_env"].index("fog_night") == 7
+
+    def test_extensible_register_group(self):
+        """Adding a new group does not affect existing groups."""
+        t = ScenarioTaxonomy()
+        old_idx = t["maneuver"].index("turn_left")
+        t.register_group("kit_context", ["intersection", "construction_zone"])
+        # Existing index unchanged
+        assert t["maneuver"].index("turn_left") == old_idx
+        # New group accessible
+        assert t.num_classes("kit_context") == 2
+        assert t["kit_context"].index("intersection") == 0
+
+    def test_extend_appends_only(self):
+        """extend() must not change indices of existing labels."""
+        t = ScenarioTaxonomy()
+        t.extend("maneuver", ["u_turn"])
+        assert t["maneuver"].index("turn_right") == 6   # unchanged
+        assert t["maneuver"].index("u_turn") == 7       # appended
+        assert t.num_classes("maneuver") == 8
+
+    def test_register_group_duplicate_raises(self):
+        t = ScenarioTaxonomy()
+        with pytest.raises(ValueError, match="already registered"):
+            t.register_group("maneuver", ["foo"])
+
+    def test_extend_unknown_group_raises(self):
+        t = ScenarioTaxonomy()
+        with pytest.raises(KeyError):
+            t.extend("nonexistent", ["foo"])
+
+    def test_extend_duplicate_label_raises(self):
+        t = ScenarioTaxonomy()
+        with pytest.raises(ValueError, match="already exist"):
+            t.extend("maneuver", ["turn_left"])
+
+    def test_group_contains_no_duplicates(self):
+        t = ScenarioTaxonomy()
+        for g in t.groups:
+            assert len(set(g.labels)) == len(g.labels)
+
+    def test_taxonomy_group_duplicate_labels_raises(self):
+        with pytest.raises(ValueError, match="duplicate"):
+            TaxonomyGroup(name="test", labels=("a", "a", "b"))
+
+    def test_multi_label_multi_group(self):
+        """Taxonomy supports querying labels across all three groups at once."""
+        t = ScenarioTaxonomy()
+        # Each group has its own independent index space; all lookups must succeed.
+        m_idx = t["maneuver"].index("curve_left")
+        e_idx = t["edge_case"].index("give_way")
+        w_idx = t["weather_env"].index("rain_night")
+        # Indices within each group must be in valid range
+        assert 0 <= m_idx < t.num_classes("maneuver")
+        assert 0 <= e_idx < t.num_classes("edge_case")
+        assert 0 <= w_idx < t.num_classes("weather_env")
+
+
+# ---------------------------------------------------------------------------
+# ReasoningBand — shapes
+# ---------------------------------------------------------------------------
+
+class TestReasoningBandShapes:
+    def test_infer_mode_returns_one_horizon(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        logits = band(vh, mode="infer").logits
+        for group in DEFAULT_TAXONOMY.groups:
+            assert group.name in logits
+            assert len(logits[group.name]) == 1
+            assert logits[group.name][0].shape == (B, len(group))
+
+    def test_train_mode_returns_five_horizons(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        logits = band(vh, mode="train").logits
+        # 1 current + 4 future = 5
+        for group in DEFAULT_TAXONOMY.groups:
+            assert len(logits[group.name]) == 5
+
+    def test_all_taxonomy_groups_present(self, device):
+        band = _band(device)
+        logits = band(_vh(device), mode="infer").logits
+        assert set(logits.keys()) == set(DEFAULT_TAXONOMY.group_names)
+
+    def test_custom_num_future_horizons(self, device):
+        band = _band(device, num_future_horizons=2)
+        logits = band(_vh(device), mode="train").logits
+        for group in DEFAULT_TAXONOMY.groups:
+            assert len(logits[group.name]) == 3  # 1 current + 2 future
+
+    def test_output_logits_finite(self, device):
+        band = _band(device)
+        logits = band(_vh(device), mode="train").logits
+        for group_horizons in logits.values():
+            for t in group_horizons:
+                assert torch.isfinite(t).all()
+
+
+# ---------------------------------------------------------------------------
+# Zero-init gate (planner coupling, #98/#103) + per-horizon confidence
+# ---------------------------------------------------------------------------
+
+class TestZeroInitGateAndConfidence:
+    """The band feeds the planner through a zero-init gate: at initialisation
+    the modulated visual history is IDENTICAL to the input (strict no-op), so
+    enabling the band leaves the reactive baseline unchanged until training
+    moves the gate.  A per-horizon confidence accompanies the logits (#103)."""
+
+    def test_returns_typed_prediction(self, device):
+        band = _band(device)
+        pred = band(_vh(device), mode="train")
+        assert isinstance(pred, ReasoningPrediction)
+        assert set(pred.logits.keys()) == set(DEFAULT_TAXONOMY.group_names)
+
+    def test_gate_is_noop_at_init(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        for mode in ("infer", "train"):
+            pred = band(vh, mode=mode)
+            assert torch.allclose(pred.modulated_visual_history, vh, atol=1e-6), (
+                "Zero-init gate must be a strict no-op at initialisation."
+            )
+
+    def test_gate_diverges_once_trained(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        with torch.no_grad():
+            band.gate.beta.bias.fill_(0.5)
+        pred = band(vh, mode="infer")
+        assert not torch.allclose(pred.modulated_visual_history, vh)
+
+    def test_visual_history_not_mutated_in_place(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        vh_before = vh.clone()
+        band(vh, mode="train")
+        assert torch.equal(vh, vh_before)
+
+    def test_confidence_shape_train_and_infer(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        assert band(vh, mode="train").confidence.shape == (B, 5)
+        assert band(vh, mode="infer").confidence.shape == (B, 1)
+
+    def test_gate_receives_gradient(self, device):
+        band = _band(device)
+        pred = band(_vh(device), mode="train")
+        pred.modulated_visual_history.sum().backward()
+        assert band.gate.gamma.weight.grad is not None
+
+
+# ---------------------------------------------------------------------------
+# Multi-label
+# ---------------------------------------------------------------------------
+
+class TestMultiLabel:
+    def test_several_classes_active_simultaneously(self, device):
+        """Multiple labels across different groups can be active at once."""
+        teacher = DeterministicTeacher(
+            active_labels={
+                "maneuver": ["turn_left", "curve_left"],  # two active in same group
+                "edge_case": ["give_way", "avoid_roadworks"],
+                "weather_env": ["rain_night", "fog_day"],
+            }
+        )
+        frame = torch.zeros(B, 3, 8, 8, device=device)
+        targets = teacher.label([frame], num_future_horizons=0)
+
+        m_target = targets["maneuver"][0]
+        assert m_target[:, DEFAULT_TAXONOMY["maneuver"].index("turn_left")].all()
+        assert m_target[:, DEFAULT_TAXONOMY["maneuver"].index("curve_left")].all()
+        # All-zero for inactive labels
+        assert m_target[:, DEFAULT_TAXONOMY["maneuver"].index("continue_straight")].sum() == 0
+
+    def test_multi_label_loss_accepts_multiple_active(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        logits = band(vh, mode="train").logits
+
+        # Create targets with multiple classes active
+        targets = {}
+        for group in DEFAULT_TAXONOMY.groups:
+            t_list = []
+            for _ in logits[group.name]:
+                t = torch.zeros(B, len(group), device=device)
+                t[:, 0] = 1.0
+                t[:, 1] = 1.0   # two classes active
+                t_list.append(t)
+            targets[group.name] = t_list
+
+        loss_fn = ReasoningLoss(weight=1.0)
+        loss = loss_fn(logits, targets)
+        assert torch.isfinite(loss) and loss > 0
+
+
+# ---------------------------------------------------------------------------
+# DeterministicTeacher
+# ---------------------------------------------------------------------------
+
+class TestDeterministicTeacher:
+    def test_deterministic_across_calls(self, device):
+        teacher = DeterministicTeacher(
+            active_labels={"maneuver": ["turn_right"], "edge_case": ["nudge_out"]}
+        )
+        frame = torch.randn(B, 3, 8, 8, device=device)
+        t1 = teacher.label([frame], num_future_horizons=4)
+        t2 = teacher.label([frame], num_future_horizons=4)
+        for group_name in t1:
+            for h1, h2 in zip(t1[group_name], t2[group_name]):
+                assert torch.equal(h1, h2)
+
+    def test_deterministic_returns_correct_number_of_horizons(self, device):
+        teacher = DeterministicTeacher()
+        frame = torch.zeros(B, 3, 8, 8, device=device)
+        targets = teacher.label([frame], num_future_horizons=4)
+        for group_name in DEFAULT_TAXONOMY.group_names:
+            assert len(targets[group_name]) == 5  # 1 current + 4 future
+
+    def test_deterministic_correct_shapes(self, device):
+        teacher = DeterministicTeacher()
+        frame = torch.zeros(B, 3, 8, 8, device=device)
+        targets = teacher.label([frame], num_future_horizons=4)
+        for group in DEFAULT_TAXONOMY.groups:
+            for t in targets[group.name]:
+                assert t.shape == (B, len(group))
+
+    def test_deterministic_active_labels_set_correctly(self, device):
+        teacher = DeterministicTeacher(
+            active_labels={"maneuver": ["continue_straight"]}
+        )
+        frame = torch.zeros(B, 3, 8, 8, device=device)
+        targets = teacher.label([frame], num_future_horizons=0)
+        t = targets["maneuver"][0]
+        idx = DEFAULT_TAXONOMY["maneuver"].index("continue_straight")
+        assert (t[:, idx] == 1.0).all()
+        # All other maneuver classes must be 0
+        mask = torch.ones(len(DEFAULT_TAXONOMY["maneuver"]), dtype=torch.bool)
+        mask[idx] = False
+        assert (t[:, mask] == 0.0).all()
+
+    def test_deterministic_all_zero_when_no_active_labels(self, device):
+        teacher = DeterministicTeacher()   # no active_labels
+        frame = torch.zeros(B, 3, 8, 8, device=device)
+        targets = teacher.label([frame], num_future_horizons=0)
+        for group_name in DEFAULT_TAXONOMY.group_names:
+            assert (targets[group_name][0] == 0.0).all()
+
+    def test_deterministic_invalid_label_raises(self):
+        with pytest.raises(KeyError):
+            DeterministicTeacher(active_labels={"maneuver": ["nonexistent_label"]})
+
+    def test_deterministic_ignores_pixel_values(self, device):
+        """Output must be identical regardless of frame pixel content."""
+        teacher = DeterministicTeacher(active_labels={"maneuver": ["turn_left"]})
+        f1 = torch.zeros(B, 3, 8, 8, device=device)
+        f2 = torch.ones(B, 3, 8, 8, device=device) * 255
+        t1 = teacher.label([f1], num_future_horizons=0)
+        t2 = teacher.label([f2], num_future_horizons=0)
+        assert torch.equal(t1["maneuver"][0], t2["maneuver"][0])
+
+
+# ---------------------------------------------------------------------------
+# ReasoningLoss
+# ---------------------------------------------------------------------------
+
+class TestReasoningLoss:
+    def _make_logits_and_targets(self, device, logit_val: float, target_val: float):
+        """Create synthetic logits and targets for all groups × 5 horizons."""
+        band = _band(device)
+        vh = _vh(device)
+        logits = band(vh, mode="train").logits
+        # Override with constant logit values
+        for group in DEFAULT_TAXONOMY.groups:
+            logits[group.name] = [
+                torch.full((B, len(group)), logit_val, device=device)
+                for _ in range(5)
+            ]
+        targets = {}
+        for group in DEFAULT_TAXONOMY.groups:
+            targets[group.name] = [
+                torch.full((B, len(group)), target_val, device=device)
+                for _ in range(5)
+            ]
+        return logits, targets
+
+    def test_loss_near_zero_for_perfect_targets(self, device):
+        """logit >> 0 with target=1 → near-zero BCE."""
+        logits, targets = self._make_logits_and_targets(device, 10.0, 1.0)
+        loss = ReasoningLoss(weight=1.0)(logits, targets)
+        assert loss.item() < 0.1
+
+    def test_loss_lower_for_better_predictions(self, device):
+        """Better-aligned logits → lower loss than random logits."""
+        logits_good, targets = self._make_logits_and_targets(device, 8.0, 1.0)
+        logits_bad, _ = self._make_logits_and_targets(device, -8.0, 1.0)
+        loss_good = ReasoningLoss()(logits_good, targets)
+        loss_bad = ReasoningLoss()(logits_bad, targets)
+        assert loss_good < loss_bad
+
+    def test_loss_weight_scales_output(self, device):
+        logits, targets = self._make_logits_and_targets(device, 0.0, 0.5)
+        l1 = ReasoningLoss(weight=1.0)(logits, targets)
+        l2 = ReasoningLoss(weight=2.0)(logits, targets)
+        assert torch.allclose(l2, 2.0 * l1, atol=1e-5)
+
+    def test_loss_finite_and_positive(self, device):
+        logits, targets = self._make_logits_and_targets(device, 0.0, 0.5)
+        loss = ReasoningLoss()(logits, targets)
+        assert torch.isfinite(loss) and loss > 0
+
+    def test_loss_group_mismatch_raises(self, device):
+        logits, targets = self._make_logits_and_targets(device, 0.0, 0.5)
+        del targets["maneuver"]
+        with pytest.raises(ValueError, match="Group mismatch"):
+            ReasoningLoss()(logits, targets)
+
+    def test_loss_horizon_mismatch_raises(self, device):
+        logits, targets = self._make_logits_and_targets(device, 0.0, 0.5)
+        targets["maneuver"] = targets["maneuver"][:3]   # 3 horizons vs 5
+        with pytest.raises(ValueError, match="horizons"):
+            ReasoningLoss()(logits, targets)
+
+    def test_loss_reduction_none_returns_per_sample(self, device):
+        logits, targets = self._make_logits_and_targets(device, 0.0, 0.5)
+        loss = ReasoningLoss(reduction="none")(logits, targets)
+        assert loss.shape == (B,)
+
+    def test_loss_invalid_reduction_raises(self):
+        with pytest.raises(ValueError, match="reduction"):
+            ReasoningLoss(reduction="sum")
+
+    def test_loss_gradients_flow(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        logits = band(vh, mode="train").logits
+        targets = {}
+        for group in DEFAULT_TAXONOMY.groups:
+            targets[group.name] = [
+                torch.zeros(B, len(group), device=device) for _ in logits[group.name]
+            ]
+        loss = ReasoningLoss()(logits, targets)
+        loss.backward()
+        # Gradients must flow to the decoder heads
+        assert any(p.grad is not None for p in band.heads.parameters())
+
+
+# ---------------------------------------------------------------------------
+# AutoE2E integration — reasoning band disabled = unchanged baseline
+# ---------------------------------------------------------------------------
+
+class _AutoE2EHarness:
+    """Shared mock-backbone harness (NOT collected: no Test prefix) so the
+    wiring, Moondream and faithfulness suites reuse _build/_inputs without
+    pytest re-collecting inherited tests."""
+
+    class _MockBackbone(nn.Module):
+        def __init__(self, backbone="swin_v2_tiny", is_pretrained=True, **kw):
+            super().__init__()
+            self.backbone_channels = 1440
+            self._st = nn.ModuleList([
+                nn.Sequential(nn.Conv2d(3, 96, 3, 1, 1), nn.AdaptiveAvgPool2d(64)),
+                nn.Sequential(nn.Conv2d(96, 192, 3, 1, 1), nn.AdaptiveAvgPool2d(32)),
+                nn.Sequential(nn.Conv2d(192, 384, 3, 1, 1), nn.AdaptiveAvgPool2d(16)),
+                nn.Sequential(nn.Conv2d(384, 768, 3, 1, 1), nn.AdaptiveAvgPool2d(8)),
+            ])
+        def forward(self, x):
+            outs, h = [], x
+            for s in self._st:
+                h = s(h)
+                outs.append(h)
+            return outs
+
+    def _build(self, device, *, enable_reasoning_band=False,
+               enable_world_model=False, reasoning_kwargs=None):
+        from unittest.mock import patch
+        from model_components.auto_e2e import AutoE2E
+        with patch("model_components.reactive_e2e.Backbone", self._MockBackbone):
+            return AutoE2E(
+                num_views=2,
+                view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
+                enable_world_model=enable_world_model,
+                world_model_kwargs={"feature_channels": 768} if enable_world_model else None,
+                enable_reasoning_band=enable_reasoning_band,
+                reasoning_kwargs=reasoning_kwargs,
+            ).to(device)
+
+    def _inputs(self, device):
+        return (
+            torch.randn(B, 2, 3, 256, 256, device=device),  # camera_tiles
+            torch.randn(B, 3, 256, 256, device=device),      # map_input (256 required by map encoder)
+            torch.zeros(B, 896, device=device),              # visual_history
+            torch.randn(B, 256, device=device),              # egomotion_history
+        )
+
+
+class TestAutoE2EReasoningBandWiring(_AutoE2EHarness):
+    def test_disabled_returns_same_shape_as_baseline(self, device):
+        """enable_reasoning_band=False → output identical to un-modified AutoE2E."""
+        m = self._build(device, enable_reasoning_band=False)
+        cam, mp, vh, ego = self._inputs(device)
+        out = m(cam, mp, vh, ego, mode="infer")
+        traj = out[0] if isinstance(out, tuple) else out
+        assert traj.shape == (B, 128)
+
+    def test_disabled_reasoning_band_is_none(self, device):
+        m = self._build(device, enable_reasoning_band=False)
+        assert m.Reasoning_Band is None
+
+    def test_enabled_reasoning_band_is_set(self, device):
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        assert m.Reasoning_Band is not None
+
+    def test_infer_mode_returns_trajectory_only(self, device):
+        """In infer mode the reasoning_pred is not returned (same as World Model)."""
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        cam, mp, vh, ego = self._inputs(device)
+        out = m(cam, mp, vh, ego, mode="infer")
+        # Should NOT be a 3-tuple (reasoning_pred only comes in train mode)
+        if isinstance(out, tuple):
+            assert len(out) <= 2
+        else:
+            assert out.shape[-1] == 128
+
+    def test_train_mode_returns_3tuple(self, device):
+        """In train mode with reasoning band on: (trajectory, future_state_pred, reasoning_pred)."""
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        cam, mp, vh, ego = self._inputs(device)
+        tgt = torch.randn(B, 128, device=device)
+        out = m(cam, mp, vh, ego, mode="train", trajectory_target=tgt)
+        assert isinstance(out, tuple) and len(out) == 3
+        _traj, future_state_pred, reasoning_pred = out
+        assert future_state_pred is None   # World Model is OFF
+        assert reasoning_pred is not None
+        assert "maneuver" in reasoning_pred.logits
+
+    def test_reasoning_pred_horizons_in_train(self, device):
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        cam, mp, vh, ego = self._inputs(device)
+        tgt = torch.randn(B, 128, device=device)
+        _, _, reasoning_pred = m(cam, mp, vh, ego, mode="train", trajectory_target=tgt)
+        for group in DEFAULT_TAXONOMY.groups:
+            assert len(reasoning_pred.logits[group.name]) == 5
+
+    def test_baseline_unchanged_enable_false(self, device):
+        """Confirm enable_reasoning_band=False ⇒ exact return contract as before."""
+        m_base = self._build(device, enable_reasoning_band=False)
+        cam, mp, vh, ego = self._inputs(device)
+        tgt = torch.randn(B, 128, device=device)
+        out_infer = m_base(cam, mp, vh, ego, mode="infer")
+        out_train = m_base(cam, mp, vh, ego, mode="train", trajectory_target=tgt)
+        # Infer: plain tensor or 1-tuple
+        if isinstance(out_infer, tuple):
+            assert len(out_infer) <= 2
+        else:
+            assert torch.is_tensor(out_infer)
+        # Train without world model: plain tensor (no 3-tuple)
+        assert not (isinstance(out_train, tuple) and len(out_train) == 3)
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy extensibility — KIT labels (no-break contract)
+# ---------------------------------------------------------------------------
+
+class TestTaxonomyExtensibility:
+    def test_kit_label_does_not_shift_existing_indices(self):
+        """Adding a KIT group must not change any existing group's indices."""
+        t = ScenarioTaxonomy()
+        # Record all indices before extension
+        before = {
+            g.name: {label: g.index(label) for label in g.labels}
+            for g in t.groups
+        }
+        t.register_group("kit_high_level", [
+            "intersection_scenario",
+            "overtake",
+            "construction_zone",
+        ])
+        # All old indices must be unchanged
+        for gname, label_map in before.items():
+            for label, idx in label_map.items():
+                assert t[gname].index(label) == idx
+
+    def test_kit_group_accessible_after_register(self):
+        t = ScenarioTaxonomy()
+        t.register_group("kit_high_level", ["intersection_scenario"])
+        assert t.num_classes("kit_high_level") == 1
+        assert t["kit_high_level"].index("intersection_scenario") == 0
+
+    def test_reasoning_band_with_extended_taxonomy(self, device):
+        """ReasoningBand works correctly with an extended taxonomy."""
+        t = ScenarioTaxonomy()
+        t.register_group("kit_high_level", ["intersection_scenario", "overtake"])
+        band = ReasoningBand(
+            visual_history_dim=VH_DIM, hidden_dim=32, taxonomy=t
+        ).to(device)
+        logits = band(_vh(device), mode="train").logits
+        assert "kit_high_level" in logits
+        assert len(logits["kit_high_level"]) == 5
+        assert logits["kit_high_level"][0].shape == (B, 2)
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric Loss option (class-imbalance; arXiv:2009.14119)
+# ---------------------------------------------------------------------------
+
+class TestAsymmetricLoss:
+    def _logits_targets(self, logit_val: float, target_val: float):
+        logits = {g.name: [torch.full((B, len(g)), logit_val)]
+                  for g in DEFAULT_TAXONOMY.groups}
+        targets = {g.name: [torch.full((B, len(g)), target_val)]
+                   for g in DEFAULT_TAXONOMY.groups}
+        return logits, targets
+
+    def test_asl_near_zero_for_perfect_predictions(self):
+        logits, targets = self._logits_targets(10.0, 1.0)
+        assert ReasoningLoss(loss_type="asl")(logits, targets).item() < 0.01
+
+    def test_asl_downweights_easy_negatives_vs_bce(self):
+        logits, targets = self._logits_targets(-2.0, 0.0)
+        asl = ReasoningLoss(loss_type="asl")(logits, targets).item()
+        bce = ReasoningLoss(loss_type="bce")(logits, targets).item()
+        assert asl < bce
+
+    def test_reduction_none_shape(self):
+        logits, targets = self._logits_targets(0.0, 0.5)
+        loss = ReasoningLoss(loss_type="asl", reduction="none")(logits, targets)
+        assert loss.shape == (B,)
+
+    def test_invalid_loss_type_raises(self):
+        with pytest.raises(ValueError, match="loss_type"):
+            ReasoningLoss(loss_type="focal")
+
+    def test_asl_backward(self):
+        logits = {g.name: [torch.zeros(B, len(g), requires_grad=True)]
+                  for g in DEFAULT_TAXONOMY.groups}
+        targets = {g.name: [torch.ones(B, len(g))] for g in DEFAULT_TAXONOMY.groups}
+        ReasoningLoss(loss_type="asl")(logits, targets).backward()
+        assert logits["maneuver"][0].grad is not None

--- a/Model/training/losses/__init__.py
+++ b/Model/training/losses/__init__.py
@@ -1,0 +1,5 @@
+"""Training loss modules for AutoE2E (kept outside the model per Zain's criterion)."""
+
+from .reasoning_loss import ReasoningLoss
+
+__all__ = ["ReasoningLoss"]

--- a/Model/training/losses/reasoning_loss.py
+++ b/Model/training/losses/reasoning_loss.py
@@ -1,0 +1,156 @@
+"""Multi-label, multi-horizon student↔teacher distillation loss (issue #98).
+
+This module lives OUTSIDE the model (in ``Model/training/``) and is computed
+in the training loop — matching Zain's explicit requirement that loss modules
+for each band stay separate from the model forward pass (same principle as the
+JEPA loss in #85).
+
+The loss is binary-cross-entropy (BCE) with sigmoid targets, summed across
+taxonomy groups and averaged across horizons, then scaled by a scalar weight.
+Soft teacher targets (confidence scores in [0, 1]) are supported directly
+because ``F.binary_cross_entropy_with_logits`` accepts float targets.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import torch
+import torch.nn.functional as F
+
+# Type aliases matching reasoning_band.py and teachers/base.py
+ReasoningOutput = Dict[str, List[torch.Tensor]]   # logits (raw, pre-sigmoid)
+ReasoningTargets = Dict[str, List[torch.Tensor]]  # targets in [0, 1]
+
+
+class ReasoningLoss:
+    """Weighted student↔teacher distillation loss for the reasoning band.
+
+    Computes BCE with logits between the student's per-group, per-horizon
+    sigmoid heads and the teacher's multi-label targets.  Losses are averaged
+    across horizons and summed across groups (so adding a new group increases
+    the raw loss magnitude; callers should rescale ``weight`` accordingly).
+
+    This class is intentionally **not** an ``nn.Module`` — it holds no
+    trainable parameters (it is a pure stateless loss function) and lives in
+    the training loop, not in the model graph.
+
+    Args:
+        weight: scalar multiplier applied to the final loss before returning
+            (default 1.0, matching the JEPA equal-weight start policy from #85).
+        reduction: ``"mean"`` (default) averages over the batch; ``"none"``
+            returns per-sample losses of shape ``[B]`` for logging.
+        loss_type: ``"bce"`` (default) or ``"asl"``.  ASL (Asymmetric Loss,
+            Ridnik et al., arXiv:2009.14119) down-weights the flood of easy
+            negatives that dominates an imbalanced multi-label problem — our
+            scenario distribution is heavily skewed (intersection ~29.6% vs
+            nighttime ~5.1%) — and reported 86.6 vs 84.0 mAP over plain
+            cross-entropy on MS-COCO.  Soft teacher targets are supported by
+            weighting the positive/negative terms with the target value.
+        gamma_neg / gamma_pos / clip: ASL focusing/shift parameters (paper
+            defaults 4 / 0 / 0.05); ignored for ``loss_type="bce"``.
+
+    Example::
+
+        loss_fn = ReasoningLoss(weight=1.0)
+        loss = loss_fn(student_logits, teacher_targets)
+        loss.backward()
+    """
+
+    def __init__(
+        self,
+        weight: float = 1.0,
+        reduction: str = "mean",
+        loss_type: str = "bce",
+        gamma_neg: float = 4.0,
+        gamma_pos: float = 0.0,
+        clip: float = 0.05,
+    ) -> None:
+        if reduction not in ("mean", "none"):
+            raise ValueError(
+                f"Unsupported reduction '{reduction}'. Choose 'mean' or 'none'."
+            )
+        if loss_type not in ("bce", "asl"):
+            raise ValueError(
+                f"Unsupported loss_type '{loss_type}'. Choose 'bce' or 'asl'."
+            )
+        self.weight = weight
+        self.reduction = reduction
+        self.loss_type = loss_type
+        self.gamma_neg = gamma_neg
+        self.gamma_pos = gamma_pos
+        self.clip = clip
+
+    def _asl_with_logits(
+        self, logits: torch.Tensor, targets: torch.Tensor
+    ) -> torch.Tensor:
+        """Asymmetric Loss (element-wise, ``[B, C]``), soft-target friendly."""
+        eps = 1e-8
+        p = torch.sigmoid(logits)
+        # Probability shifting: hard-discard very easy negatives.
+        p_shifted = (p - self.clip).clamp(min=0.0)
+        loss_pos = ((1.0 - p) ** self.gamma_pos) * torch.log(p.clamp(min=eps))
+        loss_neg = (p_shifted ** self.gamma_neg) * torch.log(
+            (1.0 - p_shifted).clamp(min=eps)
+        )
+        return -(targets * loss_pos + (1.0 - targets) * loss_neg)
+
+    def __call__(
+        self,
+        student_logits: ReasoningOutput,
+        teacher_targets: ReasoningTargets,
+    ) -> torch.Tensor:
+        """Compute the reasoning distillation loss.
+
+        Args:
+            student_logits: dict mapping group name → list of per-horizon raw
+                logits ``[B, num_classes]`` (output of :class:`ReasoningBand`).
+            teacher_targets: dict mapping group name → list of per-horizon
+                float targets ``[B, num_classes]`` in ``[0, 1]`` (output of a
+                :class:`VLMTeacher`).
+
+        Returns:
+            Scalar loss (or ``[B]`` when ``reduction="none"``), multiplied by
+            ``self.weight``.
+
+        Raises:
+            ValueError: if the set of groups or number of horizons does not
+                match between logits and targets.
+        """
+        if student_logits.keys() != teacher_targets.keys():
+            raise ValueError(
+                f"Group mismatch: student has {set(student_logits.keys())}, "
+                f"teacher has {set(teacher_targets.keys())}."
+            )
+
+        group_losses: list[torch.Tensor] = []
+
+        for group_name in student_logits:
+            s_horizons = student_logits[group_name]
+            t_horizons = teacher_targets[group_name]
+            if len(s_horizons) != len(t_horizons):
+                raise ValueError(
+                    f"Group '{group_name}': student has {len(s_horizons)} horizons, "
+                    f"teacher has {len(t_horizons)}."
+                )
+            horizon_losses: list[torch.Tensor] = []
+            for s_logit, t_target in zip(s_horizons, t_horizons):
+                if self.loss_type == "asl":
+                    elem = self._asl_with_logits(s_logit, t_target.float())
+                    term = elem.mean() if self.reduction == "mean" else elem.mean(dim=-1)
+                else:
+                    # BCE with logits handles multi-label naturally (sigmoid implicit).
+                    term = F.binary_cross_entropy_with_logits(
+                        s_logit, t_target.float(), reduction=self.reduction
+                    )
+                    # When reduction="none", bce is [B, C]; average over classes.
+                    if self.reduction == "none":
+                        term = term.mean(dim=-1)   # [B]
+                horizon_losses.append(term)
+
+            # Average across horizons: [B] or scalar.
+            group_losses.append(torch.stack(horizon_losses).mean(dim=0))
+
+        # Sum across groups (each group contributes independently).
+        total: torch.Tensor = torch.stack(group_losses).sum(dim=0)
+        return self.weight * total


### PR DESCRIPTION
Part of #98; the planner coupling and per-horizon confidence follow the convergence in #103.

## Why
This adds the trained **Reasoning band** from the 1 July design — the 1 Hz lane that classifies the driving scenario for the current + 4 future scenes and conditions the trajectory planner through a zero-init gate. A follow-up PR (#109) adds the offline teacher registry and the evaluation pipeline on top of this one.

## What this adds
- `reasoning/scenario_taxonomy.py` — the label space as an extensible multi-label registry: maneuver (7) / edge_case (6) / weather_env (8); new axes (e.g. KITScenes labels) append without breaking indices.
- `reasoning/reasoning_band.py` — `ReasoningBand`: trunk over the 896 Encoded Visual History → per-group sigmoid heads for current + 4 horizons, a **per-horizon confidence head** (#103, temporal-first) and a **`ZeroInitGate`** (FiLM-style, weights AND biases zero-initialised — the repo's alpha=0 pattern) that modulates the visual history fed to the planner. Strict no-op at init: enabling the band leaves the reactive baseline byte-identical until training moves the gate (tested).
- `reasoning/teachers/` — the swappable teacher interface (`VLMTeacher`) with a deterministic backend for CI; real VLM backends land in the stacked PR through the same registry.
- `training/losses/reasoning_loss.py` — the distillation loss lives **outside the model** (per the World-Model follow-up decision): BCE default plus an asymmetric-loss option ([2009.14119](https://arxiv.org/abs/2009.14119)) for the strong class imbalance.
- Wiring in `auto_e2e.py`: `enable_reasoning_band` (default **off**).

## Scope — NOT in this PR (next PR in the stack)
Offline teacher registry (Qwen2-VL / VideoLLaMA3 + cross-teacher agreement) · OpenAI-compatible teacher endpoint · long-tail split + intervention/faithfulness check · reasoning column in the speed benchmark — all in #109.

## Tests
`pytest Model/tests` → **309 passed** (+29 for this band). `ruff` + `mypy` clean.
