### PR TITLE
feat(reasoning): VLM teacher registry + OpenAI-compatible endpoint + long-tail/faithfulness evaluation (#98)

### DIFF
--- a/Model/evaluation/__init__.py
+++ b/Model/evaluation/__init__.py
@@ -7,7 +7,8 @@ from .metrics import (
     offroad_rate,
 )
 from .baselines import constant_velocity_baseline, hold_last_action_baseline
-from .splits import episode_range_split, geographic_holdout_split
+from .splits import episode_range_split, geographic_holdout_split, long_tail_split
+from .faithfulness import reasoning_intervention_delta
 
 __all__ = [
     # existing (open-loop displacement metrics + gate)
@@ -24,4 +25,7 @@ __all__ = [
     # validation splits (#66 §4)
     "episode_range_split",
     "geographic_holdout_split",
+    # reasoning band evaluation (#98/#103)
+    "long_tail_split",
+    "reasoning_intervention_delta",
 ]

--- a/Model/evaluation/faithfulness.py
+++ b/Model/evaluation/faithfulness.py
@@ -15,7 +15,7 @@ not perturb the reactive baseline before training.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 
@@ -26,7 +26,9 @@ def reasoning_intervention_delta(
     map_input: torch.Tensor,
     visual_history: torch.Tensor,
     egomotion_history: torch.Tensor,
-    camera_params: Optional[torch.Tensor] = None,
+    projection: Optional[Any] = None,
+    geometry_type: Optional[str] = None,
+    image_transform: Optional[Any] = None,
 ) -> dict[str, float]:
     """Measure how much the reasoning band's coupling moves the trajectory.
 
@@ -36,15 +38,20 @@ def reasoning_intervention_delta(
 
     Args:
         model: an ``AutoE2E`` instance with ``enable_reasoning_band=True``.
-        camera_tiles / map_input / visual_history / egomotion_history /
-            camera_params: one evaluation batch, as in ``AutoE2E.forward``.
+        camera_tiles / map_input / visual_history / egomotion_history: one
+            evaluation batch, as in ``AutoE2E.forward``.
+        projection / geometry_type / image_transform: the current geometry ABI
+            forwarded to ``AutoE2E.forward`` (replaces the old ``camera_params``
+            argument).
 
     Returns:
         dict with:
         * ``trajectory_l2``: mean L2 distance between the coupled and
           intervened trajectories (0.0 while the gate is untrained).
-        * ``history_shift``: mean L2 between the modulated and raw visual
-          history (how hard the gate is actually steering the planner input).
+        * ``history_shift``: mean L2 between the modulated and the **effective**
+          visual history the band actually receives inside the model (with the
+          World Model on, that is the WAM-aggregated history, not the raw
+          caller input) — how hard the gate is steering the planner input.
 
     Raises:
         ValueError: if the model has no reasoning band to intervene on.
@@ -70,27 +77,55 @@ def reasoning_intervention_delta(
         if buffer is not None and saved_frames is not None:
             buffer._buf = list(saved_frames)
 
+    fwd_kwargs = dict(
+        projection=projection,
+        geometry_type=geometry_type,
+        image_transform=image_transform,
+        mode="infer",
+    )
+
+    # Capture the EFFECTIVE visual history the band receives inside the model.
+    # With the World Model enabled, AutoE2E replaces the caller's
+    # ``visual_history`` with the WAM-aggregated history before the band runs;
+    # measuring history_shift against the raw caller input would be wrong.
+    captured: dict[str, torch.Tensor] = {}
+
+    def _hook(_module: torch.nn.Module, inputs: Any, output: Any) -> None:
+        captured["effective"] = inputs[0].detach()
+        captured["modulated"] = output.modulated_visual_history.detach()
+
+    handle = band.register_forward_hook(_hook)
     try:
         with torch.no_grad():
             coupled = model(
                 camera_tiles, map_input, visual_history, egomotion_history,
-                camera_params=camera_params, mode="infer",
+                **fwd_kwargs,
             )
             _restore_buffer()
-            pred = band(visual_history, mode="infer")
-            # Intervention: bypass the band entirely (planner sees the raw
-            # visual history), then restore it.  setattr keeps mypy happy
-            # about temporarily nulling an nn.Module attribute.
+    finally:
+        handle.remove()
+
+    try:
+        with torch.no_grad():
+            # Intervention: bypass the band entirely (planner sees the effective
+            # visual history unmodulated), then restore it.  setattr keeps mypy
+            # happy about temporarily nulling an nn.Module attribute.
             setattr(model, "Reasoning_Band", None)
             intervened = model(
                 camera_tiles, map_input, visual_history, egomotion_history,
-                camera_params=camera_params, mode="infer",
+                **fwd_kwargs,
             )
     finally:
         model.Reasoning_Band = band
         _restore_buffer()
         if was_training:
             model.train()
+
+    if "modulated" not in captured:
+        raise RuntimeError(
+            "the reasoning band did not run during the coupled forward; "
+            "cannot compute history_shift."
+        )
 
     coupled_traj = coupled[0] if isinstance(coupled, tuple) else coupled
     intervened_traj = intervened[0] if isinstance(intervened, tuple) else intervened
@@ -99,7 +134,7 @@ def reasoning_intervention_delta(
         coupled_traj - intervened_traj, dim=-1
     ).mean()
     history_shift = torch.linalg.vector_norm(
-        pred.modulated_visual_history - visual_history, dim=-1
+        captured["modulated"] - captured["effective"], dim=-1
     ).mean()
 
     return {

--- a/Model/evaluation/faithfulness.py
+++ b/Model/evaluation/faithfulness.py
@@ -1,0 +1,108 @@
+"""Reasoning-band faithfulness check via intervention (#98/#103).
+
+Recent VLA benchmarks show that a model's stated reasoning can be *decorative*
+rather than causal — high observational alignment while interventions on the
+reasoning leave the trajectory unchanged (VLADriveBench, arXiv:2606.12706).
+This module measures the opposite, causal notion directly in our stack: run
+the same batch **with and without the reasoning band's planner coupling** and
+report how much the trajectory actually moves.
+
+Because the band's gate is zero-initialised (no-op), the delta is exactly 0.0
+at initialisation and only becomes positive once training pushes the gate away
+from zero — so this doubles as a regression check that enabling the band does
+not perturb the reactive baseline before training.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+def reasoning_intervention_delta(
+    model: torch.nn.Module,
+    camera_tiles: torch.Tensor,
+    map_input: torch.Tensor,
+    visual_history: torch.Tensor,
+    egomotion_history: torch.Tensor,
+    camera_params: Optional[torch.Tensor] = None,
+) -> dict[str, float]:
+    """Measure how much the reasoning band's coupling moves the trajectory.
+
+    Runs ``model`` twice in ``mode="infer"`` on the same inputs: once as-is
+    (reasoning band active) and once with the band bypassed (intervention),
+    then compares the predicted trajectories.
+
+    Args:
+        model: an ``AutoE2E`` instance with ``enable_reasoning_band=True``.
+        camera_tiles / map_input / visual_history / egomotion_history /
+            camera_params: one evaluation batch, as in ``AutoE2E.forward``.
+
+    Returns:
+        dict with:
+        * ``trajectory_l2``: mean L2 distance between the coupled and
+          intervened trajectories (0.0 while the gate is untrained).
+        * ``history_shift``: mean L2 between the modulated and raw visual
+          history (how hard the gate is actually steering the planner input).
+
+    Raises:
+        ValueError: if the model has no reasoning band to intervene on.
+    """
+    band = getattr(model, "Reasoning_Band", None)
+    if band is None:
+        raise ValueError(
+            "reasoning_intervention_delta needs a model built with "
+            "enable_reasoning_band=True."
+        )
+
+    was_training = model.training
+    model.eval()
+
+    # The World Model's rolling buffer is per-sequence state that every
+    # forward PUSHES to — without snapshot/restore the coupled and intervened
+    # runs would see different histories (non-zero delta even with an
+    # untrained gate) and the caller's rollout state would be advanced.
+    buffer = getattr(model, "visual_history_buffer", None)
+    saved_frames = list(buffer._buf) if buffer is not None else None
+
+    def _restore_buffer() -> None:
+        if buffer is not None and saved_frames is not None:
+            buffer._buf = list(saved_frames)
+
+    try:
+        with torch.no_grad():
+            coupled = model(
+                camera_tiles, map_input, visual_history, egomotion_history,
+                camera_params=camera_params, mode="infer",
+            )
+            _restore_buffer()
+            pred = band(visual_history, mode="infer")
+            # Intervention: bypass the band entirely (planner sees the raw
+            # visual history), then restore it.  setattr keeps mypy happy
+            # about temporarily nulling an nn.Module attribute.
+            setattr(model, "Reasoning_Band", None)
+            intervened = model(
+                camera_tiles, map_input, visual_history, egomotion_history,
+                camera_params=camera_params, mode="infer",
+            )
+    finally:
+        model.Reasoning_Band = band
+        _restore_buffer()
+        if was_training:
+            model.train()
+
+    coupled_traj = coupled[0] if isinstance(coupled, tuple) else coupled
+    intervened_traj = intervened[0] if isinstance(intervened, tuple) else intervened
+
+    trajectory_l2 = torch.linalg.vector_norm(
+        coupled_traj - intervened_traj, dim=-1
+    ).mean()
+    history_shift = torch.linalg.vector_norm(
+        pred.modulated_visual_history - visual_history, dim=-1
+    ).mean()
+
+    return {
+        "trajectory_l2": float(trajectory_l2),
+        "history_shift": float(history_shift),
+    }

--- a/Model/evaluation/splits.py
+++ b/Model/evaluation/splits.py
@@ -70,3 +70,38 @@ def geographic_holdout_split(
     if not train:
         raise ValueError("holdout_cities cover every episode — train split is empty")
     return train, val
+
+
+def long_tail_split(
+    sample_scenarios: Sequence[Sequence[str]],
+    long_tail_classes: Sequence[str],
+) -> tuple[list[int], list[int]]:
+    """Stratify evaluation samples into long-tail vs nominal subsets (#98).
+
+    Average open-loop metrics are dominated by ego status and nominal driving
+    (Li et al., CVPR 2024 — "Is Ego Status All You Need?"), so the reasoning
+    band must be measured on the long-tail subset, reported as the delta over
+    an ego-status-only baseline (e.g. :func:`hold_last_action_baseline`).
+
+    Like the other helpers here, this operates on caller-supplied labels — one
+    sequence of active scenario class names per evaluation sample (from teacher
+    labels, L2D metadata, or KITScenes annotations); it does not read datasets.
+
+    Args:
+        sample_scenarios: per-sample active scenario classes (index-aligned).
+        long_tail_classes: class names that define the long tail (e.g. the
+            ``edge_case`` taxonomy group, or KITScenes' rare categories).
+    Returns:
+        ``(long_tail_indices, nominal_indices)`` — a sample lands in the
+        long-tail subset when ANY of its classes is in ``long_tail_classes``.
+    Raises:
+        ValueError: if ``long_tail_classes`` is empty.
+    """
+    if not long_tail_classes:
+        raise ValueError("long_tail_classes must be non-empty")
+    rare = set(long_tail_classes)
+    long_tail: list[int] = []
+    nominal: list[int] = []
+    for i, classes in enumerate(sample_scenarios):
+        (long_tail if rare.intersection(classes) else nominal).append(i)
+    return long_tail, nominal

--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -1,4 +1,7 @@
+from typing import Any, Dict, Optional
+
 import torch.nn as nn
+
 from .reactive_e2e import ReactiveE2E
 from .world_action_model import RollingHistoryBuffer, WorldActionModel
 
@@ -13,7 +16,9 @@ class AutoE2E(nn.Module):
                  map_fusion_mode="residual", map_fusion_kwargs=None,
                  temporal_memory_mode="no_memory", temporal_memory_kwargs=None,
                  planner_mode="bezier", planner_kwargs=None,
-                 enable_world_model=False, world_model_kwargs=None):
+                 enable_world_model=False, world_model_kwargs=None,
+                 enable_reasoning_band=False,
+                 reasoning_kwargs: Optional[Dict[str, Any]] = None):
         super(AutoE2E, self).__init__()
 
         # Reactive model which runs at 10Hz and processes multi-camera inputs
@@ -34,8 +39,8 @@ class AutoE2E(nn.Module):
         # future visual features (JEPA). Reuses the reactive backbone (one shared
         # backbone; the JEPA target is a frozen copy of it). Opt-in (default OFF)
         # so the reactive-only default is byte-identical.
-        self.World_Action_Model_E2E = None
-        self.visual_history_buffer = None
+        self.World_Action_Model_E2E: Optional[WorldActionModel] = None
+        self.visual_history_buffer: Optional[RollingHistoryBuffer] = None
         if enable_world_model:
             wmk = dict(world_model_kwargs or {})
             history_len = wmk.pop("history_len", 4)
@@ -46,6 +51,20 @@ class AutoE2E(nn.Module):
                 history_len=history_len, num_views=num_views, **wmk,
             )
             self.visual_history_buffer = RollingHistoryBuffer(history_len=history_len)
+
+        # Reasoning Band (slow, ~1Hz): classifies the current (and in training,
+        # future) scenario across multi-label taxonomy groups, supervised by
+        # the student/teacher loss, and feeds the trajectory planner through a
+        # ZERO-INIT gate that modulates the visual history (#98/#103) — a
+        # strict no-op at initialisation, so with the gate untrained the
+        # reactive baseline is unchanged.  Opt-in (default OFF) so the
+        # reactive-only baseline is byte-for-byte unchanged when disabled.
+        self.Reasoning_Band: Optional[nn.Module] = None
+        if enable_reasoning_band:
+            from .reasoning.reasoning_band import ReasoningBand  # local import — lazy
+            rkw = dict(reasoning_kwargs or {})
+            rkw.setdefault("visual_history_dim", visual_history_dim)
+            self.Reasoning_Band = ReasoningBand(**rkw)
 
     def reset_visual_history(self):
         """Clear the World Model's rolling buffer (call between sequences)."""
@@ -103,22 +122,41 @@ class AutoE2E(nn.Module):
             # Encode the current 1 Hz multi-view frame; push a detached copy so the
             # planner's history is a pure rolling memory (no graph across steps).
             visual_embedding, _ = wam(camera_tiles)
-            self.visual_history_buffer.push(visual_embedding.detach())
+            self.visual_history_buffer.push(visual_embedding.detach())  # type: ignore[union-attr]
             # The planner and the future prediction read the SAME history (post-push,
             # i.e. including the current frame) so the JEPA context stays aligned
             # with what the planner actually sees.
             visual_history = wam.aggregate_history(
-                self.visual_history_buffer.visual_history())
+                self.visual_history_buffer.visual_history())  # type: ignore[union-attr]
             if mode == "train":
                 future_state_pred = wam.predict_future(visual_history)
+
+        # Reasoning Band (1Hz): classify the current scenario (and, in training,
+        # future horizons), then condition the planner through the band's
+        # zero-init gate: the planner receives the MODULATED visual history,
+        # which at initialisation is identical to the input (strict no-op) and
+        # only diverges as training moves the gate (#98/#103).
+        reasoning_pred = None
+        if self.Reasoning_Band is not None:
+            reasoning_pred = self.Reasoning_Band(visual_history, mode=mode)
+            visual_history = reasoning_pred.modulated_visual_history
 
         trajectory = self.Reactive_E2E(camera_tiles, map_input, visual_history, egomotion_history,
         projection=projection, geometry_type=geometry_type, image_transform=image_transform,
         mode=mode, trajectory_target=trajectory_target, **kwargs)
 
-        # Inference: just the trajectory. Training with the World Model on: also
-        # return the predicted future state (the differentiable JEPA loss itself is
-        # computed in the training loop via the windowed WorldActionModel path).
+        # Return contract:
+        #   * Reasoning band OFF, World Model OFF → same as before (scalar / trajectory).
+        #   * World Model ON, mode="train" → (trajectory, future_state_pred)       [existing]
+        #   * Reasoning Band ON, mode="train" → (trajectory, future_state_pred, reasoning_pred)
+        #   * Reasoning Band ON, mode!="train" → same as World-Model-only path
+        #
+        # The reasoning_pred follows the same pattern as future_state_pred: only
+        # returned in mode="train" (with the future horizons) for the training
+        # loop to compute the reasoning loss.  It is a ReasoningPrediction
+        # (per-group logits + per-horizon confidence + the modulated history).
+        if self.Reasoning_Band is not None and mode == "train":
+            return trajectory, future_state_pred, reasoning_pred
         if self.World_Action_Model_E2E is not None and mode == "train":
             return trajectory, future_state_pred
         return trajectory

--- a/Model/model_components/reasoning/__init__.py
+++ b/Model/model_components/reasoning/__init__.py
@@ -1,0 +1,10 @@
+"""Reasoning band — scenario classification head for AutoE2E (issue #98).
+
+This package is opt-in (default OFF); importing it never pulls heavy
+dependencies (the Qwen2-VL backend uses a lazy import inside its module).
+"""
+
+from .scenario_taxonomy import ScenarioTaxonomy, TaxonomyGroup
+from .reasoning_band import ReasoningBand
+
+__all__ = ["ScenarioTaxonomy", "TaxonomyGroup", "ReasoningBand"]

--- a/Model/model_components/reasoning/reasoning_band.py
+++ b/Model/model_components/reasoning/reasoning_band.py
@@ -54,11 +54,22 @@ class ReasoningPrediction:
             other modes: 1 (current scenario only).
         confidence: ``[B, num_horizons]`` raw logits for the per-horizon
             confidence (issue #103, temporal-first).  Same horizon count as
-            ``logits``.
+            ``logits``.  NOTE: this output is **not supervised in the core PR** —
+            it is a trainable placeholder.  Supervise it with
+            :func:`~training.losses.reasoning_loss.confidence_brier_loss`
+            against a target (e.g. the cross-teacher agreement fraction); the
+            full supervise-and-consume-by-the-planner loop is tracked in #110.
         modulated_visual_history: ``[B, visual_history_dim]`` — the visual
             history after the zero-init gate.  Identical to the input at
             initialisation (strict no-op) so the reactive baseline is
             unchanged until training moves the gate.
+
+    Ablation surface: ``logits`` exposes **every** horizon (now, +1 … +4 s), so
+    a caller can build an all-horizon-pooled latent or a horizon-token planner
+    coupling on top of this output.  The band's own gate is the current-only
+    pooled baseline (option B); richer couplings (all-horizon pooled / horizon
+    cross-attention) are follow-ups that reuse this same output contract, so the
+    interface does not block them.
     """
 
     logits: ReasoningOutput

--- a/Model/model_components/reasoning/reasoning_band.py
+++ b/Model/model_components/reasoning/reasoning_band.py
@@ -1,0 +1,233 @@
+"""Reasoning Band — multi-label, multi-horizon scenario classification (issue #98).
+
+The band consumes the 896-dim Encoded Visual History (the same vector the World
+Action Model produces via :meth:`WorldActionModel.aggregate_history`) and
+decodes it into per-group sigmoid classification heads for the current scenario
+and — in training — four future horizons at +1 … +4 s (@1 Hz).
+
+Its scenario prediction is supervised by the Video-Language-Model loss
+(student/teacher, see ``Model/training/losses/reasoning_loss.py``).  In
+addition, the band feeds the trajectory planner through a **zero-init gate**
+(agreed in issues #98/#103): the current-scenario probabilities modulate the
+visual history via a FiLM-style transform whose weights start at zero, so the
+reactive baseline is byte-identical at initialisation and the coupling only
+takes effect as training pushes the gate away from zero.  A per-horizon
+**confidence head** (issue #103, temporal-first) accompanies the class logits.
+
+Architecture summary:
+
+    896-dim visual_history
+        ├── trunk (shared MLP)
+        │       ├── per-group × per-horizon sigmoid heads → multi-label logits
+        │       └── confidence head                       → [B, horizons]
+        └── zero-init gate (conditioned on current-scenario probabilities)
+                └── modulated visual_history              → trajectory planner
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import torch
+import torch.nn as nn
+
+from .scenario_taxonomy import ScenarioTaxonomy, DEFAULT_TAXONOMY
+
+
+# ---------------------------------------------------------------------------
+# Typed output containers
+# ---------------------------------------------------------------------------
+
+# ReasoningOutput[group_name][horizon_index] = raw logits [B, num_classes]
+ReasoningOutput = Dict[str, List[torch.Tensor]]
+
+
+@dataclass
+class ReasoningPrediction:
+    """Typed result of one reasoning-band forward pass (1 Hz tick).
+
+    Fields:
+        logits: dict mapping each taxonomy group to a list of per-horizon raw
+            logits ``[B, num_classes]`` (apply ``torch.sigmoid`` for
+            probabilities).  Train mode: ``1 + num_future_horizons`` entries;
+            other modes: 1 (current scenario only).
+        confidence: ``[B, num_horizons]`` raw logits for the per-horizon
+            confidence (issue #103, temporal-first).  Same horizon count as
+            ``logits``.
+        modulated_visual_history: ``[B, visual_history_dim]`` — the visual
+            history after the zero-init gate.  Identical to the input at
+            initialisation (strict no-op) so the reactive baseline is
+            unchanged until training moves the gate.
+    """
+
+    logits: ReasoningOutput
+    confidence: torch.Tensor
+    modulated_visual_history: torch.Tensor
+
+
+# ---------------------------------------------------------------------------
+# Zero-init gate (planner coupling, issues #98/#103)
+# ---------------------------------------------------------------------------
+
+
+class ZeroInitGate(nn.Module):
+    """FiLM-style gate that modulates the visual history with scenario probs.
+
+    ``output = visual_history * (1 + gamma) + beta`` where ``gamma`` and
+    ``beta`` are linear projections of the current-scenario probability
+    vector.  Both projections are zero-initialised (weights AND biases), so at
+    initialisation the gate is a strict no-op — the same alpha=0 pattern the
+    repo uses in ``ResidualMapFusion``.  Gradients move the gate away from
+    zero only where the scenario signal helps the trajectory.
+
+    Args:
+        scenario_dim: size of the conditioning vector (total classes across
+            all taxonomy groups).
+        visual_history_dim: dimensionality of the visual history (default 896).
+    """
+
+    def __init__(self, scenario_dim: int, visual_history_dim: int) -> None:
+        super().__init__()
+        self.gamma = nn.Linear(scenario_dim, visual_history_dim)
+        self.beta = nn.Linear(scenario_dim, visual_history_dim)
+        nn.init.zeros_(self.gamma.weight)
+        nn.init.zeros_(self.gamma.bias)
+        nn.init.zeros_(self.beta.weight)
+        nn.init.zeros_(self.beta.bias)
+
+    def forward(
+        self, visual_history: torch.Tensor, scenario_probs: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply the gate.
+
+        Args:
+            visual_history: ``[B, visual_history_dim]``.
+            scenario_probs: ``[B, scenario_dim]`` current-scenario
+                probabilities in ``[0, 1]``.
+
+        Returns:
+            Modulated ``[B, visual_history_dim]`` (equal to the input at init).
+        """
+        gamma = self.gamma(scenario_probs)
+        beta = self.beta(scenario_probs)
+        return visual_history * (1.0 + gamma) + beta
+
+
+# ---------------------------------------------------------------------------
+# Main module
+# ---------------------------------------------------------------------------
+
+
+class ReasoningBand(nn.Module):
+    """Multi-label, multi-horizon scenario classification band for AutoE2E.
+
+    Consumes the 896-dim Encoded Visual History produced by the World Action
+    Model and outputs, per taxonomy group, sigmoid classification logits for
+    the current scene and (in training) four future horizons at +1 … +4 s,
+    plus a per-horizon confidence (issue #103).  The current-scenario
+    probabilities feed the trajectory planner through a zero-init gate.
+
+    Args:
+        visual_history_dim: input dimensionality (must match the Encoded
+            Visual History dimension, default 896).
+        hidden_dim: width of the shared trunk (default 256).
+        num_future_horizons: future horizons predicted in training
+            (default 4, for h=+1..+4 s at 1 Hz).
+        taxonomy: scenario label registry (defaults to
+            :data:`DEFAULT_TAXONOMY`).
+
+    Example::
+
+        band = ReasoningBand()
+        pred = band(visual_history, mode="train")   # visual_history: [B, 896]
+        pred.logits["maneuver"]          # list of 5 tensors [B, 7] (h=0..4)
+        pred.confidence                  # [B, 5]
+        pred.modulated_visual_history    # [B, 896] (== input at init)
+    """
+
+    def __init__(
+        self,
+        visual_history_dim: int = 896,
+        hidden_dim: int = 256,
+        num_future_horizons: int = 4,
+        taxonomy: Optional[ScenarioTaxonomy] = None,
+    ) -> None:
+        super().__init__()
+        self.visual_history_dim = visual_history_dim
+        self.num_future_horizons = num_future_horizons
+        self.taxonomy = taxonomy if taxonomy is not None else DEFAULT_TAXONOMY
+
+        # Shared trunk: project the visual history into a compact representation.
+        self.trunk = nn.Sequential(
+            nn.Linear(visual_history_dim, hidden_dim),
+            nn.GELU(),
+            nn.LayerNorm(hidden_dim),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.GELU(),
+        )
+
+        # One linear head per (group, horizon): h=0 (current) plus
+        # h=1..num_future_horizons (future, train mode only).
+        total_horizons = 1 + num_future_horizons
+        self.heads = nn.ModuleDict(
+            {
+                f"{group.name}_h{h}": nn.Linear(hidden_dim, len(group))
+                for group in self.taxonomy.groups
+                for h in range(total_horizons)
+            }
+        )
+
+        # Per-horizon confidence (raw logits; issue #103, temporal-first).
+        self.confidence_head = nn.Linear(hidden_dim, total_horizons)
+
+        # Planner coupling: zero-init gate conditioned on the current-scenario
+        # probability vector (all groups concatenated).
+        self.gate = ZeroInitGate(
+            scenario_dim=self.taxonomy.total_classes(),
+            visual_history_dim=visual_history_dim,
+        )
+
+    def forward(
+        self,
+        visual_history: torch.Tensor,
+        mode: str = "infer",
+        images: Optional[torch.Tensor] = None,
+    ) -> ReasoningPrediction:
+        """Run the reasoning band.
+
+        Args:
+            visual_history: ``[B, visual_history_dim]`` — the Encoded Visual
+                History from :meth:`WorldActionModel.aggregate_history`.
+            mode: ``"train"`` produces all ``1 + num_future_horizons``
+                horizons; any other value produces only the current horizon.
+            images: unused by this variant (present so the frozen-VLM variant
+                can share the same call signature in ``AutoE2E``).
+
+        Returns:
+            A :class:`ReasoningPrediction`.
+        """
+        del images  # only the frozen-VLM variant consumes raw frames
+        features = self.trunk(visual_history)
+        num_horizons = 1 + self.num_future_horizons if mode == "train" else 1
+
+        logits: ReasoningOutput = {}
+        for group in self.taxonomy.groups:
+            logits[group.name] = [
+                self.heads[f"{group.name}_h{h}"](features)
+                for h in range(num_horizons)
+            ]
+
+        confidence = self.confidence_head(features)[:, :num_horizons]
+
+        current_probs = torch.cat(
+            [torch.sigmoid(logits[g.name][0]) for g in self.taxonomy.groups],
+            dim=1,
+        )
+        modulated = self.gate(visual_history, current_probs)
+
+        return ReasoningPrediction(
+            logits=logits,
+            confidence=confidence,
+            modulated_visual_history=modulated,
+        )

--- a/Model/model_components/reasoning/scenario_taxonomy.py
+++ b/Model/model_components/reasoning/scenario_taxonomy.py
@@ -1,0 +1,215 @@
+"""Single source of truth for the scenario label space (issue #98).
+
+Three independent axes, each MULTI-LABEL (several labels can be active
+simultaneously across and within axes):
+
+* **maneuver** — normal driving manoeuvres (7 classes).
+* **edge_case** — edge-case / long-tail manoeuvres (6 classes).
+* **weather_env** — weather × time-of-day combinations (8 classes).
+
+The registry is extensible: call :meth:`ScenarioTaxonomy.register_group` to
+add a new axis (e.g. KIT high-level labels) without changing existing group
+indices or breaking the loss contract.  Index ordering within each group is
+stable and part of the loss contract — do NOT reorder entries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence
+
+
+@dataclass
+class TaxonomyGroup:
+    """One axis in the scenario taxonomy.
+
+    Args:
+        name: unique identifier (e.g. ``"maneuver"``).
+        labels: ordered tuple of class names.  Index order is part of the
+            loss contract — append only, never insert or reorder.
+    """
+
+    name: str
+    labels: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if len(set(self.labels)) != len(self.labels):
+            raise ValueError(
+                f"TaxonomyGroup '{self.name}' contains duplicate labels: "
+                f"{self.labels}"
+            )
+
+    def __len__(self) -> int:
+        return len(self.labels)
+
+    def index(self, label: str) -> int:
+        """Return the stable index of *label* (raises ``KeyError`` if absent)."""
+        try:
+            return self.labels.index(label)
+        except ValueError:
+            raise KeyError(
+                f"Label '{label}' not found in group '{self.name}'. "
+                f"Known labels: {self.labels}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Canonical label sets (do NOT reorder — index is part of the loss contract)
+# ---------------------------------------------------------------------------
+
+_MANEUVER_LABELS: tuple[str, ...] = (
+    "continue_straight",
+    "curve_left",
+    "curve_right",
+    "change_lane_left",
+    "change_lane_right",
+    "turn_left",
+    "turn_right",
+)
+
+_EDGE_CASE_LABELS: tuple[str, ...] = (
+    "nudge_out",
+    "give_way",
+    "stop_for_object_in_path",
+    "close_to_vru",
+    "avoid_roadworks",
+    "stop_for_emergency_vehicle",
+)
+
+_WEATHER_ENV_LABELS: tuple[str, ...] = (
+    "fair_day",
+    "fair_night",
+    "rain_day",
+    "rain_night",
+    "snow_day",
+    "snow_night",
+    "fog_day",
+    "fog_night",
+)
+
+
+class ScenarioTaxonomy:
+    """Registry of scenario label groups.
+
+    The three canonical groups are registered at construction time.
+    Additional groups (e.g. KIT high-level labels) can be added later via
+    :meth:`register_group` or :meth:`extend` without breaking any existing
+    group's index contract.
+
+    Example::
+
+        taxonomy = ScenarioTaxonomy()
+        g = taxonomy["maneuver"]
+        idx = g.index("turn_left")   # → 6  (stable)
+
+        # Extend with KIT labels (append-only within the new group):
+        taxonomy.register_group("kit_context", ["intersection", "construction_zone"])
+
+    """
+
+    def __init__(self) -> None:
+        self._groups: Dict[str, TaxonomyGroup] = {}
+
+        # Register the three canonical axes in a fixed order so that
+        # ``groups`` always starts with {maneuver, edge_case, weather_env}.
+        self.register_group("maneuver", list(_MANEUVER_LABELS))
+        self.register_group("edge_case", list(_EDGE_CASE_LABELS))
+        self.register_group("weather_env", list(_WEATHER_ENV_LABELS))
+
+    # ------------------------------------------------------------------
+    # Extension API
+    # ------------------------------------------------------------------
+
+    def register_group(self, name: str, labels: Sequence[str]) -> TaxonomyGroup:
+        """Register a new label group.
+
+        Args:
+            name: unique group identifier.
+            labels: ordered list of class names.  Index order is stable once
+                registered — append-only semantics are the caller's
+                responsibility for subsequent :meth:`extend` calls.
+
+        Returns:
+            The newly created :class:`TaxonomyGroup`.
+
+        Raises:
+            ValueError: if *name* is already registered.
+        """
+        if name in self._groups:
+            raise ValueError(
+                f"Group '{name}' is already registered. "
+                "Use extend() to append labels to an existing group."
+            )
+        group = TaxonomyGroup(name=name, labels=tuple(labels))
+        self._groups[name] = group
+        return group
+
+    def extend(self, name: str, new_labels: Sequence[str]) -> TaxonomyGroup:
+        """Append *new_labels* to an existing group (append-only).
+
+        This is the only sanctioned way to grow a group's label set so that
+        existing indices remain stable.
+
+        Args:
+            name: group to extend.
+            new_labels: labels to append (must not overlap with current set).
+
+        Returns:
+            The updated :class:`TaxonomyGroup`.
+        """
+        if name not in self._groups:
+            raise KeyError(
+                f"Group '{name}' is not registered. "
+                "Call register_group() first."
+            )
+        existing = self._groups[name]
+        overlap = set(new_labels) & set(existing.labels)
+        if overlap:
+            raise ValueError(
+                f"Labels {sorted(overlap)} already exist in group '{name}'."
+            )
+        updated_labels = existing.labels + tuple(new_labels)
+        self._groups[name] = TaxonomyGroup(name=name, labels=updated_labels)
+        return self._groups[name]
+
+    # ------------------------------------------------------------------
+    # Read API
+    # ------------------------------------------------------------------
+
+    def __getitem__(self, name: str) -> TaxonomyGroup:
+        try:
+            return self._groups[name]
+        except KeyError:
+            raise KeyError(
+                f"Group '{name}' not found. "
+                f"Registered groups: {list(self._groups)}"
+            )
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._groups
+
+    @property
+    def groups(self) -> List[TaxonomyGroup]:
+        """All registered groups in insertion order."""
+        return list(self._groups.values())
+
+    @property
+    def group_names(self) -> List[str]:
+        """Names of all registered groups in insertion order."""
+        return list(self._groups.keys())
+
+    def num_classes(self, name: str) -> int:
+        """Number of classes in group *name*."""
+        return len(self[name])
+
+    def total_classes(self) -> int:
+        """Total number of classes across all groups.
+
+        Used as the conditioning dimension of the planner gate (the
+        current-scenario probabilities of every group, concatenated).
+        """
+        return sum(len(g) for g in self._groups.values())
+
+
+# Module-level default taxonomy instance — shared across the package.
+DEFAULT_TAXONOMY: ScenarioTaxonomy = ScenarioTaxonomy()

--- a/Model/model_components/reasoning/teachers/__init__.py
+++ b/Model/model_components/reasoning/teachers/__init__.py
@@ -1,13 +1,12 @@
 """Teacher backends for reasoning-band pseudo-label generation (issue #98).
 
 Teachers are TRAIN-ONLY offline autolabellers — they are never part of the
-inference loop.  For CI and unit tests use :class:`DeterministicTeacher`
-(no GPU, no network); real VLM backends (Qwen2-VL, VideoLLaMA3) plug in as
-follow-up work through the same registry.
+inference loop.  The default real backend is :class:`Qwen2VLTeacher`; for CI
+and unit tests use :class:`DeterministicTeacher` (no GPU, no network).
 
 Extension point: to add a new teacher backend (e.g. an Alpamayo CoC
-autolabeller), subclass :class:`VLMTeacher` from ``base.py`` and register the
-class in ``_TEACHER_REGISTRY`` below.
+autolabeller for v2), subclass :class:`VLMTeacher` from ``base.py`` and
+register the class in ``_TEACHER_REGISTRY`` below.
 
     from model_components.reasoning.teachers.base import VLMTeacher
 
@@ -20,11 +19,31 @@ class in ``_TEACHER_REGISTRY`` below.
 
 from .base import VLMTeacher
 from .deterministic import DeterministicTeacher
+from .multi_teacher import MultiTeacher
 
-__all__ = ["VLMTeacher", "DeterministicTeacher"]
+__all__ = [
+    "VLMTeacher",
+    "DeterministicTeacher",
+    "MultiTeacher",
+]
 
 # Registry: maps a string key to a teacher class.  Populated lazily so that
 # importing this package never requires heavy dependencies.
 _TEACHER_REGISTRY: dict[str, type[VLMTeacher]] = {
     "deterministic": DeterministicTeacher,
+    "multi": MultiTeacher,
 }
+
+
+def _register_lazy_backends() -> None:
+    """Register the heavy (lazily-imported) backends by name."""
+    from .openai_endpoint import OpenAIEndpointTeacher
+    from .qwen2vl import Qwen2VLTeacher
+    from .videollama3 import VideoLlama3Teacher
+
+    _TEACHER_REGISTRY.setdefault("qwen2vl", Qwen2VLTeacher)
+    _TEACHER_REGISTRY.setdefault("videollama3", VideoLlama3Teacher)
+    _TEACHER_REGISTRY.setdefault("openai_endpoint", OpenAIEndpointTeacher)
+
+
+_register_lazy_backends()

--- a/Model/model_components/reasoning/teachers/__init__.py
+++ b/Model/model_components/reasoning/teachers/__init__.py
@@ -1,0 +1,30 @@
+"""Teacher backends for reasoning-band pseudo-label generation (issue #98).
+
+Teachers are TRAIN-ONLY offline autolabellers — they are never part of the
+inference loop.  For CI and unit tests use :class:`DeterministicTeacher`
+(no GPU, no network); real VLM backends (Qwen2-VL, VideoLLaMA3) plug in as
+follow-up work through the same registry.
+
+Extension point: to add a new teacher backend (e.g. an Alpamayo CoC
+autolabeller), subclass :class:`VLMTeacher` from ``base.py`` and register the
+class in ``_TEACHER_REGISTRY`` below.
+
+    from model_components.reasoning.teachers.base import VLMTeacher
+
+    class MyTeacher(VLMTeacher):
+        ...
+
+    # Optional: register so consumers can look it up by name.
+    _TEACHER_REGISTRY["my_teacher"] = MyTeacher
+"""
+
+from .base import VLMTeacher
+from .deterministic import DeterministicTeacher
+
+__all__ = ["VLMTeacher", "DeterministicTeacher"]
+
+# Registry: maps a string key to a teacher class.  Populated lazily so that
+# importing this package never requires heavy dependencies.
+_TEACHER_REGISTRY: dict[str, type[VLMTeacher]] = {
+    "deterministic": DeterministicTeacher,
+}

--- a/Model/model_components/reasoning/teachers/base.py
+++ b/Model/model_components/reasoning/teachers/base.py
@@ -1,0 +1,76 @@
+"""Abstract teacher interface for reasoning-band pseudo-label generation (issue #98).
+
+Teachers are TRAIN-ONLY, offline autolabellers.  They are never instantiated
+at inference time and must not appear in the model's forward pass.
+
+Usage pattern in a training loop::
+
+    teacher = Qwen2VLTeacher(taxonomy)
+    # … for each batch …
+    targets = teacher.label(frames, num_future_horizons=4)
+    # targets["maneuver"][0] is a [B, 7] float tensor (multi-label, 0/1 or soft)
+    loss = reasoning_loss(student_logits, targets, weight=1.0)
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Sequence
+
+import torch
+
+from ..scenario_taxonomy import ScenarioTaxonomy, DEFAULT_TAXONOMY
+
+# ReasoningTargets[group_name][horizon_index] = float target tensor [B, num_classes]
+# Values in [0, 1]: hard (0/1) for deterministic / soft for VLM confidence scores.
+ReasoningTargets = Dict[str, List[torch.Tensor]]
+
+
+class VLMTeacher(ABC):
+    """Abstract base class for scenario pseudo-label teachers.
+
+    All teachers share the same :meth:`label` interface so the training loop
+    can swap backends without code changes.
+
+    Args:
+        taxonomy: the label registry used to determine group names and class
+            counts.  Defaults to :data:`DEFAULT_TAXONOMY`.
+
+    Extension point — Alpamayo CoC autolabeller (v2):
+        Implement a subclass that calls the NVlabs CoC autolabeller API,
+        mapping its chain-of-causation output onto the taxonomy groups.
+        Register the class in
+        ``model_components.reasoning.teachers._TEACHER_REGISTRY`` under the
+        key ``"alpamayo_coc"`` so users can select it via a config string.
+        **Do NOT implement CoC here** — this extension point is intentionally
+        left as a docstring-only placeholder for a future contributor.
+    """
+
+    def __init__(
+        self, taxonomy: Optional[ScenarioTaxonomy] = None
+    ) -> None:
+        self.taxonomy = taxonomy if taxonomy is not None else DEFAULT_TAXONOMY
+
+    @abstractmethod
+    def label(
+        self,
+        frames: Sequence[torch.Tensor],
+        num_future_horizons: int = 4,
+    ) -> ReasoningTargets:
+        """Produce multi-label targets for the current scene and future horizons.
+
+        Args:
+            frames: sequence of image tensors representing the current and
+                (optionally) future front-camera frames.  The first element
+                is the current frame; subsequent elements correspond to future
+                horizons.  Each tensor is ``[B, C, H, W]`` or ``[B, 3, H, W]``.
+            num_future_horizons: number of future horizons to label (must be
+                consistent with the reasoning band's configuration).
+
+        Returns:
+            :data:`ReasoningTargets` — a dict mapping each group name to a
+            list of ``1 + num_future_horizons`` float tensors of shape
+            ``[B, num_classes]`` in ``[0, 1]``.  Hard labels use 0.0 / 1.0;
+            soft labels from a VLM use confidence scores.
+        """
+        raise NotImplementedError

--- a/Model/model_components/reasoning/teachers/deterministic.py
+++ b/Model/model_components/reasoning/teachers/deterministic.py
@@ -1,0 +1,99 @@
+"""Deterministic (keyword-rule) teacher for CI and offline testing (issue #98).
+
+This teacher uses only CPU arithmetic — no neural network, no GPU, no heavy
+dependencies.  It is the recommended backend for unit tests and CI pipelines.
+
+The label logic is purely keyword-based: the caller supplies a dict of active
+label names per group (``active_labels``), and the teacher constructs the
+corresponding one-hot target tensors.  If no active labels are provided for
+a group, the teacher returns all-zero targets (no class active).
+
+This deterministic behaviour makes it trivial to construct expected outputs
+in test assertions.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Sequence
+
+import torch
+
+from ..scenario_taxonomy import ScenarioTaxonomy
+from .base import VLMTeacher, ReasoningTargets
+
+
+class DeterministicTeacher(VLMTeacher):
+    """Keyword/rule-based teacher that produces deterministic multi-label targets.
+
+    Args:
+        taxonomy: label registry.  Defaults to :data:`DEFAULT_TAXONOMY`.
+        active_labels: dict mapping group names to lists of label strings that
+            should be set to 1.0 in the target tensor.  Any group not present
+            defaults to all-zero targets.  Labels not in the taxonomy group
+            raise a ``KeyError``.
+
+    Example::
+
+        teacher = DeterministicTeacher(
+            active_labels={
+                "maneuver": ["turn_left"],
+                "edge_case": ["avoid_roadworks"],
+                "weather_env": ["rain_night"],
+            }
+        )
+        # Returns the same targets regardless of the frames argument.
+        targets = teacher.label(frames=[frame], num_future_horizons=4)
+    """
+
+    def __init__(
+        self,
+        taxonomy: Optional[ScenarioTaxonomy] = None,
+        active_labels: Optional[Dict[str, List[str]]] = None,
+    ) -> None:
+        super().__init__(taxonomy)
+        self.active_labels: Dict[str, List[str]] = active_labels or {}
+
+        # Validate at construction time so errors surface early.
+        for group_name, labels in self.active_labels.items():
+            group = self.taxonomy[group_name]
+            for label in labels:
+                group.index(label)  # raises KeyError if not found
+
+    def label(
+        self,
+        frames: Sequence[torch.Tensor],
+        num_future_horizons: int = 4,
+    ) -> ReasoningTargets:
+        """Return deterministic targets derived from ``active_labels``.
+
+        The targets are identical for all horizons and for all frames in the
+        batch (keyword rules do not depend on image content).
+
+        Args:
+            frames: sequence of image tensors.  Shape ``[B, C, H, W]`` for
+                each frame.  Only the batch size is read; pixel values are
+                ignored.
+            num_future_horizons: number of future horizons.
+
+        Returns:
+            :data:`ReasoningTargets` with ``1 + num_future_horizons`` horizon
+            entries per group, each a ``[B, num_classes]`` float tensor in
+            ``{0.0, 1.0}``.
+        """
+        if not frames:
+            raise ValueError("frames must be non-empty.")
+
+        B = frames[0].shape[0]
+        device = frames[0].device
+        total_horizons = 1 + num_future_horizons
+
+        out: ReasoningTargets = {}
+        for group in self.taxonomy.groups:
+            active = self.active_labels.get(group.name, [])
+            target = torch.zeros(B, len(group), device=device)
+            for label in active:
+                idx = group.index(label)
+                target[:, idx] = 1.0
+            out[group.name] = [target.clone() for _ in range(total_horizons)]
+
+        return out

--- a/Model/model_components/reasoning/teachers/multi_teacher.py
+++ b/Model/model_components/reasoning/teachers/multi_teacher.py
@@ -51,6 +51,19 @@ class MultiTeacher(VLMTeacher):
                     "All teachers must share the same taxonomy groups; got "
                     f"{t.taxonomy.group_names} vs {self.taxonomy.group_names}."
                 )
+            # Group names matching is not enough: agreement is computed
+            # index-by-index, so every teacher must use the SAME label tuple in
+            # the SAME order — otherwise index i means a different class per
+            # teacher and the fused target is semantically invalid.
+            for group in self.taxonomy.groups:
+                if t.taxonomy[group.name].labels != group.labels:
+                    raise ValueError(
+                        f"Teacher taxonomy mismatch in group '{group.name}': "
+                        "label tuples differ in content or order "
+                        f"({t.taxonomy[group.name].labels} vs {group.labels}). "
+                        "Agreement fusion requires identical label ordering so "
+                        "index i is the same class for every teacher."
+                    )
         self.teachers = list(teachers)
 
     def label(

--- a/Model/model_components/reasoning/teachers/multi_teacher.py
+++ b/Model/model_components/reasoning/teachers/multi_teacher.py
@@ -1,0 +1,81 @@
+"""Agreement-based fusion of several teachers (issue #98/#103).
+
+Fusing multiple annotators with per-label agreement substantially improves
+multi-label pseudo-label quality over the best single VLM (+47-55% F1 in a
+dashcam multi-label study, arXiv:2510.01126; the multi-teacher pattern is also
+how Hydra-MDP won the NAVSIM challenge, arXiv:2406.06978).  The fused target
+is the **fraction of teachers that agree** on each label — which doubles as
+the soft confidence signal for the per-horizon confidence head (#103), instead
+of trusting any single teacher's (systematically over-confident) self-report.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+
+from ..scenario_taxonomy import ScenarioTaxonomy
+from .base import VLMTeacher, ReasoningTargets
+
+
+class MultiTeacher(VLMTeacher):
+    """Fuse the targets of several teachers into agreement-fraction targets.
+
+    Args:
+        teachers: two or more :class:`VLMTeacher` instances.  They must share
+            the taxonomy (same groups, same class counts).
+        taxonomy: label registry; defaults to the first teacher's taxonomy.
+
+    Example::
+
+        fused = MultiTeacher([qwen_teacher, videollama_teacher])
+        targets = fused.label(frames, num_future_horizons=4)
+        # targets[group][h] values are agreement fractions in {0, 0.5, 1.0}
+        # for two teachers — usable both as soft labels and as confidence.
+    """
+
+    def __init__(
+        self,
+        teachers: Sequence[VLMTeacher],
+        taxonomy: Optional[ScenarioTaxonomy] = None,
+    ) -> None:
+        if len(teachers) < 2:
+            raise ValueError(
+                f"MultiTeacher needs at least 2 teachers, got {len(teachers)}."
+            )
+        super().__init__(taxonomy if taxonomy is not None else teachers[0].taxonomy)
+        for t in teachers:
+            if t.taxonomy.group_names != self.taxonomy.group_names:
+                raise ValueError(
+                    "All teachers must share the same taxonomy groups; got "
+                    f"{t.taxonomy.group_names} vs {self.taxonomy.group_names}."
+                )
+        self.teachers = list(teachers)
+
+    def label(
+        self,
+        frames: Sequence[torch.Tensor],
+        num_future_horizons: int = 4,
+    ) -> ReasoningTargets:
+        """Average the member teachers' targets (per label, per horizon).
+
+        Returns:
+            :data:`ReasoningTargets` whose values are the mean of the member
+            targets — for hard {0,1} members this is the agreement fraction.
+        """
+        all_targets = [
+            t.label(frames, num_future_horizons=num_future_horizons)
+            for t in self.teachers
+        ]
+
+        fused: ReasoningTargets = {}
+        for group in self.taxonomy.groups:
+            horizons = len(all_targets[0][group.name])
+            fused[group.name] = [
+                torch.stack(
+                    [targets[group.name][h] for targets in all_targets]
+                ).mean(dim=0)
+                for h in range(horizons)
+            ]
+        return fused

--- a/Model/model_components/reasoning/teachers/openai_endpoint.py
+++ b/Model/model_components/reasoning/teachers/openai_endpoint.py
@@ -6,17 +6,28 @@ request schema, response schema)`` and speaks the OpenAI chat-completions API,
 so the backend behind the URL can be Cosmos3-Nano on vLLM / vLLM-Omni, a Qwen
 server, an external API, or a local mock — with no code change here.
 
+Two request modes:
+
+* ``mode="per_frame"`` — one request per frame, each horizon labelled
+  independently (simple; good for image-only backends).
+* ``mode="clip_horizons"`` — one request per sample with the whole clip
+  (current + future frames, plus optional ego/route/map ``extra_context``),
+  returning all horizons in a single JSON object.  This preserves temporal
+  context and is what video-native backends (Cosmos) want.
+
+Failure policy: ``strict=True`` (default) **raises** on endpoint/parse failure,
+so a transport outage, auth error, or malformed response cannot silently poison
+the dataset with all-zero labels.  ``strict=False`` abstains (empty labels) for
+large best-effort jobs.
+
 TRAIN-ONLY / OFFLINE: like every teacher, this runs during offline label
 pre-extraction and is NEVER part of the vehicle inference loop.  No teacher
-weights are shipped; only the endpoint URL is referenced, so the runtime
-artifact stays lightweight and licence-clean (the Cosmos weights never enter
-the repo — only its outputs, as offline labels).
+weights are shipped; only the endpoint URL is referenced.
 
 Testability: the network boundary is a single injectable ``transport`` callable,
 so unit tests run with a stub (no network, no GPU).  Prompt construction and
-response parsing are reused verbatim from :mod:`.qwen2vl` (the same closed JSON
-schema over the taxonomy), so every teacher backend stays label-space-consistent
-and migrates for free when the taxonomy grows into the compositional ontology.
+per-frame parsing are reused from :mod:`.qwen2vl` (the same closed JSON schema
+over the taxonomy), so every teacher backend stays label-space-consistent.
 """
 
 from __future__ import annotations
@@ -48,11 +59,7 @@ def _tensor_to_data_url(img: torch.Tensor) -> str:
 
 
 def _urllib_transport(timeout: float) -> Transport:
-    """Default transport: POST JSON to an OpenAI-compatible endpoint via urllib.
-
-    Uses the standard library only (no new runtime dependency); network calls
-    happen offline during label pre-extraction, never at inference.
-    """
+    """Default transport: POST JSON to an OpenAI-compatible endpoint via urllib."""
 
     def _post(
         url: str, payload: Dict[str, Any], headers: Dict[str, str]
@@ -76,29 +83,101 @@ def _extract_content(response: Dict[str, Any]) -> str:
         return ""
 
 
+def build_clip_prompt(
+    taxonomy: ScenarioTaxonomy,
+    num_horizons: int,
+    extra_context: Optional[str] = None,
+) -> str:
+    """Prompt for labelling a whole clip: one JSON with a per-horizon array.
+
+    Unlike :func:`~.qwen2vl.build_scenario_prompt` (one frame), this asks the
+    backend to reason over the ordered clip and return every horizon at once,
+    optionally conditioned on ego/route/map ``extra_context``.
+    """
+    lines = [
+        f"You are labelling a short driving clip of {num_horizons} front-camera "
+        "frames, ordered from the current frame (horizon 0) to the furthest "
+        "future frame.",
+        "For EACH horizon, list every label that applies from the categories below.",
+        "Use only the exact label strings given.  If none applies, use [].",
+        "",
+    ]
+    for group in taxonomy.groups:
+        lines.append(f"- {group.name}: {', '.join(group.labels)}")
+    if extra_context:
+        lines += ["", "Scene context (ego state / route / map):", extra_context]
+    per_group = '{"' + '": [...], "'.join(taxonomy.group_names) + '": [...]}'
+    lines += [
+        "",
+        "Answer with ONLY a JSON object, no other text, in the form:",
+        '{"horizons": [' + per_group + ", ...]}",
+        f"with exactly {num_horizons} entries, in horizon order.",
+    ]
+    return "\n".join(lines)
+
+
+def parse_clip_response(
+    text: str, taxonomy: ScenarioTaxonomy, num_horizons: int
+) -> List[Dict[str, List[str]]]:
+    """Parse a clip response into ``num_horizons`` per-group active-label dicts.
+
+    Tolerant like :func:`~.qwen2vl.parse_scenario_response`: chatter around the
+    JSON, unknown labels, and missing horizons all degrade to empty (abstain)
+    rather than raising — the endpoint's ``strict`` flag decides what to do
+    with an empty/malformed answer.
+    """
+    empty: List[Dict[str, List[str]]] = [
+        {g.name: [] for g in taxonomy.groups} for _ in range(num_horizons)
+    ]
+    start = text.find("{")
+    if start == -1:
+        return empty
+    try:
+        raw, _ = json.JSONDecoder().raw_decode(text[start:])
+    except json.JSONDecodeError:
+        return empty
+    if not isinstance(raw, dict):
+        return empty
+    horizons = raw.get("horizons")
+    if not isinstance(horizons, list):
+        return empty
+
+    out: List[Dict[str, List[str]]] = []
+    for h in range(num_horizons):
+        entry = horizons[h] if h < len(horizons) and isinstance(horizons[h], dict) else {}
+        parsed: Dict[str, List[str]] = {}
+        for group in taxonomy.groups:
+            values = entry.get(group.name, [])
+            if not isinstance(values, list):
+                values = []
+            parsed[group.name] = [
+                v for v in values if isinstance(v, str) and v in group.labels
+            ]
+        out.append(parsed)
+    return out
+
+
 class OpenAIEndpointTeacher(VLMTeacher):
     """Offline scenario autolabeller backed by any OpenAI-compatible endpoint.
-
-    The intended default backend is @riita10069's Cosmos3-Nano Reasoner served
-    behind a vLLM / vLLM-Omni OpenAI-compatible endpoint, but nothing here is
-    Cosmos-specific: point ``base_url`` at any compatible server (or inject a
-    ``transport`` for tests / a local mock).
-
-    Future horizons are labelled from the **future frames themselves**
-    (``frames[1:]``) — privileged offline information, following the same
-    leakage-prevention split as :class:`~.qwen2vl.Qwen2VLTeacher`.
 
     Args:
         taxonomy: label registry.  Defaults to :data:`DEFAULT_TAXONOMY`.
         base_url: OpenAI-compatible base URL (e.g. ``"http://host:8000/v1"``).
         model: model name to request (e.g. ``"cosmos3-nano"``).
-        prompt_version: recorded on the teacher for artifact provenance
-            (riita's ``prompt_version`` field); does not change the request.
+        prompt_version: recorded for artifact provenance; does not change the
+            request wire format.
         api_key: optional bearer token for the endpoint.
         timeout: per-request timeout in seconds (default backend only).
         max_tokens: generation budget for the JSON answer.
         transport: injectable ``(url, payload, headers) -> response`` callable.
             Defaults to a stdlib urllib POST.  Inject a stub in tests.
+        mode: ``"per_frame"`` (default) or ``"clip_horizons"`` (see module docstring).
+        strict: if ``True`` (default) raise on any endpoint/parse failure so the
+            dataset is never silently poisoned; if ``False`` abstain (empty
+            labels) for best-effort bulk jobs.  A downstream artifact layer
+            should record the abstain/error provenance for filtering (follow-up).
+        extra_context: optional text (ego/route/map) injected into the
+            ``clip_horizons`` prompt; ignored in ``per_frame`` mode.
     """
 
     def __init__(
@@ -112,14 +191,24 @@ class OpenAIEndpointTeacher(VLMTeacher):
         timeout: float = 60.0,
         max_tokens: int = 256,
         transport: Optional[Transport] = None,
+        mode: str = "per_frame",
+        strict: bool = True,
+        extra_context: Optional[str] = None,
     ) -> None:
         super().__init__(taxonomy)
+        if mode not in ("per_frame", "clip_horizons"):
+            raise ValueError(
+                f"Unsupported mode '{mode}'. Choose 'per_frame' or 'clip_horizons'."
+            )
         self.base_url = base_url.rstrip("/")
         self.model = model
         self.prompt_version = prompt_version
         self.api_key = api_key
         self.timeout = timeout
         self.max_tokens = max_tokens
+        self.mode = mode
+        self.strict = strict
+        self.extra_context = extra_context
         self._transport: Transport = (
             transport if transport is not None else _urllib_transport(timeout)
         )
@@ -135,43 +224,103 @@ class OpenAIEndpointTeacher(VLMTeacher):
             headers["Authorization"] = f"Bearer {self.api_key}"
         return headers
 
-    def _build_payload(self, img: torch.Tensor, prompt: str) -> Dict[str, Any]:
+    def _payload(self, images: Sequence[torch.Tensor], prompt: str) -> Dict[str, Any]:
+        content: List[Dict[str, Any]] = [{"type": "text", "text": prompt}]
+        for img in images:
+            content.append(
+                {"type": "image_url", "image_url": {"url": _tensor_to_data_url(img)}}
+            )
         return {
             "model": self.model,
-            "messages": [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": prompt},
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": _tensor_to_data_url(img)},
-                        },
-                    ],
-                }
-            ],
+            "messages": [{"role": "user", "content": content}],
             "temperature": 0.0,
             "max_tokens": self.max_tokens,
         }
 
-    def _label_one_frame_batch(
-        self, frame: torch.Tensor
-    ) -> List[Dict[str, List[str]]]:
-        """Label one ``[B, 3, H, W]`` frame batch → per-sample label dicts."""
+    def _post(self, payload: Dict[str, Any]) -> Optional[str]:
+        """Call the endpoint; on failure raise (strict) or return None (abstain).
+
+        Returns the assistant text, or ``None`` only when ``strict=False`` and
+        the call/response failed.  An empty/malformed response is treated as a
+        failure under ``strict`` (it is exactly the silent-poisoning case).
+        """
+        try:
+            response = self._transport(self.endpoint, payload, self._headers())
+            text = _extract_content(response)
+        except Exception as exc:  # noqa: BLE001 — outage / auth / transport error
+            if self.strict:
+                raise RuntimeError(
+                    f"teacher endpoint call failed ({self.endpoint}): {exc}"
+                ) from exc
+            return None
+        if not text and self.strict:
+            raise RuntimeError(
+                f"teacher endpoint returned an empty/malformed response "
+                f"({self.endpoint})."
+            )
+        return text
+
+    def _label_per_frame(
+        self, frames: Sequence[torch.Tensor], total_horizons: int
+    ) -> ReasoningTargets:
         prompt = build_scenario_prompt(self.taxonomy)
-        per_sample: List[Dict[str, List[str]]] = []
-        for img in frame:
-            try:
-                payload = self._build_payload(img, prompt)
-                response = self._transport(self.endpoint, payload, self._headers())
-                text = _extract_content(response)
-            except Exception:  # noqa: BLE001
-                # Abstain (empty labels), never crash a labelling batch: at
-                # scale a dropped frame is far cheaper than a crashed run.
-                per_sample.append({g.name: [] for g in self.taxonomy.groups})
-                continue
-            per_sample.append(parse_scenario_response(text, self.taxonomy))
-        return per_sample
+        per_horizon: List[Dict[str, torch.Tensor]] = []
+        for h in range(total_horizons):
+            frame = frames[h]
+            per_sample: List[Dict[str, List[str]]] = []
+            for img in frame:
+                text = self._post(self._payload([img], prompt))
+                if text is None:  # abstained (strict=False)
+                    per_sample.append({g.name: [] for g in self.taxonomy.groups})
+                else:
+                    per_sample.append(parse_scenario_response(text, self.taxonomy))
+            per_horizon.append(
+                labels_to_targets(per_sample, self.taxonomy, device=frame.device)
+            )
+        return self._assemble(per_horizon, total_horizons)
+
+    def _label_clip(
+        self, frames: Sequence[torch.Tensor], total_horizons: int
+    ) -> ReasoningTargets:
+        prompt = build_clip_prompt(self.taxonomy, total_horizons, self.extra_context)
+        batch = frames[0].shape[0]
+        # per_horizon_samples[h] = list of per-sample label dicts at horizon h.
+        per_horizon_samples: List[List[Dict[str, List[str]]]] = [
+            [] for _ in range(total_horizons)
+        ]
+        for b in range(batch):
+            images = [frames[h][b] for h in range(total_horizons)]
+            text = self._post(self._payload(images, prompt))
+            horizon_dicts: List[Dict[str, List[str]]]
+            if text is None:  # abstained (strict=False)
+                horizon_dicts = [
+                    {g.name: [] for g in self.taxonomy.groups}
+                    for _ in range(total_horizons)
+                ]
+            else:
+                horizon_dicts = parse_clip_response(
+                    text, self.taxonomy, total_horizons
+                )
+            for h in range(total_horizons):
+                per_horizon_samples[h].append(horizon_dicts[h])
+
+        per_horizon = [
+            labels_to_targets(
+                per_horizon_samples[h], self.taxonomy, device=frames[h].device
+            )
+            for h in range(total_horizons)
+        ]
+        return self._assemble(per_horizon, total_horizons)
+
+    def _assemble(
+        self, per_horizon: List[Dict[str, torch.Tensor]], total_horizons: int
+    ) -> ReasoningTargets:
+        out: ReasoningTargets = {}
+        for group in self.taxonomy.groups:
+            out[group.name] = [
+                per_horizon[h][group.name] for h in range(total_horizons)
+            ]
+        return out
 
     def label(
         self,
@@ -189,12 +338,13 @@ class OpenAIEndpointTeacher(VLMTeacher):
         Returns:
             :data:`ReasoningTargets` with hard ``{0, 1}`` values.  Soft
             confidence comes from cross-teacher agreement
-            (:class:`~.multi_teacher.MultiTeacher`), not from a single
-            teacher's self-report.
+            (:class:`~.multi_teacher.MultiTeacher`), not a single teacher's
+            self-report.
 
         Raises:
             ValueError: if fewer than ``1 + num_future_horizons`` frame
                 batches are supplied.
+            RuntimeError: under ``strict=True``, on any endpoint/parse failure.
         """
         total_horizons = 1 + num_future_horizons
         if len(frames) < total_horizons:
@@ -202,17 +352,6 @@ class OpenAIEndpointTeacher(VLMTeacher):
                 f"need {total_horizons} frame batches (current + "
                 f"{num_future_horizons} future), got {len(frames)}."
             )
-
-        per_horizon: List[Dict[str, torch.Tensor]] = []
-        for h in range(total_horizons):
-            per_sample = self._label_one_frame_batch(frames[h])
-            per_horizon.append(
-                labels_to_targets(per_sample, self.taxonomy, device=frames[h].device)
-            )
-
-        out: ReasoningTargets = {}
-        for group in self.taxonomy.groups:
-            out[group.name] = [
-                per_horizon[h][group.name] for h in range(total_horizons)
-            ]
-        return out
+        if self.mode == "clip_horizons":
+            return self._label_clip(frames, total_horizons)
+        return self._label_per_frame(frames, total_horizons)

--- a/Model/model_components/reasoning/teachers/openai_endpoint.py
+++ b/Model/model_components/reasoning/teachers/openai_endpoint.py
@@ -1,0 +1,218 @@
+"""OpenAI-compatible endpoint teacher backend for reasoning-band pseudo-labels (issue #98).
+
+Implements the *model-agnostic teacher endpoint* from @riita10069's Enhancement
+Proposal in #98.  AutoE2E depends only on ``(base_url, model, prompt_version,
+request schema, response schema)`` and speaks the OpenAI chat-completions API,
+so the backend behind the URL can be Cosmos3-Nano on vLLM / vLLM-Omni, a Qwen
+server, an external API, or a local mock — with no code change here.
+
+TRAIN-ONLY / OFFLINE: like every teacher, this runs during offline label
+pre-extraction and is NEVER part of the vehicle inference loop.  No teacher
+weights are shipped; only the endpoint URL is referenced, so the runtime
+artifact stays lightweight and licence-clean (the Cosmos weights never enter
+the repo — only its outputs, as offline labels).
+
+Testability: the network boundary is a single injectable ``transport`` callable,
+so unit tests run with a stub (no network, no GPU).  Prompt construction and
+response parsing are reused verbatim from :mod:`.qwen2vl` (the same closed JSON
+schema over the taxonomy), so every teacher backend stays label-space-consistent
+and migrates for free when the taxonomy grows into the compositional ontology.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+import torch
+
+from ..scenario_taxonomy import ScenarioTaxonomy
+from .base import ReasoningTargets, VLMTeacher
+from .qwen2vl import build_scenario_prompt, labels_to_targets, parse_scenario_response
+
+# transport(url, payload, headers) -> parsed JSON response dict (OpenAI schema).
+Transport = Callable[[str, Dict[str, Any], Dict[str, str]], Dict[str, Any]]
+
+
+def _tensor_to_data_url(img: torch.Tensor) -> str:
+    """Encode a ``[3, H, W]`` image tensor as a base64 PNG ``data:`` URL."""
+    from torchvision.transforms.functional import to_pil_image
+
+    pil = to_pil_image(img.detach().cpu())
+    buf = io.BytesIO()
+    pil.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{b64}"
+
+
+def _urllib_transport(timeout: float) -> Transport:
+    """Default transport: POST JSON to an OpenAI-compatible endpoint via urllib.
+
+    Uses the standard library only (no new runtime dependency); network calls
+    happen offline during label pre-extraction, never at inference.
+    """
+
+    def _post(
+        url: str, payload: Dict[str, Any], headers: Dict[str, str]
+    ) -> Dict[str, Any]:
+        import urllib.request
+
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            decoded: Dict[str, Any] = json.loads(resp.read().decode("utf-8"))
+            return decoded
+
+    return _post
+
+
+def _extract_content(response: Dict[str, Any]) -> str:
+    """Pull the assistant message text from an OpenAI chat-completion response."""
+    try:
+        return str(response["choices"][0]["message"]["content"])
+    except (KeyError, IndexError, TypeError):
+        return ""
+
+
+class OpenAIEndpointTeacher(VLMTeacher):
+    """Offline scenario autolabeller backed by any OpenAI-compatible endpoint.
+
+    The intended default backend is @riita10069's Cosmos3-Nano Reasoner served
+    behind a vLLM / vLLM-Omni OpenAI-compatible endpoint, but nothing here is
+    Cosmos-specific: point ``base_url`` at any compatible server (or inject a
+    ``transport`` for tests / a local mock).
+
+    Future horizons are labelled from the **future frames themselves**
+    (``frames[1:]``) — privileged offline information, following the same
+    leakage-prevention split as :class:`~.qwen2vl.Qwen2VLTeacher`.
+
+    Args:
+        taxonomy: label registry.  Defaults to :data:`DEFAULT_TAXONOMY`.
+        base_url: OpenAI-compatible base URL (e.g. ``"http://host:8000/v1"``).
+        model: model name to request (e.g. ``"cosmos3-nano"``).
+        prompt_version: recorded on the teacher for artifact provenance
+            (riita's ``prompt_version`` field); does not change the request.
+        api_key: optional bearer token for the endpoint.
+        timeout: per-request timeout in seconds (default backend only).
+        max_tokens: generation budget for the JSON answer.
+        transport: injectable ``(url, payload, headers) -> response`` callable.
+            Defaults to a stdlib urllib POST.  Inject a stub in tests.
+    """
+
+    def __init__(
+        self,
+        taxonomy: Optional[ScenarioTaxonomy] = None,
+        *,
+        base_url: str = "http://localhost:8000/v1",
+        model: str = "cosmos3-nano",
+        prompt_version: str = "reasoning_label_v1",
+        api_key: Optional[str] = None,
+        timeout: float = 60.0,
+        max_tokens: int = 256,
+        transport: Optional[Transport] = None,
+    ) -> None:
+        super().__init__(taxonomy)
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.prompt_version = prompt_version
+        self.api_key = api_key
+        self.timeout = timeout
+        self.max_tokens = max_tokens
+        self._transport: Transport = (
+            transport if transport is not None else _urllib_transport(timeout)
+        )
+
+    @property
+    def endpoint(self) -> str:
+        """Full chat-completions URL derived from ``base_url``."""
+        return f"{self.base_url}/chat/completions"
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _build_payload(self, img: torch.Tensor, prompt: str) -> Dict[str, Any]:
+        return {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": _tensor_to_data_url(img)},
+                        },
+                    ],
+                }
+            ],
+            "temperature": 0.0,
+            "max_tokens": self.max_tokens,
+        }
+
+    def _label_one_frame_batch(
+        self, frame: torch.Tensor
+    ) -> List[Dict[str, List[str]]]:
+        """Label one ``[B, 3, H, W]`` frame batch → per-sample label dicts."""
+        prompt = build_scenario_prompt(self.taxonomy)
+        per_sample: List[Dict[str, List[str]]] = []
+        for img in frame:
+            try:
+                payload = self._build_payload(img, prompt)
+                response = self._transport(self.endpoint, payload, self._headers())
+                text = _extract_content(response)
+            except Exception:  # noqa: BLE001
+                # Abstain (empty labels), never crash a labelling batch: at
+                # scale a dropped frame is far cheaper than a crashed run.
+                per_sample.append({g.name: [] for g in self.taxonomy.groups})
+                continue
+            per_sample.append(parse_scenario_response(text, self.taxonomy))
+        return per_sample
+
+    def label(
+        self,
+        frames: Sequence[torch.Tensor],
+        num_future_horizons: int = 4,
+    ) -> ReasoningTargets:
+        """Generate multi-label scenario targets from front-camera frames.
+
+        Args:
+            frames: sequence of ``1 + num_future_horizons`` frame batches, each
+                ``[B, 3, H, W]``.  ``frames[0]`` is the current frame;
+                ``frames[h]`` is the +h s frame (labelled directly, offline).
+            num_future_horizons: number of future horizons.
+
+        Returns:
+            :data:`ReasoningTargets` with hard ``{0, 1}`` values.  Soft
+            confidence comes from cross-teacher agreement
+            (:class:`~.multi_teacher.MultiTeacher`), not from a single
+            teacher's self-report.
+
+        Raises:
+            ValueError: if fewer than ``1 + num_future_horizons`` frame
+                batches are supplied.
+        """
+        total_horizons = 1 + num_future_horizons
+        if len(frames) < total_horizons:
+            raise ValueError(
+                f"need {total_horizons} frame batches (current + "
+                f"{num_future_horizons} future), got {len(frames)}."
+            )
+
+        per_horizon: List[Dict[str, torch.Tensor]] = []
+        for h in range(total_horizons):
+            per_sample = self._label_one_frame_batch(frames[h])
+            per_horizon.append(
+                labels_to_targets(per_sample, self.taxonomy, device=frames[h].device)
+            )
+
+        out: ReasoningTargets = {}
+        for group in self.taxonomy.groups:
+            out[group.name] = [
+                per_horizon[h][group.name] for h in range(total_horizons)
+            ]
+        return out

--- a/Model/model_components/reasoning/teachers/qwen2vl.py
+++ b/Model/model_components/reasoning/teachers/qwen2vl.py
@@ -1,0 +1,259 @@
+"""Qwen2-VL teacher backend for reasoning-band pseudo-label generation (issue #98).
+
+LICENSE NOTE — IMPORTANT:
+    Qwen2-VL (``Qwen/Qwen2-VL-*`` on HuggingFace) is released under the
+    Apache 2.0 license.  **This teacher is a TRAIN-ONLY offline autolabeller
+    and is never deployed in the vehicle inference loop.**  Users must verify
+    the licence of the specific model checkpoint they use (including any
+    fine-tuned variants) before using it in a project context.  The HuggingFace
+    model card may impose additional terms — always check.
+
+    Per the WG decision of 1 July 2026: the VLM teacher generates pseudo-labels
+    offline (once, cached to disk); only the labelled dataset — not the VLM
+    itself — is used during training.  The teacher is therefore never loaded
+    on the inference device / vehicle PC.
+
+Lazy import strategy:
+    The ``transformers`` package is imported inside the label pipeline (not at
+    module level), so importing the ``teachers`` package — or the full
+    ``reasoning`` package — never requires heavy dependencies and CI pipelines
+    without a GPU still work.  The prompt construction and response parsing
+    are pure module-level functions, unit-testable without any model.
+
+Extension point — Alpamayo CoC (v2):
+    See :class:`model_components.reasoning.teachers.base.VLMTeacher` for the
+    documented hook to add an Alpamayo Chain-of-Causation autolabeller in v2.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional, Sequence
+
+import torch
+
+from ..scenario_taxonomy import ScenarioTaxonomy
+from .base import VLMTeacher, ReasoningTargets
+
+
+def build_scenario_prompt(taxonomy: ScenarioTaxonomy) -> str:
+    """Build the structured labelling prompt for one frame.
+
+    Asks for a single JSON object whose keys are the taxonomy groups and whose
+    values are lists of active labels — a closed, machine-parseable output
+    space (structured labels beat free-form text for downstream decision
+    accuracy and parsing cost; arXiv:2506.05442).
+    """
+    lines = [
+        "You are labelling one front-camera frame from a driving log.",
+        "For each category below, list every label that applies to the scene.",
+        "Use only the exact label strings given.  If none applies, use [].",
+        "",
+    ]
+    for group in taxonomy.groups:
+        lines.append(f"- {group.name}: {', '.join(group.labels)}")
+    lines += [
+        "",
+        "Answer with ONLY a JSON object, no other text, in the form:",
+        '{"' + '": [...], "'.join(taxonomy.group_names) + '": [...]}',
+    ]
+    return "\n".join(lines)
+
+
+def parse_scenario_response(
+    text: str, taxonomy: ScenarioTaxonomy
+) -> Dict[str, List[str]]:
+    """Parse a model response into per-group active-label lists.
+
+    Tolerant to chatter around the JSON (extracts the first ``{...}`` block)
+    and to unknown labels (silently dropped — the closed label set is the
+    contract).  An unparseable response yields empty lists for every group
+    (abstain), never an exception: at labelling scale a crashed batch is worse
+    than an abstained frame.
+    """
+    empty: Dict[str, List[str]] = {g.name: [] for g in taxonomy.groups}
+    start = text.find("{")
+    if start == -1:
+        return empty
+    try:
+        # raw_decode parses the FIRST valid JSON object and ignores trailing
+        # text — robust to chatter after the object (a greedy regex would
+        # swallow any later '}' and fail to parse, silently dropping labels).
+        raw, _ = json.JSONDecoder().raw_decode(text[start:])
+    except json.JSONDecodeError:
+        return empty
+    if not isinstance(raw, dict):
+        return empty
+
+    out: Dict[str, List[str]] = {}
+    for group in taxonomy.groups:
+        values = raw.get(group.name, [])
+        if not isinstance(values, list):
+            values = []
+        out[group.name] = [
+            v for v in values if isinstance(v, str) and v in group.labels
+        ]
+    return out
+
+
+def labels_to_targets(
+    per_sample_labels: Sequence[Dict[str, List[str]]],
+    taxonomy: ScenarioTaxonomy,
+    device: Optional[torch.device] = None,
+) -> Dict[str, torch.Tensor]:
+    """Turn per-sample active-label dicts into ``[B, num_classes]`` tensors."""
+    out: Dict[str, torch.Tensor] = {}
+    for group in taxonomy.groups:
+        target = torch.zeros(len(per_sample_labels), len(group), device=device)
+        for i, labels in enumerate(per_sample_labels):
+            for label in labels.get(group.name, []):
+                target[i, group.index(label)] = 1.0
+        out[group.name] = target
+    return out
+
+
+class Qwen2VLTeacher(VLMTeacher):
+    """Offline scenario autolabeller backed by Qwen2-VL.
+
+    Generates multi-label scenario targets from front-camera frame(s) using a
+    Qwen2-VL model loaded from HuggingFace.  Designed for offline
+    pre-extraction of pseudo-labels (piggyback on #100): run once on the full
+    training split and cache the outputs.  Do NOT instantiate this class on
+    the vehicle PC.
+
+    Future horizons are labelled from the **future frames themselves**
+    (``frames[1:]``) — privileged information that exists offline in the log.
+    Following Alpamayo-R1's leakage-prevention split (arXiv:2511.00088), the
+    future frames only decide *which label is true* at each horizon; they are
+    never fed to the student.
+
+    Args:
+        taxonomy: label registry.  Defaults to :data:`DEFAULT_TAXONOMY`.
+        model_name: HuggingFace model identifier (default
+            ``"Qwen/Qwen2-VL-7B-Instruct"``).
+        device: torch device string for the VLM (default ``"cuda"``).
+        max_new_tokens: generation budget for the JSON answer (default 256).
+
+    Raises:
+        ImportError: if ``transformers`` is not installed (raised lazily on
+            the first :meth:`label` call, not at import time).
+    """
+
+    def __init__(
+        self,
+        taxonomy: Optional[ScenarioTaxonomy] = None,
+        model_name: str = "Qwen/Qwen2-VL-7B-Instruct",
+        device: str = "cuda",
+        max_new_tokens: int = 256,
+    ) -> None:
+        super().__init__(taxonomy)
+        self.model_name = model_name
+        self.device = device
+        self.max_new_tokens = max_new_tokens
+        # Model and processor are loaded lazily on the first label() call.
+        self._model: Optional[Any] = None
+        self._processor: Optional[Any] = None
+
+    def _ensure_loaded(self) -> None:
+        """Lazily load the Qwen2-VL model and processor.
+
+        Raises:
+            ImportError: if ``transformers`` is not available.
+        """
+        if self._model is not None:
+            return
+        try:
+            from transformers import Qwen2VLForConditionalGeneration, AutoProcessor  # type: ignore[import]
+        except ImportError as exc:
+            raise ImportError(
+                "Qwen2VLTeacher requires the 'transformers' package. "
+                "Install it with:  pip install transformers\n"
+                "This dependency is intentionally not listed as a core "
+                "requirement because the teacher is a TRAIN-ONLY offline "
+                "tool that is never used at inference time."
+            ) from exc
+
+        self._model = Qwen2VLForConditionalGeneration.from_pretrained(
+            self.model_name, torch_dtype="auto"
+        ).to(self.device)
+        self._model.eval()
+        self._processor = AutoProcessor.from_pretrained(self.model_name)
+
+    def _label_one_frame_batch(self, frame: torch.Tensor) -> List[Dict[str, List[str]]]:
+        """Label one ``[B, 3, H, W]`` frame batch → per-sample label dicts."""
+        from torchvision.transforms.functional import to_pil_image
+
+        assert self._model is not None and self._processor is not None
+        prompt = build_scenario_prompt(self.taxonomy)
+
+        per_sample: List[Dict[str, List[str]]] = []
+        for img in frame:
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image"},
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ]
+            chat = self._processor.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+            inputs = self._processor(
+                text=[chat], images=[to_pil_image(img.cpu())], return_tensors="pt"
+            ).to(self.device)
+            with torch.no_grad():
+                generated = self._model.generate(
+                    **inputs, max_new_tokens=self.max_new_tokens, do_sample=False
+                )
+            new_tokens = generated[:, inputs["input_ids"].shape[1]:]
+            text = self._processor.batch_decode(
+                new_tokens, skip_special_tokens=True
+            )[0]
+            per_sample.append(parse_scenario_response(text, self.taxonomy))
+        return per_sample
+
+    def label(
+        self,
+        frames: Sequence[torch.Tensor],
+        num_future_horizons: int = 4,
+    ) -> ReasoningTargets:
+        """Generate multi-label scenario targets from front-camera frames.
+
+        Args:
+            frames: sequence of ``1 + num_future_horizons`` frame batches,
+                each ``[B, 3, H, W]``.  ``frames[0]`` is the current frame;
+                ``frames[h]`` is the +h s frame, labelled directly (privileged
+                offline information).
+            num_future_horizons: number of future horizons.
+
+        Returns:
+            :data:`ReasoningTargets` with hard {0, 1} values.  Soft targets /
+            confidence come from cross-teacher agreement
+            (:class:`~.multi_teacher.MultiTeacher`), not from a single
+            teacher's self-report.
+
+        Raises:
+            ValueError: if fewer than ``1 + num_future_horizons`` frame
+                batches are supplied.
+        """
+        total_horizons = 1 + num_future_horizons
+        if len(frames) < total_horizons:
+            raise ValueError(
+                f"need {total_horizons} frame batches (current + "
+                f"{num_future_horizons} future), got {len(frames)}."
+            )
+        self._ensure_loaded()
+
+        per_horizon: List[Dict[str, torch.Tensor]] = []
+        for h in range(total_horizons):
+            per_sample = self._label_one_frame_batch(frames[h])
+            per_horizon.append(
+                labels_to_targets(per_sample, self.taxonomy, device=frames[h].device)
+            )
+
+        out: ReasoningTargets = {}
+        for group in self.taxonomy.groups:
+            out[group.name] = [per_horizon[h][group.name] for h in range(total_horizons)]
+        return out

--- a/Model/model_components/reasoning/teachers/videollama3.py
+++ b/Model/model_components/reasoning/teachers/videollama3.py
@@ -1,0 +1,69 @@
+"""VideoLLaMA3 teacher backend (issue #98) — second opinion for agreement.
+
+VideoLLaMA3 (Apache-2.0, ``DAMO-NLP-SG/VideoLLaMA3-7B``; arXiv:2501.13106) is
+the video-native second teacher in the two-teacher agreement pipeline: it
+ingests the 1 Hz frame window natively (fps=1 sampling), giving an opinion
+that is independent from Qwen2-VL's.  Labels are fused with
+:class:`~.multi_teacher.MultiTeacher`, whose agreement fraction doubles as the
+confidence signal (#103).
+
+Like every teacher here it is TRAIN-ONLY and never runs in the vehicle.
+
+Status: the prompt/parse layer is shared with the Qwen backend
+(:func:`~.qwen2vl.build_scenario_prompt` / ``parse_scenario_response``); the
+checkpoint-specific generation call is wired when the labelling pipeline runs
+on GPU hardware (it follows the model card's ``transformers`` usage).  Until
+then :meth:`label` raises ``NotImplementedError`` with a clear message rather
+than risking a silently wrong integration.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+import torch
+
+from ..scenario_taxonomy import ScenarioTaxonomy
+from .base import VLMTeacher, ReasoningTargets
+
+
+class VideoLlama3Teacher(VLMTeacher):
+    """Offline scenario autolabeller backed by VideoLLaMA3 (video-native).
+
+    Args:
+        taxonomy: label registry.  Defaults to :data:`DEFAULT_TAXONOMY`.
+        model_name: HuggingFace model identifier (default
+            ``"DAMO-NLP-SG/VideoLLaMA3-7B"``).
+        device: torch device string for the VLM (default ``"cuda"``).
+    """
+
+    def __init__(
+        self,
+        taxonomy: Optional[ScenarioTaxonomy] = None,
+        model_name: str = "DAMO-NLP-SG/VideoLLaMA3-7B",
+        device: str = "cuda",
+    ) -> None:
+        super().__init__(taxonomy)
+        self.model_name = model_name
+        self.device = device
+        self._model: Optional[Any] = None
+        self._processor: Optional[Any] = None
+
+    def label(
+        self,
+        frames: Sequence[torch.Tensor],
+        num_future_horizons: int = 4,
+    ) -> ReasoningTargets:
+        """Generate targets from the 1 Hz frame window (video-native).
+
+        Raises:
+            NotImplementedError: the checkpoint-specific generation call is
+                wired together with the GPU labelling pipeline; use
+                :class:`~.deterministic.DeterministicTeacher` in CI and
+                :class:`~.qwen2vl.Qwen2VLTeacher` as the working backend.
+        """
+        raise NotImplementedError(
+            "VideoLlama3Teacher's generation call is wired with the GPU "
+            "labelling pipeline (the prompt/parse layer is shared with the "
+            "Qwen2-VL backend). Use DeterministicTeacher for CI."
+        )

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -29,8 +29,10 @@ def run_speed_benchmark(backbone, device, batch_size=1, num_views=7,
     # per-forward cost here is an upper bound on its real-time budget.
     extra_kwargs = {}
     if reasoning != "off":
-        extra_kwargs = dict(enable_reasoning_band=True,
-                            reasoning_kwargs={"backbone": reasoning})
+        # ReasoningBand takes no "backbone" argument (only visual_history_dim,
+        # hidden_dim, num_future_horizons, taxonomy); enable the band with its
+        # defaults. ``reasoning`` is kept purely as the result label/column.
+        extra_kwargs = dict(enable_reasoning_band=True)
     model = AutoE2E(backbone=backbone, num_views=num_views,
                     view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
                     **extra_kwargs)

--- a/Model/speed_benchmark/speed_benchmark.py
+++ b/Model/speed_benchmark/speed_benchmark.py
@@ -12,17 +12,28 @@ from model_components.auto_e2e import AutoE2E
 from model_components.view_fusion import PinholeProjection
 
 
-def run_speed_benchmark(backbone, device, batch_size=1, num_views=7):
+def run_speed_benchmark(backbone, device, batch_size=1, num_views=7,
+                        reasoning="off"):
 
     print(f"{'='*80}")
-    print(f"  backbone = '{backbone}' | fusion = 'bev' | batch={batch_size} | views={num_views}")
+    print(f"  backbone = '{backbone}' | fusion = 'bev' | batch={batch_size} "
+          f"| views={num_views} | reasoning = '{reasoning}'")
     print(f"{'='*80}\n")
 
     # Instantiate model. Fusion is always BEV (concat / cross_attn and the
     # fusion_mode knob were removed); nav-map is a separate map_input branch, not
     # a camera view. Small BEV grid keeps the benchmark fast.
+    #
+    # ``reasoning`` optionally enables the Reasoning band (#98) so its inference
+    # cost is measured explicitly.  The band runs at 1 Hz in deployment, so the
+    # per-forward cost here is an upper bound on its real-time budget.
+    extra_kwargs = {}
+    if reasoning != "off":
+        extra_kwargs = dict(enable_reasoning_band=True,
+                            reasoning_kwargs={"backbone": reasoning})
     model = AutoE2E(backbone=backbone, num_views=num_views,
-                    view_fusion_kwargs={"bev_h": 8, "bev_w": 8})
+                    view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
+                    **extra_kwargs)
     model = model.to(device)
     model.eval()
 
@@ -93,6 +104,7 @@ def run_speed_benchmark(backbone, device, batch_size=1, num_views=7):
     results = {
         "backbone": backbone,
         "fusion_mode": "bev",
+        "reasoning_band": reasoning,
         "batch_size": batch_size,
         "num_views": num_views,
         "avg_fps": round(avg_fps, 2),
@@ -167,11 +179,11 @@ def save_results_json(all_results, device, input_resolution=(256, 256)):
 def print_markdown_table(all_results):
     """Print results as a Markdown table for easy pasting into README."""
     print("\n## Benchmark Results\n")
-    print("| Backbone | Fusion Mode | Batch | FPS | Latency (ms) | p99 (ms) | VRAM (MB) | Params |")
-    print("|----------|-------------|-------|-----|--------------|----------|-----------|--------|")
+    print("| Backbone | Fusion Mode | Reasoning | Batch | FPS | Latency (ms) | p99 (ms) | VRAM (MB) | Params |")
+    print("|----------|-------------|-----------|-------|-----|--------------|----------|-----------|--------|")
     for r in all_results:
         params_m = r["total_params"] / 1_000_000
-        print(f"| {r['backbone']} | {r['fusion_mode']} | {r['batch_size']} | "
+        print(f"| {r['backbone']} | {r['fusion_mode']} | {r.get('reasoning_band', 'off')} | {r['batch_size']} | "
               f"{r['avg_fps']:.1f} | {r['avg_latency_ms']:.1f} | {r['p99_latency_ms']:.1f} | "
               f"{r['peak_vram_allocated_mb']:.0f} | {params_m:.1f}M |")
 
@@ -205,6 +217,18 @@ def main():
             result = run_speed_benchmark(backbone, device, batch_size=batch_size)
             all_results.append(result)
             print()
+
+    # Reasoning band (#98): measure the added cost of the branch explicitly,
+    # on the default backbone at batch 1 (its deployment operating point —
+    # the band runs at 1 Hz).
+    reasoning_variants = ["head_on_896"]
+    for reasoning in reasoning_variants:
+        if torch.cuda.is_available():
+            torch.cuda.reset_peak_memory_stats()
+        result = run_speed_benchmark(backbones[0], device, batch_size=1,
+                                     reasoning=reasoning)
+        all_results.append(result)
+        print()
 
     # Save structured results
     save_results_json(all_results, device)

--- a/Model/tests/test_reasoning_band.py
+++ b/Model/tests/test_reasoning_band.py
@@ -1,0 +1,621 @@
+"""Tests for the Reasoning Band (issue #98).
+
+All tests use synthetic tensors — no GPU required, no network calls.
+Mirrors the style of test_world_action_model.py.
+
+Covered:
+    * I/O shapes of ScenarioTaxonomy, ReasoningBand, DeterministicTeacher,
+      ReasoningLoss.
+    * Planner coupling (#98/#103): forward returns a ReasoningPrediction whose
+      zero-init gate is a strict no-op at initialisation (modulated history ==
+      input) and only diverges once trained; per-horizon confidence included.
+    * Taxonomy is extensible: adding a KIT label does not change existing indices.
+    * Multi-label: several classes can be active simultaneously.
+    * Multi-horizon: train mode returns 5 horizons; infer mode returns 1.
+    * DeterministicTeacher is deterministic.
+    * ReasoningLoss decreases toward trivial targets (sigmoid(0) → 0.5 ≠ 1.0;
+      sigmoid(10) → ~1.0 ≈ 1.0 → near-zero loss).
+    * AutoE2E with enable_reasoning_band=False is byte-identical to baseline.
+"""
+
+from __future__ import annotations
+
+
+import pytest
+import torch
+import torch.nn as nn
+
+from model_components.reasoning.scenario_taxonomy import (
+    ScenarioTaxonomy,
+    TaxonomyGroup,
+    DEFAULT_TAXONOMY,
+)
+from model_components.reasoning.reasoning_band import ReasoningBand, ReasoningPrediction
+from model_components.reasoning.teachers.deterministic import DeterministicTeacher
+from training.losses.reasoning_loss import ReasoningLoss
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+B = 2      # batch size used throughout
+VH_DIM = 896  # Encoded Visual History dimension
+
+
+def _vh(device: torch.device) -> torch.Tensor:
+    """Synthetic visual history [B, 896]."""
+    return torch.randn(B, VH_DIM, device=device)
+
+
+def _band(device: torch.device, **kw) -> ReasoningBand:
+    return ReasoningBand(visual_history_dim=VH_DIM, hidden_dim=64, **kw).to(device)
+
+
+# ---------------------------------------------------------------------------
+# ScenarioTaxonomy
+# ---------------------------------------------------------------------------
+
+class TestScenarioTaxonomy:
+    def test_default_groups_present(self):
+        t = ScenarioTaxonomy()
+        assert "maneuver" in t
+        assert "edge_case" in t
+        assert "weather_env" in t
+
+    def test_default_group_sizes(self):
+        t = ScenarioTaxonomy()
+        assert t.num_classes("maneuver") == 7
+        assert t.num_classes("edge_case") == 6
+        assert t.num_classes("weather_env") == 8
+
+    def test_stable_index_ordering(self):
+        """Index is part of the loss contract — must not change."""
+        t = ScenarioTaxonomy()
+        assert t["maneuver"].index("continue_straight") == 0
+        assert t["maneuver"].index("turn_right") == 6
+        assert t["edge_case"].index("nudge_out") == 0
+        assert t["weather_env"].index("fair_day") == 0
+        assert t["weather_env"].index("fog_night") == 7
+
+    def test_extensible_register_group(self):
+        """Adding a new group does not affect existing groups."""
+        t = ScenarioTaxonomy()
+        old_idx = t["maneuver"].index("turn_left")
+        t.register_group("kit_context", ["intersection", "construction_zone"])
+        # Existing index unchanged
+        assert t["maneuver"].index("turn_left") == old_idx
+        # New group accessible
+        assert t.num_classes("kit_context") == 2
+        assert t["kit_context"].index("intersection") == 0
+
+    def test_extend_appends_only(self):
+        """extend() must not change indices of existing labels."""
+        t = ScenarioTaxonomy()
+        t.extend("maneuver", ["u_turn"])
+        assert t["maneuver"].index("turn_right") == 6   # unchanged
+        assert t["maneuver"].index("u_turn") == 7       # appended
+        assert t.num_classes("maneuver") == 8
+
+    def test_register_group_duplicate_raises(self):
+        t = ScenarioTaxonomy()
+        with pytest.raises(ValueError, match="already registered"):
+            t.register_group("maneuver", ["foo"])
+
+    def test_extend_unknown_group_raises(self):
+        t = ScenarioTaxonomy()
+        with pytest.raises(KeyError):
+            t.extend("nonexistent", ["foo"])
+
+    def test_extend_duplicate_label_raises(self):
+        t = ScenarioTaxonomy()
+        with pytest.raises(ValueError, match="already exist"):
+            t.extend("maneuver", ["turn_left"])
+
+    def test_group_contains_no_duplicates(self):
+        t = ScenarioTaxonomy()
+        for g in t.groups:
+            assert len(set(g.labels)) == len(g.labels)
+
+    def test_taxonomy_group_duplicate_labels_raises(self):
+        with pytest.raises(ValueError, match="duplicate"):
+            TaxonomyGroup(name="test", labels=("a", "a", "b"))
+
+    def test_multi_label_multi_group(self):
+        """Taxonomy supports querying labels across all three groups at once."""
+        t = ScenarioTaxonomy()
+        # Each group has its own independent index space; all lookups must succeed.
+        m_idx = t["maneuver"].index("curve_left")
+        e_idx = t["edge_case"].index("give_way")
+        w_idx = t["weather_env"].index("rain_night")
+        # Indices within each group must be in valid range
+        assert 0 <= m_idx < t.num_classes("maneuver")
+        assert 0 <= e_idx < t.num_classes("edge_case")
+        assert 0 <= w_idx < t.num_classes("weather_env")
+
+
+# ---------------------------------------------------------------------------
+# ReasoningBand — shapes
+# ---------------------------------------------------------------------------
+
+class TestReasoningBandShapes:
+    def test_infer_mode_returns_one_horizon(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        logits = band(vh, mode="infer").logits
+        for group in DEFAULT_TAXONOMY.groups:
+            assert group.name in logits
+            assert len(logits[group.name]) == 1
+            assert logits[group.name][0].shape == (B, len(group))
+
+    def test_train_mode_returns_five_horizons(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        logits = band(vh, mode="train").logits
+        # 1 current + 4 future = 5
+        for group in DEFAULT_TAXONOMY.groups:
+            assert len(logits[group.name]) == 5
+
+    def test_all_taxonomy_groups_present(self, device):
+        band = _band(device)
+        logits = band(_vh(device), mode="infer").logits
+        assert set(logits.keys()) == set(DEFAULT_TAXONOMY.group_names)
+
+    def test_custom_num_future_horizons(self, device):
+        band = _band(device, num_future_horizons=2)
+        logits = band(_vh(device), mode="train").logits
+        for group in DEFAULT_TAXONOMY.groups:
+            assert len(logits[group.name]) == 3  # 1 current + 2 future
+
+    def test_output_logits_finite(self, device):
+        band = _band(device)
+        logits = band(_vh(device), mode="train").logits
+        for group_horizons in logits.values():
+            for t in group_horizons:
+                assert torch.isfinite(t).all()
+
+
+# ---------------------------------------------------------------------------
+# Zero-init gate (planner coupling, #98/#103) + per-horizon confidence
+# ---------------------------------------------------------------------------
+
+class TestZeroInitGateAndConfidence:
+    """The band feeds the planner through a zero-init gate: at initialisation
+    the modulated visual history is IDENTICAL to the input (strict no-op), so
+    enabling the band leaves the reactive baseline unchanged until training
+    moves the gate.  A per-horizon confidence accompanies the logits (#103)."""
+
+    def test_returns_typed_prediction(self, device):
+        band = _band(device)
+        pred = band(_vh(device), mode="train")
+        assert isinstance(pred, ReasoningPrediction)
+        assert set(pred.logits.keys()) == set(DEFAULT_TAXONOMY.group_names)
+
+    def test_gate_is_noop_at_init(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        for mode in ("infer", "train"):
+            pred = band(vh, mode=mode)
+            assert torch.allclose(pred.modulated_visual_history, vh, atol=1e-6), (
+                "Zero-init gate must be a strict no-op at initialisation."
+            )
+
+    def test_gate_diverges_once_trained(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        with torch.no_grad():
+            band.gate.beta.bias.fill_(0.5)
+        pred = band(vh, mode="infer")
+        assert not torch.allclose(pred.modulated_visual_history, vh)
+
+    def test_visual_history_not_mutated_in_place(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        vh_before = vh.clone()
+        band(vh, mode="train")
+        assert torch.equal(vh, vh_before)
+
+    def test_confidence_shape_train_and_infer(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        assert band(vh, mode="train").confidence.shape == (B, 5)
+        assert band(vh, mode="infer").confidence.shape == (B, 1)
+
+    def test_gate_receives_gradient(self, device):
+        band = _band(device)
+        pred = band(_vh(device), mode="train")
+        pred.modulated_visual_history.sum().backward()
+        assert band.gate.gamma.weight.grad is not None
+
+
+# ---------------------------------------------------------------------------
+# Multi-label
+# ---------------------------------------------------------------------------
+
+class TestMultiLabel:
+    def test_several_classes_active_simultaneously(self, device):
+        """Multiple labels across different groups can be active at once."""
+        teacher = DeterministicTeacher(
+            active_labels={
+                "maneuver": ["turn_left", "curve_left"],  # two active in same group
+                "edge_case": ["give_way", "avoid_roadworks"],
+                "weather_env": ["rain_night", "fog_day"],
+            }
+        )
+        frame = torch.zeros(B, 3, 8, 8, device=device)
+        targets = teacher.label([frame], num_future_horizons=0)
+
+        m_target = targets["maneuver"][0]
+        assert m_target[:, DEFAULT_TAXONOMY["maneuver"].index("turn_left")].all()
+        assert m_target[:, DEFAULT_TAXONOMY["maneuver"].index("curve_left")].all()
+        # All-zero for inactive labels
+        assert m_target[:, DEFAULT_TAXONOMY["maneuver"].index("continue_straight")].sum() == 0
+
+    def test_multi_label_loss_accepts_multiple_active(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        logits = band(vh, mode="train").logits
+
+        # Create targets with multiple classes active
+        targets = {}
+        for group in DEFAULT_TAXONOMY.groups:
+            t_list = []
+            for _ in logits[group.name]:
+                t = torch.zeros(B, len(group), device=device)
+                t[:, 0] = 1.0
+                t[:, 1] = 1.0   # two classes active
+                t_list.append(t)
+            targets[group.name] = t_list
+
+        loss_fn = ReasoningLoss(weight=1.0)
+        loss = loss_fn(logits, targets)
+        assert torch.isfinite(loss) and loss > 0
+
+
+# ---------------------------------------------------------------------------
+# DeterministicTeacher
+# ---------------------------------------------------------------------------
+
+class TestDeterministicTeacher:
+    def test_deterministic_across_calls(self, device):
+        teacher = DeterministicTeacher(
+            active_labels={"maneuver": ["turn_right"], "edge_case": ["nudge_out"]}
+        )
+        frame = torch.randn(B, 3, 8, 8, device=device)
+        t1 = teacher.label([frame], num_future_horizons=4)
+        t2 = teacher.label([frame], num_future_horizons=4)
+        for group_name in t1:
+            for h1, h2 in zip(t1[group_name], t2[group_name]):
+                assert torch.equal(h1, h2)
+
+    def test_deterministic_returns_correct_number_of_horizons(self, device):
+        teacher = DeterministicTeacher()
+        frame = torch.zeros(B, 3, 8, 8, device=device)
+        targets = teacher.label([frame], num_future_horizons=4)
+        for group_name in DEFAULT_TAXONOMY.group_names:
+            assert len(targets[group_name]) == 5  # 1 current + 4 future
+
+    def test_deterministic_correct_shapes(self, device):
+        teacher = DeterministicTeacher()
+        frame = torch.zeros(B, 3, 8, 8, device=device)
+        targets = teacher.label([frame], num_future_horizons=4)
+        for group in DEFAULT_TAXONOMY.groups:
+            for t in targets[group.name]:
+                assert t.shape == (B, len(group))
+
+    def test_deterministic_active_labels_set_correctly(self, device):
+        teacher = DeterministicTeacher(
+            active_labels={"maneuver": ["continue_straight"]}
+        )
+        frame = torch.zeros(B, 3, 8, 8, device=device)
+        targets = teacher.label([frame], num_future_horizons=0)
+        t = targets["maneuver"][0]
+        idx = DEFAULT_TAXONOMY["maneuver"].index("continue_straight")
+        assert (t[:, idx] == 1.0).all()
+        # All other maneuver classes must be 0
+        mask = torch.ones(len(DEFAULT_TAXONOMY["maneuver"]), dtype=torch.bool)
+        mask[idx] = False
+        assert (t[:, mask] == 0.0).all()
+
+    def test_deterministic_all_zero_when_no_active_labels(self, device):
+        teacher = DeterministicTeacher()   # no active_labels
+        frame = torch.zeros(B, 3, 8, 8, device=device)
+        targets = teacher.label([frame], num_future_horizons=0)
+        for group_name in DEFAULT_TAXONOMY.group_names:
+            assert (targets[group_name][0] == 0.0).all()
+
+    def test_deterministic_invalid_label_raises(self):
+        with pytest.raises(KeyError):
+            DeterministicTeacher(active_labels={"maneuver": ["nonexistent_label"]})
+
+    def test_deterministic_ignores_pixel_values(self, device):
+        """Output must be identical regardless of frame pixel content."""
+        teacher = DeterministicTeacher(active_labels={"maneuver": ["turn_left"]})
+        f1 = torch.zeros(B, 3, 8, 8, device=device)
+        f2 = torch.ones(B, 3, 8, 8, device=device) * 255
+        t1 = teacher.label([f1], num_future_horizons=0)
+        t2 = teacher.label([f2], num_future_horizons=0)
+        assert torch.equal(t1["maneuver"][0], t2["maneuver"][0])
+
+
+# ---------------------------------------------------------------------------
+# ReasoningLoss
+# ---------------------------------------------------------------------------
+
+class TestReasoningLoss:
+    def _make_logits_and_targets(self, device, logit_val: float, target_val: float):
+        """Create synthetic logits and targets for all groups × 5 horizons."""
+        band = _band(device)
+        vh = _vh(device)
+        logits = band(vh, mode="train").logits
+        # Override with constant logit values
+        for group in DEFAULT_TAXONOMY.groups:
+            logits[group.name] = [
+                torch.full((B, len(group)), logit_val, device=device)
+                for _ in range(5)
+            ]
+        targets = {}
+        for group in DEFAULT_TAXONOMY.groups:
+            targets[group.name] = [
+                torch.full((B, len(group)), target_val, device=device)
+                for _ in range(5)
+            ]
+        return logits, targets
+
+    def test_loss_near_zero_for_perfect_targets(self, device):
+        """logit >> 0 with target=1 → near-zero BCE."""
+        logits, targets = self._make_logits_and_targets(device, 10.0, 1.0)
+        loss = ReasoningLoss(weight=1.0)(logits, targets)
+        assert loss.item() < 0.1
+
+    def test_loss_lower_for_better_predictions(self, device):
+        """Better-aligned logits → lower loss than random logits."""
+        logits_good, targets = self._make_logits_and_targets(device, 8.0, 1.0)
+        logits_bad, _ = self._make_logits_and_targets(device, -8.0, 1.0)
+        loss_good = ReasoningLoss()(logits_good, targets)
+        loss_bad = ReasoningLoss()(logits_bad, targets)
+        assert loss_good < loss_bad
+
+    def test_loss_weight_scales_output(self, device):
+        logits, targets = self._make_logits_and_targets(device, 0.0, 0.5)
+        l1 = ReasoningLoss(weight=1.0)(logits, targets)
+        l2 = ReasoningLoss(weight=2.0)(logits, targets)
+        assert torch.allclose(l2, 2.0 * l1, atol=1e-5)
+
+    def test_loss_finite_and_positive(self, device):
+        logits, targets = self._make_logits_and_targets(device, 0.0, 0.5)
+        loss = ReasoningLoss()(logits, targets)
+        assert torch.isfinite(loss) and loss > 0
+
+    def test_loss_group_mismatch_raises(self, device):
+        logits, targets = self._make_logits_and_targets(device, 0.0, 0.5)
+        del targets["maneuver"]
+        with pytest.raises(ValueError, match="Group mismatch"):
+            ReasoningLoss()(logits, targets)
+
+    def test_loss_horizon_mismatch_raises(self, device):
+        logits, targets = self._make_logits_and_targets(device, 0.0, 0.5)
+        targets["maneuver"] = targets["maneuver"][:3]   # 3 horizons vs 5
+        with pytest.raises(ValueError, match="horizons"):
+            ReasoningLoss()(logits, targets)
+
+    def test_loss_reduction_none_returns_per_sample(self, device):
+        logits, targets = self._make_logits_and_targets(device, 0.0, 0.5)
+        loss = ReasoningLoss(reduction="none")(logits, targets)
+        assert loss.shape == (B,)
+
+    def test_loss_invalid_reduction_raises(self):
+        with pytest.raises(ValueError, match="reduction"):
+            ReasoningLoss(reduction="sum")
+
+    def test_loss_gradients_flow(self, device):
+        band = _band(device)
+        vh = _vh(device)
+        logits = band(vh, mode="train").logits
+        targets = {}
+        for group in DEFAULT_TAXONOMY.groups:
+            targets[group.name] = [
+                torch.zeros(B, len(group), device=device) for _ in logits[group.name]
+            ]
+        loss = ReasoningLoss()(logits, targets)
+        loss.backward()
+        # Gradients must flow to the decoder heads
+        assert any(p.grad is not None for p in band.heads.parameters())
+
+
+# ---------------------------------------------------------------------------
+# AutoE2E integration — reasoning band disabled = unchanged baseline
+# ---------------------------------------------------------------------------
+
+class _AutoE2EHarness:
+    """Shared mock-backbone harness (NOT collected: no Test prefix) so the
+    wiring, Moondream and faithfulness suites reuse _build/_inputs without
+    pytest re-collecting inherited tests."""
+
+    class _MockBackbone(nn.Module):
+        def __init__(self, backbone="swin_v2_tiny", is_pretrained=True, **kw):
+            super().__init__()
+            self.backbone_channels = 1440
+            self._st = nn.ModuleList([
+                nn.Sequential(nn.Conv2d(3, 96, 3, 1, 1), nn.AdaptiveAvgPool2d(64)),
+                nn.Sequential(nn.Conv2d(96, 192, 3, 1, 1), nn.AdaptiveAvgPool2d(32)),
+                nn.Sequential(nn.Conv2d(192, 384, 3, 1, 1), nn.AdaptiveAvgPool2d(16)),
+                nn.Sequential(nn.Conv2d(384, 768, 3, 1, 1), nn.AdaptiveAvgPool2d(8)),
+            ])
+        def forward(self, x):
+            outs, h = [], x
+            for s in self._st:
+                h = s(h)
+                outs.append(h)
+            return outs
+
+    def _build(self, device, *, enable_reasoning_band=False,
+               enable_world_model=False, reasoning_kwargs=None):
+        from unittest.mock import patch
+        from model_components.auto_e2e import AutoE2E
+        with patch("model_components.reactive_e2e.Backbone", self._MockBackbone):
+            return AutoE2E(
+                num_views=2,
+                view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
+                enable_world_model=enable_world_model,
+                world_model_kwargs={"feature_channels": 768} if enable_world_model else None,
+                enable_reasoning_band=enable_reasoning_band,
+                reasoning_kwargs=reasoning_kwargs,
+            ).to(device)
+
+    def _inputs(self, device):
+        return (
+            torch.randn(B, 2, 3, 256, 256, device=device),  # camera_tiles
+            torch.randn(B, 3, 256, 256, device=device),      # map_input (256 required by map encoder)
+            torch.zeros(B, 896, device=device),              # visual_history
+            torch.randn(B, 256, device=device),              # egomotion_history
+        )
+
+
+class TestAutoE2EReasoningBandWiring(_AutoE2EHarness):
+    def test_disabled_returns_same_shape_as_baseline(self, device):
+        """enable_reasoning_band=False → output identical to un-modified AutoE2E."""
+        m = self._build(device, enable_reasoning_band=False)
+        cam, mp, vh, ego = self._inputs(device)
+        out = m(cam, mp, vh, ego, mode="infer")
+        traj = out[0] if isinstance(out, tuple) else out
+        assert traj.shape == (B, 128)
+
+    def test_disabled_reasoning_band_is_none(self, device):
+        m = self._build(device, enable_reasoning_band=False)
+        assert m.Reasoning_Band is None
+
+    def test_enabled_reasoning_band_is_set(self, device):
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        assert m.Reasoning_Band is not None
+
+    def test_infer_mode_returns_trajectory_only(self, device):
+        """In infer mode the reasoning_pred is not returned (same as World Model)."""
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        cam, mp, vh, ego = self._inputs(device)
+        out = m(cam, mp, vh, ego, mode="infer")
+        # Should NOT be a 3-tuple (reasoning_pred only comes in train mode)
+        if isinstance(out, tuple):
+            assert len(out) <= 2
+        else:
+            assert out.shape[-1] == 128
+
+    def test_train_mode_returns_3tuple(self, device):
+        """In train mode with reasoning band on: (trajectory, future_state_pred, reasoning_pred)."""
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        cam, mp, vh, ego = self._inputs(device)
+        tgt = torch.randn(B, 128, device=device)
+        out = m(cam, mp, vh, ego, mode="train", trajectory_target=tgt)
+        assert isinstance(out, tuple) and len(out) == 3
+        _traj, future_state_pred, reasoning_pred = out
+        assert future_state_pred is None   # World Model is OFF
+        assert reasoning_pred is not None
+        assert "maneuver" in reasoning_pred.logits
+
+    def test_reasoning_pred_horizons_in_train(self, device):
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        cam, mp, vh, ego = self._inputs(device)
+        tgt = torch.randn(B, 128, device=device)
+        _, _, reasoning_pred = m(cam, mp, vh, ego, mode="train", trajectory_target=tgt)
+        for group in DEFAULT_TAXONOMY.groups:
+            assert len(reasoning_pred.logits[group.name]) == 5
+
+    def test_baseline_unchanged_enable_false(self, device):
+        """Confirm enable_reasoning_band=False ⇒ exact return contract as before."""
+        m_base = self._build(device, enable_reasoning_band=False)
+        cam, mp, vh, ego = self._inputs(device)
+        tgt = torch.randn(B, 128, device=device)
+        out_infer = m_base(cam, mp, vh, ego, mode="infer")
+        out_train = m_base(cam, mp, vh, ego, mode="train", trajectory_target=tgt)
+        # Infer: plain tensor or 1-tuple
+        if isinstance(out_infer, tuple):
+            assert len(out_infer) <= 2
+        else:
+            assert torch.is_tensor(out_infer)
+        # Train without world model: plain tensor (no 3-tuple)
+        assert not (isinstance(out_train, tuple) and len(out_train) == 3)
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy extensibility — KIT labels (no-break contract)
+# ---------------------------------------------------------------------------
+
+class TestTaxonomyExtensibility:
+    def test_kit_label_does_not_shift_existing_indices(self):
+        """Adding a KIT group must not change any existing group's indices."""
+        t = ScenarioTaxonomy()
+        # Record all indices before extension
+        before = {
+            g.name: {label: g.index(label) for label in g.labels}
+            for g in t.groups
+        }
+        t.register_group("kit_high_level", [
+            "intersection_scenario",
+            "overtake",
+            "construction_zone",
+        ])
+        # All old indices must be unchanged
+        for gname, label_map in before.items():
+            for label, idx in label_map.items():
+                assert t[gname].index(label) == idx
+
+    def test_kit_group_accessible_after_register(self):
+        t = ScenarioTaxonomy()
+        t.register_group("kit_high_level", ["intersection_scenario"])
+        assert t.num_classes("kit_high_level") == 1
+        assert t["kit_high_level"].index("intersection_scenario") == 0
+
+    def test_reasoning_band_with_extended_taxonomy(self, device):
+        """ReasoningBand works correctly with an extended taxonomy."""
+        t = ScenarioTaxonomy()
+        t.register_group("kit_high_level", ["intersection_scenario", "overtake"])
+        band = ReasoningBand(
+            visual_history_dim=VH_DIM, hidden_dim=32, taxonomy=t
+        ).to(device)
+        logits = band(_vh(device), mode="train").logits
+        assert "kit_high_level" in logits
+        assert len(logits["kit_high_level"]) == 5
+        assert logits["kit_high_level"][0].shape == (B, 2)
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric Loss option (class-imbalance; arXiv:2009.14119)
+# ---------------------------------------------------------------------------
+
+class TestAsymmetricLoss:
+    def _logits_targets(self, logit_val: float, target_val: float):
+        logits = {g.name: [torch.full((B, len(g)), logit_val)]
+                  for g in DEFAULT_TAXONOMY.groups}
+        targets = {g.name: [torch.full((B, len(g)), target_val)]
+                   for g in DEFAULT_TAXONOMY.groups}
+        return logits, targets
+
+    def test_asl_near_zero_for_perfect_predictions(self):
+        logits, targets = self._logits_targets(10.0, 1.0)
+        assert ReasoningLoss(loss_type="asl")(logits, targets).item() < 0.01
+
+    def test_asl_downweights_easy_negatives_vs_bce(self):
+        logits, targets = self._logits_targets(-2.0, 0.0)
+        asl = ReasoningLoss(loss_type="asl")(logits, targets).item()
+        bce = ReasoningLoss(loss_type="bce")(logits, targets).item()
+        assert asl < bce
+
+    def test_reduction_none_shape(self):
+        logits, targets = self._logits_targets(0.0, 0.5)
+        loss = ReasoningLoss(loss_type="asl", reduction="none")(logits, targets)
+        assert loss.shape == (B,)
+
+    def test_invalid_loss_type_raises(self):
+        with pytest.raises(ValueError, match="loss_type"):
+            ReasoningLoss(loss_type="focal")
+
+    def test_asl_backward(self):
+        logits = {g.name: [torch.zeros(B, len(g), requires_grad=True)]
+                  for g in DEFAULT_TAXONOMY.groups}
+        targets = {g.name: [torch.ones(B, len(g))] for g in DEFAULT_TAXONOMY.groups}
+        ReasoningLoss(loss_type="asl")(logits, targets).backward()
+        assert logits["maneuver"][0].grad is not None

--- a/Model/tests/test_reasoning_band.py
+++ b/Model/tests/test_reasoning_band.py
@@ -429,7 +429,7 @@ class TestReasoningLoss:
 
 class _AutoE2EHarness:
     """Shared mock-backbone harness (NOT collected: no Test prefix) so the
-    wiring, Moondream and faithfulness suites reuse _build/_inputs without
+    wiring and faithfulness suites reuse _build/_inputs without
     pytest re-collecting inherited tests."""
 
     class _MockBackbone(nn.Module):
@@ -583,39 +583,66 @@ class TestTaxonomyExtensibility:
 
 
 # ---------------------------------------------------------------------------
-# Asymmetric Loss option (class-imbalance; arXiv:2009.14119)
+# Faithfulness / intervention check (#98 evaluation protocol)
 # ---------------------------------------------------------------------------
 
-class TestAsymmetricLoss:
-    def _logits_targets(self, logit_val: float, target_val: float):
-        logits = {g.name: [torch.full((B, len(g)), logit_val)]
-                  for g in DEFAULT_TAXONOMY.groups}
-        targets = {g.name: [torch.full((B, len(g)), target_val)]
-                   for g in DEFAULT_TAXONOMY.groups}
-        return logits, targets
+class TestReasoningInterventionDelta(_AutoE2EHarness):
+    """The intervention metric: with the gate untrained the coupled and
+    intervened trajectories are identical (delta 0.0); once the gate moves,
+    the reasoning signal measurably influences the trajectory."""
 
-    def test_asl_near_zero_for_perfect_predictions(self):
-        logits, targets = self._logits_targets(10.0, 1.0)
-        assert ReasoningLoss(loss_type="asl")(logits, targets).item() < 0.01
+    def test_zero_delta_at_init(self, device):
+        from evaluation.faithfulness import reasoning_intervention_delta
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        cam, mp, vh, ego = self._inputs(device)
+        delta = reasoning_intervention_delta(m, cam, mp, vh, ego)
+        assert delta["trajectory_l2"] == pytest.approx(0.0, abs=1e-5)
+        assert delta["history_shift"] == pytest.approx(0.0, abs=1e-5)
 
-    def test_asl_downweights_easy_negatives_vs_bce(self):
-        logits, targets = self._logits_targets(-2.0, 0.0)
-        asl = ReasoningLoss(loss_type="asl")(logits, targets).item()
-        bce = ReasoningLoss(loss_type="bce")(logits, targets).item()
-        assert asl < bce
+    def test_positive_delta_once_gate_moves(self, device):
+        from evaluation.faithfulness import reasoning_intervention_delta
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        with torch.no_grad():
+            m.Reasoning_Band.gate.beta.bias.fill_(1.0)
+        cam, mp, vh, ego = self._inputs(device)
+        delta = reasoning_intervention_delta(m, cam, mp, vh, ego)
+        assert delta["history_shift"] > 0.0
 
-    def test_reduction_none_shape(self):
-        logits, targets = self._logits_targets(0.0, 0.5)
-        loss = ReasoningLoss(loss_type="asl", reduction="none")(logits, targets)
-        assert loss.shape == (B,)
+    def test_band_restored_after_intervention(self, device):
+        from evaluation.faithfulness import reasoning_intervention_delta
+        m = self._build(device, enable_reasoning_band=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        band = m.Reasoning_Band
+        cam, mp, vh, ego = self._inputs(device)
+        reasoning_intervention_delta(m, cam, mp, vh, ego)
+        assert m.Reasoning_Band is band
 
-    def test_invalid_loss_type_raises(self):
-        with pytest.raises(ValueError, match="loss_type"):
-            ReasoningLoss(loss_type="focal")
+    def test_requires_reasoning_band(self, device):
+        from evaluation.faithfulness import reasoning_intervention_delta
+        m = self._build(device, enable_reasoning_band=False)
+        cam, mp, vh, ego = self._inputs(device)
+        with pytest.raises(ValueError, match="enable_reasoning_band"):
+            reasoning_intervention_delta(m, cam, mp, vh, ego)
 
-    def test_asl_backward(self):
-        logits = {g.name: [torch.zeros(B, len(g), requires_grad=True)]
-                  for g in DEFAULT_TAXONOMY.groups}
-        targets = {g.name: [torch.ones(B, len(g))] for g in DEFAULT_TAXONOMY.groups}
-        ReasoningLoss(loss_type="asl")(logits, targets).backward()
-        assert logits["maneuver"][0].grad is not None
+
+# ---------------------------------------------------------------------------
+# Audit regressions (comité 3/07)
+# ---------------------------------------------------------------------------
+
+class TestAuditRegressions(_AutoE2EHarness):
+    def test_faithfulness_zero_delta_with_world_model_on(self, device):
+        """CRITICAL fix: with the World Model enabled, every forward pushes to
+        the rolling buffer — without snapshot/restore the coupled and
+        intervened runs would diverge even with an untrained gate."""
+        from evaluation.faithfulness import reasoning_intervention_delta
+        m = self._build(device, enable_reasoning_band=True,
+                        enable_world_model=True,
+                        reasoning_kwargs={"hidden_dim": 32})
+        cam, mp, vh, ego = self._inputs(device)
+        buf_before = list(m.visual_history_buffer._buf)
+        delta = reasoning_intervention_delta(m, cam, mp, vh, ego)
+        assert delta["trajectory_l2"] == pytest.approx(0.0, abs=1e-5)
+        # Caller's rollout state untouched by the metric.
+        assert len(m.visual_history_buffer._buf) == len(buf_before)

--- a/Model/tests/test_reasoning_review_fixes.py
+++ b/Model/tests/test_reasoning_review_fixes.py
@@ -1,0 +1,73 @@
+"""Tests for the review fixes on the reasoning supervision PR (#98 / #109).
+
+- MultiTeacher must reject teachers whose label tuples differ in order.
+- confidence_brier_loss supervises the per-horizon confidence head (#110 hook).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from model_components.reasoning.scenario_taxonomy import (
+    DEFAULT_TAXONOMY,
+    ScenarioTaxonomy,
+    TaxonomyGroup,
+)
+from model_components.reasoning.teachers import DeterministicTeacher, MultiTeacher
+from training.losses.reasoning_loss import confidence_brier_loss
+
+B = 2
+
+
+class TestMultiTeacherLabelOrder:
+    def test_same_group_names_but_different_label_order_raises(self):
+        tax_a = ScenarioTaxonomy()
+        tax_b = ScenarioTaxonomy()
+        # Same group names, but reverse the label order of one group.
+        man = tax_b["maneuver"]
+        tax_b._groups["maneuver"] = TaxonomyGroup(
+            name="maneuver", labels=tuple(reversed(man.labels))
+        )
+        t1 = DeterministicTeacher(taxonomy=tax_a)
+        t2 = DeterministicTeacher(taxonomy=tax_b)
+        with pytest.raises(ValueError, match="label tuples differ"):
+            MultiTeacher([t1, t2])
+
+    def test_identical_taxonomies_accepted(self):
+        t1 = DeterministicTeacher()
+        t2 = DeterministicTeacher()
+        # Must not raise (labels identical in content and order).
+        MultiTeacher([t1, t2])
+
+
+class TestConfidenceBrierLoss:
+    def test_zero_for_perfect_confidence(self):
+        logits = torch.full((B, 5), 10.0)  # sigmoid ~ 1.0
+        target = torch.ones(B, 5)
+        assert confidence_brier_loss(logits, target).item() < 1e-3
+
+    def test_penalises_confident_but_wrong(self):
+        logits = torch.full((B, 5), 10.0)  # sigmoid ~ 1.0
+        target = torch.zeros(B, 5)
+        assert confidence_brier_loss(logits, target).item() > 0.9
+
+    def test_reduction_none_shape(self):
+        loss = confidence_brier_loss(
+            torch.zeros(B, 5), torch.zeros(B, 5), reduction="none"
+        )
+        assert loss.shape == (B, 5)
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError, match="shape mismatch"):
+            confidence_brier_loss(torch.zeros(B, 5), torch.zeros(B, 4))
+
+    def test_backward_flows_to_confidence_head(self):
+        logits = torch.zeros(B, 5, requires_grad=True)
+        target = torch.full((B, 5), 0.7)
+        confidence_brier_loss(logits, target).backward()
+        assert logits.grad is not None and torch.isfinite(logits.grad).all()
+
+    def test_taxonomy_is_importable_default(self):
+        # sanity: the default taxonomy still exposes the 3 groups used above.
+        assert DEFAULT_TAXONOMY.group_names == ["maneuver", "edge_case", "weather_env"]

--- a/Model/tests/test_reasoning_supervision.py
+++ b/Model/tests/test_reasoning_supervision.py
@@ -1,0 +1,226 @@
+"""Tests for the reasoning-band supervision pipeline (issue #98/#103).
+
+Covers the pieces that run WITHOUT any VLM (CPU-only, no downloads):
+    * ReasoningLoss with loss_type="asl" (Asymmetric Loss for the class
+      imbalance) alongside the default BCE.
+    * MultiTeacher: agreement-fraction fusion of two teachers (the soft
+      confidence signal).
+    * Qwen2-VL prompt/parse helpers (pure functions; the model call itself is
+      GPU/offline work).
+    * long_tail_split: stratified evaluation subset for #98's protocol.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from evaluation.splits import long_tail_split
+from model_components.reasoning.scenario_taxonomy import (
+    DEFAULT_TAXONOMY,
+    ScenarioTaxonomy,
+)
+from model_components.reasoning.teachers import (
+    DeterministicTeacher,
+    MultiTeacher,
+)
+from model_components.reasoning.teachers.qwen2vl import (
+    build_scenario_prompt,
+    labels_to_targets,
+    parse_scenario_response,
+)
+from training.losses.reasoning_loss import ReasoningLoss
+
+B = 2
+
+
+def _frames(n: int = 1) -> list[torch.Tensor]:
+    return [torch.zeros(B, 3, 8, 8) for _ in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric Loss (ASL) option
+# ---------------------------------------------------------------------------
+
+class TestAsymmetricLoss:
+    def _logits_targets(self, logit_val: float, target_val: float):
+        logits = {
+            g.name: [torch.full((B, len(g)), logit_val)]
+            for g in DEFAULT_TAXONOMY.groups
+        }
+        targets = {
+            g.name: [torch.full((B, len(g)), target_val)]
+            for g in DEFAULT_TAXONOMY.groups
+        }
+        return logits, targets
+
+    def test_asl_near_zero_for_perfect_predictions(self):
+        logits, targets = self._logits_targets(10.0, 1.0)
+        loss = ReasoningLoss(loss_type="asl")(logits, targets)
+        assert loss.item() < 0.01
+
+    def test_asl_penalises_confident_mistakes(self):
+        good, targets = self._logits_targets(10.0, 1.0)
+        bad, _ = self._logits_targets(-10.0, 1.0)
+        loss_fn = ReasoningLoss(loss_type="asl")
+        assert loss_fn(bad, targets).item() > loss_fn(good, targets).item()
+
+    def test_asl_downweights_easy_negatives_vs_bce(self):
+        """The point of ASL: an easy negative (low prob, target 0) contributes
+        ~0 loss, while BCE still charges it."""
+        logits, targets = self._logits_targets(-2.0, 0.0)
+        asl = ReasoningLoss(loss_type="asl")(logits, targets).item()
+        bce = ReasoningLoss(loss_type="bce")(logits, targets).item()
+        assert asl < bce
+
+    def test_reduction_none_shape(self):
+        logits, targets = self._logits_targets(0.0, 0.5)
+        loss = ReasoningLoss(loss_type="asl", reduction="none")(logits, targets)
+        assert loss.shape == (B,)
+
+    def test_invalid_loss_type_raises(self):
+        with pytest.raises(ValueError, match="loss_type"):
+            ReasoningLoss(loss_type="focal")
+
+    def test_asl_backward(self):
+        logits = {
+            g.name: [torch.zeros(B, len(g), requires_grad=True)]
+            for g in DEFAULT_TAXONOMY.groups
+        }
+        targets = {
+            g.name: [torch.ones(B, len(g))] for g in DEFAULT_TAXONOMY.groups
+        }
+        ReasoningLoss(loss_type="asl")(logits, targets).backward()
+        assert logits["maneuver"][0].grad is not None
+
+
+# ---------------------------------------------------------------------------
+# MultiTeacher — agreement fusion
+# ---------------------------------------------------------------------------
+
+class TestMultiTeacher:
+    def test_agreement_fraction(self):
+        t1 = DeterministicTeacher(
+            active_labels={"maneuver": ["turn_left"], "weather_env": ["rain_day"]}
+        )
+        t2 = DeterministicTeacher(
+            active_labels={"maneuver": ["turn_left", "curve_left"]}
+        )
+        fused = MultiTeacher([t1, t2]).label(_frames(), num_future_horizons=0)
+        man = DEFAULT_TAXONOMY["maneuver"]
+        wea = DEFAULT_TAXONOMY["weather_env"]
+        assert fused["maneuver"][0][0, man.index("turn_left")] == 1.0   # both
+        assert fused["maneuver"][0][0, man.index("curve_left")] == 0.5  # one of two
+        assert fused["weather_env"][0][0, wea.index("rain_day")] == 0.5
+
+    def test_needs_two_teachers(self):
+        with pytest.raises(ValueError, match="at least 2"):
+            MultiTeacher([DeterministicTeacher()])
+
+    def test_taxonomy_mismatch_raises(self):
+        other = ScenarioTaxonomy()
+        other.register_group("kit_context", ["intersection"])
+        with pytest.raises(ValueError, match="same taxonomy"):
+            MultiTeacher([
+                DeterministicTeacher(),
+                DeterministicTeacher(taxonomy=other),
+            ])
+
+    def test_horizons_preserved(self):
+        fused = MultiTeacher(
+            [DeterministicTeacher(), DeterministicTeacher()]
+        ).label(_frames(5), num_future_horizons=4)
+        for g in DEFAULT_TAXONOMY.groups:
+            assert len(fused[g.name]) == 5
+
+
+# ---------------------------------------------------------------------------
+# Qwen2-VL prompt/parse helpers (pure — no model)
+# ---------------------------------------------------------------------------
+
+class TestQwenPromptAndParse:
+    def test_prompt_lists_every_label(self):
+        prompt = build_scenario_prompt(DEFAULT_TAXONOMY)
+        for group in DEFAULT_TAXONOMY.groups:
+            assert group.name in prompt
+            for label in group.labels:
+                assert label in prompt
+
+    def test_parse_happy_path_with_chatter(self):
+        text = (
+            'Sure! Here is the labelling:\n'
+            '{"maneuver": ["turn_left"], "edge_case": [], '
+            '"weather_env": ["rain_night"]}\nHope that helps.'
+        )
+        parsed = parse_scenario_response(text, DEFAULT_TAXONOMY)
+        assert parsed["maneuver"] == ["turn_left"]
+        assert parsed["edge_case"] == []
+        assert parsed["weather_env"] == ["rain_night"]
+
+    def test_parse_drops_unknown_labels(self):
+        text = '{"maneuver": ["turn_left", "warp_speed"], "edge_case": 3}'
+        parsed = parse_scenario_response(text, DEFAULT_TAXONOMY)
+        assert parsed["maneuver"] == ["turn_left"]
+        assert parsed["edge_case"] == []
+
+    def test_parse_garbage_abstains(self):
+        parsed = parse_scenario_response("no json here", DEFAULT_TAXONOMY)
+        assert all(v == [] for v in parsed.values())
+
+    def test_labels_to_targets(self):
+        per_sample = [
+            {"maneuver": ["turn_left"], "edge_case": [], "weather_env": []},
+            {"maneuver": [], "edge_case": ["give_way"], "weather_env": []},
+        ]
+        targets = labels_to_targets(per_sample, DEFAULT_TAXONOMY)
+        man = DEFAULT_TAXONOMY["maneuver"]
+        edge = DEFAULT_TAXONOMY["edge_case"]
+        assert targets["maneuver"][0, man.index("turn_left")] == 1.0
+        assert targets["edge_case"][1, edge.index("give_way")] == 1.0
+        assert targets["maneuver"][1].sum() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Long-tail evaluation split (#98 protocol)
+# ---------------------------------------------------------------------------
+
+class TestLongTailSplit:
+    def test_stratifies_by_membership(self):
+        scenarios = [
+            ["continue_straight", "fair_day"],
+            ["give_way", "rain_day"],
+            ["turn_left"],
+            ["close_to_vru", "fog_night"],
+        ]
+        rare = list(DEFAULT_TAXONOMY["edge_case"].labels)
+        long_tail, nominal = long_tail_split(scenarios, rare)
+        assert long_tail == [1, 3]
+        assert nominal == [0, 2]
+
+    def test_empty_long_tail_classes_raise(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            long_tail_split([["a"]], [])
+
+
+# ---------------------------------------------------------------------------
+# Teacher registry — all backends reachable by name
+# ---------------------------------------------------------------------------
+
+class TestTeacherRegistry:
+    def test_all_backends_registered(self):
+        from model_components.reasoning.teachers import _TEACHER_REGISTRY
+        for key in ("deterministic", "multi", "qwen2vl", "videollama3"):
+            assert key in _TEACHER_REGISTRY
+
+    def test_videollama3_is_explicit_about_pending_wiring(self):
+        from model_components.reasoning.teachers.videollama3 import VideoLlama3Teacher
+        with pytest.raises(NotImplementedError, match="labelling pipeline"):
+            VideoLlama3Teacher().label([torch.zeros(1, 3, 8, 8)])
+
+
+class TestParseTrailingBrace:
+    def test_trailing_brace_after_object_still_parses(self):
+        """Audit fix: a greedy regex would swallow the trailing '}' and abstain."""
+        text = '{"maneuver": ["turn_left"], "edge_case": [], "weather_env": []} bye }'
+        parsed = parse_scenario_response(text, DEFAULT_TAXONOMY)
+        assert parsed["maneuver"] == ["turn_left"]

--- a/Model/tests/test_teacher_openai_endpoint.py
+++ b/Model/tests/test_teacher_openai_endpoint.py
@@ -1,7 +1,7 @@
 """Tests for the OpenAI-compatible endpoint teacher backend (issue #98).
 
 Covers @riita10069's model-agnostic teacher endpoint: request construction,
-response parsing into taxonomy targets, the abstain-on-failure path, and
+per-frame and clip-horizons modes, the strict-vs-abstain failure policy, and
 registry reachability.  No network / GPU — the transport is a stub.
 """
 
@@ -40,7 +40,7 @@ class _RecordingTransport:
         return _openai_response(self.content)
 
 
-class TestOpenAIEndpointTeacher:
+class TestPerFrameMode:
     def test_label_shapes_and_active_labels(self):
         content = (
             '{"maneuver": ["turn_left"], '
@@ -63,7 +63,6 @@ class TestOpenAIEndpointTeacher:
         assert torch.allclose(
             out["edge_case"][2][:, edge.index("close_to_vru")], torch.ones(B)
         )
-        # a label not listed by the teacher stays 0
         assert out["maneuver"][0][:, man.index("turn_right")].sum().item() == 0.0
 
     def test_request_is_openai_compatible(self):
@@ -88,15 +87,78 @@ class TestOpenAIEndpointTeacher:
         image_part = next(p for p in content if p["type"] == "image_url")
         assert image_part["image_url"]["url"].startswith("data:image/png;base64,")
 
-    def test_abstain_on_transport_error(self):
+
+class TestFailurePolicy:
+    def test_strict_raises_on_transport_error(self):
         def boom(url: str, payload: Dict[str, Any], headers: Dict[str, str]):
             raise RuntimeError("endpoint down")
 
-        teacher = OpenAIEndpointTeacher(transport=boom)
+        teacher = OpenAIEndpointTeacher(transport=boom)  # strict=True default
+        with pytest.raises(RuntimeError, match="teacher endpoint call failed"):
+            teacher.label(_frames(1), num_future_horizons=0)
+
+    def test_strict_raises_on_empty_response(self):
+        # A malformed response (no choices) must not silently become 0-labels.
+        teacher = OpenAIEndpointTeacher(
+            transport=lambda url, payload, headers: {"choices": []}
+        )
+        with pytest.raises(RuntimeError, match="empty/malformed"):
+            teacher.label(_frames(1), num_future_horizons=0)
+
+    def test_abstain_when_not_strict(self):
+        def boom(url: str, payload: Dict[str, Any], headers: Dict[str, str]):
+            raise RuntimeError("endpoint down")
+
+        teacher = OpenAIEndpointTeacher(transport=boom, strict=False)
         out = teacher.label(_frames(1), num_future_horizons=0)
         for g in DEFAULT_TAXONOMY.groups:
             assert out[g.name][0].sum().item() == 0.0
 
+
+class TestClipHorizonsMode:
+    def test_clip_returns_all_horizons_from_one_request(self):
+        content = (
+            '{"horizons": ['
+            '{"maneuver": ["turn_left"], "edge_case": [], "weather_env": []}, '
+            '{"maneuver": [], "edge_case": ["give_way"], "weather_env": []}'
+            "]}"
+        )
+        transport = _RecordingTransport(content)
+        teacher = OpenAIEndpointTeacher(mode="clip_horizons", transport=transport)
+        out = teacher.label(_frames(2), num_future_horizons=1)  # 2 horizons
+
+        man = DEFAULT_TAXONOMY["maneuver"]
+        edge = DEFAULT_TAXONOMY["edge_case"]
+        assert torch.allclose(
+            out["maneuver"][0][:, man.index("turn_left")], torch.ones(B)
+        )
+        assert torch.allclose(
+            out["edge_case"][1][:, edge.index("give_way")], torch.ones(B)
+        )
+        # clip mode sends ONE request per sample, each carrying every frame.
+        assert len(transport.calls) == B
+        parts = transport.calls[0]["payload"]["messages"][0]["content"]
+        n_images = sum(1 for p in parts if p["type"] == "image_url")
+        assert n_images == 2  # both horizon frames in a single request
+
+    def test_clip_prompt_carries_extra_context(self):
+        content = '{"horizons": [{"maneuver": [], "edge_case": [], "weather_env": []}]}'
+        transport = _RecordingTransport(content)
+        teacher = OpenAIEndpointTeacher(
+            mode="clip_horizons",
+            transport=transport,
+            extra_context="ego: 30 km/h; route: turn right at intersection",
+        )
+        teacher.label(_frames(1), num_future_horizons=0)
+        text = transport.calls[0]["payload"]["messages"][0]["content"][0]["text"]
+        assert "route: turn right" in text
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="Unsupported mode"):
+            OpenAIEndpointTeacher(mode="nope")
+
+
+class TestRegistryAndContract:
     def test_registered_in_registry(self):
         from model_components.reasoning.teachers import _TEACHER_REGISTRY
 

--- a/Model/tests/test_teacher_openai_endpoint.py
+++ b/Model/tests/test_teacher_openai_endpoint.py
@@ -1,0 +1,108 @@
+"""Tests for the OpenAI-compatible endpoint teacher backend (issue #98).
+
+Covers @riita10069's model-agnostic teacher endpoint: request construction,
+response parsing into taxonomy targets, the abstain-on-failure path, and
+registry reachability.  No network / GPU — the transport is a stub.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+import torch
+
+from model_components.reasoning.scenario_taxonomy import DEFAULT_TAXONOMY
+from model_components.reasoning.teachers.openai_endpoint import OpenAIEndpointTeacher
+
+B = 2
+
+
+def _frames(n: int) -> List[torch.Tensor]:
+    return [torch.zeros(B, 3, 8, 8) for _ in range(n)]
+
+
+def _openai_response(content: str) -> Dict[str, Any]:
+    return {"choices": [{"message": {"role": "assistant", "content": content}}]}
+
+
+class _RecordingTransport:
+    """Stub transport: records each call, returns a fixed JSON content."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls: List[Dict[str, Any]] = []
+
+    def __call__(
+        self, url: str, payload: Dict[str, Any], headers: Dict[str, str]
+    ) -> Dict[str, Any]:
+        self.calls.append({"url": url, "payload": payload, "headers": headers})
+        return _openai_response(self.content)
+
+
+class TestOpenAIEndpointTeacher:
+    def test_label_shapes_and_active_labels(self):
+        content = (
+            '{"maneuver": ["turn_left"], '
+            '"edge_case": ["close_to_vru"], "weather_env": []}'
+        )
+        teacher = OpenAIEndpointTeacher(transport=_RecordingTransport(content))
+        out = teacher.label(_frames(5), num_future_horizons=4)
+
+        for g in DEFAULT_TAXONOMY.groups:
+            assert g.name in out
+            assert len(out[g.name]) == 5  # current + 4 horizons
+            for tensor in out[g.name]:
+                assert tensor.shape == (B, len(g))
+
+        man = DEFAULT_TAXONOMY["maneuver"]
+        assert torch.allclose(
+            out["maneuver"][0][:, man.index("turn_left")], torch.ones(B)
+        )
+        edge = DEFAULT_TAXONOMY["edge_case"]
+        assert torch.allclose(
+            out["edge_case"][2][:, edge.index("close_to_vru")], torch.ones(B)
+        )
+        # a label not listed by the teacher stays 0
+        assert out["maneuver"][0][:, man.index("turn_right")].sum().item() == 0.0
+
+    def test_request_is_openai_compatible(self):
+        transport = _RecordingTransport(
+            '{"maneuver": [], "edge_case": [], "weather_env": []}'
+        )
+        teacher = OpenAIEndpointTeacher(
+            base_url="http://host:9000/v1/",
+            model="cosmos3-nano",
+            api_key="secret",
+            transport=transport,
+        )
+        teacher.label(_frames(1), num_future_horizons=0)
+
+        call = transport.calls[0]
+        assert call["url"] == "http://host:9000/v1/chat/completions"
+        assert call["payload"]["model"] == "cosmos3-nano"
+        assert call["headers"]["Authorization"] == "Bearer secret"
+        content = call["payload"]["messages"][0]["content"]
+        types = [part["type"] for part in content]
+        assert "text" in types and "image_url" in types
+        image_part = next(p for p in content if p["type"] == "image_url")
+        assert image_part["image_url"]["url"].startswith("data:image/png;base64,")
+
+    def test_abstain_on_transport_error(self):
+        def boom(url: str, payload: Dict[str, Any], headers: Dict[str, str]):
+            raise RuntimeError("endpoint down")
+
+        teacher = OpenAIEndpointTeacher(transport=boom)
+        out = teacher.label(_frames(1), num_future_horizons=0)
+        for g in DEFAULT_TAXONOMY.groups:
+            assert out[g.name][0].sum().item() == 0.0
+
+    def test_registered_in_registry(self):
+        from model_components.reasoning.teachers import _TEACHER_REGISTRY
+
+        assert "openai_endpoint" in _TEACHER_REGISTRY
+
+    def test_requires_enough_frames(self):
+        teacher = OpenAIEndpointTeacher(transport=_RecordingTransport("{}"))
+        with pytest.raises(ValueError, match="frame batches"):
+            teacher.label(_frames(2), num_future_horizons=4)

--- a/Model/training/losses/__init__.py
+++ b/Model/training/losses/__init__.py
@@ -1,0 +1,5 @@
+"""Training loss modules for AutoE2E (kept outside the model per Zain's criterion)."""
+
+from .reasoning_loss import ReasoningLoss
+
+__all__ = ["ReasoningLoss"]

--- a/Model/training/losses/reasoning_loss.py
+++ b/Model/training/losses/reasoning_loss.py
@@ -154,3 +154,47 @@ class ReasoningLoss:
         # Sum across groups (each group contributes independently).
         total: torch.Tensor = torch.stack(group_losses).sum(dim=0)
         return self.weight * total
+
+
+def confidence_brier_loss(
+    confidence_logits: torch.Tensor,
+    target_confidence: torch.Tensor,
+    reduction: str = "mean",
+) -> torch.Tensor:
+    """Supervise the reasoning band's per-horizon confidence head (#110).
+
+    The band emits a per-horizon ``confidence`` (raw logits) but the core PR
+    (#108) does not yet give it a target — so on its own the output is
+    observability, not a trained signal. This is the proper-scoring-rule
+    supervision term from #110: the Brier (squared-error) loss between
+    ``sigmoid(confidence_logits)`` and a target in ``[0, 1]``.
+
+    A natural, label-free target is the cross-teacher **agreement fraction**
+    produced by
+    :class:`~model_components.reasoning.teachers.multi_teacher.MultiTeacher`
+    (high disagreement → low confidence), or a source-weighted label
+    confidence. Wiring this into ``train.py`` together with the planner
+    *consuming* confidence is tracked in #110; this function is the building
+    block that makes the head trainable rather than decorative.
+
+    Args:
+        confidence_logits: ``[B, num_horizons]`` raw confidence logits
+            (``ReasoningPrediction.confidence``).
+        target_confidence: ``[B, num_horizons]`` targets in ``[0, 1]``.
+        reduction: ``"mean"`` (scalar) or ``"none"`` (``[B, num_horizons]``).
+
+    Raises:
+        ValueError: on an unsupported ``reduction`` or a shape mismatch.
+    """
+    if reduction not in ("mean", "none"):
+        raise ValueError(
+            f"Unsupported reduction '{reduction}'. Choose 'mean' or 'none'."
+        )
+    if confidence_logits.shape != target_confidence.shape:
+        raise ValueError(
+            f"shape mismatch: confidence_logits {tuple(confidence_logits.shape)} "
+            f"vs target_confidence {tuple(target_confidence.shape)}."
+        )
+    pred = torch.sigmoid(confidence_logits)
+    squared_error = (pred - target_confidence.float()) ** 2
+    return squared_error.mean() if reduction == "mean" else squared_error

--- a/Model/training/losses/reasoning_loss.py
+++ b/Model/training/losses/reasoning_loss.py
@@ -1,0 +1,156 @@
+"""Multi-label, multi-horizon student↔teacher distillation loss (issue #98).
+
+This module lives OUTSIDE the model (in ``Model/training/``) and is computed
+in the training loop — matching Zain's explicit requirement that loss modules
+for each band stay separate from the model forward pass (same principle as the
+JEPA loss in #85).
+
+The loss is binary-cross-entropy (BCE) with sigmoid targets, summed across
+taxonomy groups and averaged across horizons, then scaled by a scalar weight.
+Soft teacher targets (confidence scores in [0, 1]) are supported directly
+because ``F.binary_cross_entropy_with_logits`` accepts float targets.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import torch
+import torch.nn.functional as F
+
+# Type aliases matching reasoning_band.py and teachers/base.py
+ReasoningOutput = Dict[str, List[torch.Tensor]]   # logits (raw, pre-sigmoid)
+ReasoningTargets = Dict[str, List[torch.Tensor]]  # targets in [0, 1]
+
+
+class ReasoningLoss:
+    """Weighted student↔teacher distillation loss for the reasoning band.
+
+    Computes BCE with logits between the student's per-group, per-horizon
+    sigmoid heads and the teacher's multi-label targets.  Losses are averaged
+    across horizons and summed across groups (so adding a new group increases
+    the raw loss magnitude; callers should rescale ``weight`` accordingly).
+
+    This class is intentionally **not** an ``nn.Module`` — it holds no
+    trainable parameters (it is a pure stateless loss function) and lives in
+    the training loop, not in the model graph.
+
+    Args:
+        weight: scalar multiplier applied to the final loss before returning
+            (default 1.0, matching the JEPA equal-weight start policy from #85).
+        reduction: ``"mean"`` (default) averages over the batch; ``"none"``
+            returns per-sample losses of shape ``[B]`` for logging.
+        loss_type: ``"bce"`` (default) or ``"asl"``.  ASL (Asymmetric Loss,
+            Ridnik et al., arXiv:2009.14119) down-weights the flood of easy
+            negatives that dominates an imbalanced multi-label problem — our
+            scenario distribution is heavily skewed (intersection ~29.6% vs
+            nighttime ~5.1%) — and reported 86.6 vs 84.0 mAP over plain
+            cross-entropy on MS-COCO.  Soft teacher targets are supported by
+            weighting the positive/negative terms with the target value.
+        gamma_neg / gamma_pos / clip: ASL focusing/shift parameters (paper
+            defaults 4 / 0 / 0.05); ignored for ``loss_type="bce"``.
+
+    Example::
+
+        loss_fn = ReasoningLoss(weight=1.0)
+        loss = loss_fn(student_logits, teacher_targets)
+        loss.backward()
+    """
+
+    def __init__(
+        self,
+        weight: float = 1.0,
+        reduction: str = "mean",
+        loss_type: str = "bce",
+        gamma_neg: float = 4.0,
+        gamma_pos: float = 0.0,
+        clip: float = 0.05,
+    ) -> None:
+        if reduction not in ("mean", "none"):
+            raise ValueError(
+                f"Unsupported reduction '{reduction}'. Choose 'mean' or 'none'."
+            )
+        if loss_type not in ("bce", "asl"):
+            raise ValueError(
+                f"Unsupported loss_type '{loss_type}'. Choose 'bce' or 'asl'."
+            )
+        self.weight = weight
+        self.reduction = reduction
+        self.loss_type = loss_type
+        self.gamma_neg = gamma_neg
+        self.gamma_pos = gamma_pos
+        self.clip = clip
+
+    def _asl_with_logits(
+        self, logits: torch.Tensor, targets: torch.Tensor
+    ) -> torch.Tensor:
+        """Asymmetric Loss (element-wise, ``[B, C]``), soft-target friendly."""
+        eps = 1e-8
+        p = torch.sigmoid(logits)
+        # Probability shifting: hard-discard very easy negatives.
+        p_shifted = (p - self.clip).clamp(min=0.0)
+        loss_pos = ((1.0 - p) ** self.gamma_pos) * torch.log(p.clamp(min=eps))
+        loss_neg = (p_shifted ** self.gamma_neg) * torch.log(
+            (1.0 - p_shifted).clamp(min=eps)
+        )
+        return -(targets * loss_pos + (1.0 - targets) * loss_neg)
+
+    def __call__(
+        self,
+        student_logits: ReasoningOutput,
+        teacher_targets: ReasoningTargets,
+    ) -> torch.Tensor:
+        """Compute the reasoning distillation loss.
+
+        Args:
+            student_logits: dict mapping group name → list of per-horizon raw
+                logits ``[B, num_classes]`` (output of :class:`ReasoningBand`).
+            teacher_targets: dict mapping group name → list of per-horizon
+                float targets ``[B, num_classes]`` in ``[0, 1]`` (output of a
+                :class:`VLMTeacher`).
+
+        Returns:
+            Scalar loss (or ``[B]`` when ``reduction="none"``), multiplied by
+            ``self.weight``.
+
+        Raises:
+            ValueError: if the set of groups or number of horizons does not
+                match between logits and targets.
+        """
+        if student_logits.keys() != teacher_targets.keys():
+            raise ValueError(
+                f"Group mismatch: student has {set(student_logits.keys())}, "
+                f"teacher has {set(teacher_targets.keys())}."
+            )
+
+        group_losses: list[torch.Tensor] = []
+
+        for group_name in student_logits:
+            s_horizons = student_logits[group_name]
+            t_horizons = teacher_targets[group_name]
+            if len(s_horizons) != len(t_horizons):
+                raise ValueError(
+                    f"Group '{group_name}': student has {len(s_horizons)} horizons, "
+                    f"teacher has {len(t_horizons)}."
+                )
+            horizon_losses: list[torch.Tensor] = []
+            for s_logit, t_target in zip(s_horizons, t_horizons):
+                if self.loss_type == "asl":
+                    elem = self._asl_with_logits(s_logit, t_target.float())
+                    term = elem.mean() if self.reduction == "mean" else elem.mean(dim=-1)
+                else:
+                    # BCE with logits handles multi-label naturally (sigmoid implicit).
+                    term = F.binary_cross_entropy_with_logits(
+                        s_logit, t_target.float(), reduction=self.reduction
+                    )
+                    # When reduction="none", bce is [B, C]; average over classes.
+                    if self.reduction == "none":
+                        term = term.mean(dim=-1)   # [B]
+                horizon_losses.append(term)
+
+            # Average across horizons: [B] or scalar.
+            group_losses.append(torch.stack(horizon_losses).mean(dim=0))
+
+        # Sum across groups (each group contributes independently).
+        total: torch.Tensor = torch.stack(group_losses).sum(dim=0)
+        return self.weight * total


### PR DESCRIPTION
Part of #98; builds on the trained Reasoning band in #108 (this PR is stacked on that branch).

## Why
#108 adds the trained Reasoning band. This PR adds the **offline supervision and evaluation layer** around it: the swappable teacher registry that generates the band's pseudo-labels before training, a model-agnostic teacher endpoint so any OpenAI-compatible server (including @riita10069's Cosmos3-Nano vLLM PoC) can drive labelling, and the evaluation the thread asked for (long-tail stratification + an intervention/faithfulness check). Nothing here runs in the vehicle — every teacher is train-only.

## What this adds
- **`reasoning/teachers/`** — a swappable, offline teacher registry behind one `label()` interface:
  - `Qwen2VLTeacher` — working prompt builder + robust JSON parser over a closed label schema.
  - `VideoLlama3Teacher` — a video-native second opinion (the generation call is wired together with the GPU labelling pipeline; until then it raises a clear message instead of a silently wrong integration).
  - `MultiTeacher` — fuses teachers by per-label **agreement**, which doubles as the confidence signal, rather than trusting a single VLM's token probability.
  - **`OpenAIEndpointTeacher`** (new) — a **model-agnostic backend** that speaks the OpenAI chat-completions API and depends only on `base_url`, `model`, `prompt_version`, and the request/response schema. The network boundary is an injectable transport, so CI runs it with a stub (no GPU, no network).
- **`evaluation/`** — `long_tail_split` (stratify evaluation samples by rare classes) and `reasoning_intervention_delta` (a faithfulness check: does zeroing the band's planner coupling actually move the trajectory — 0.0 at initialisation by construction, so it also guards that enabling the band leaves the reactive baseline unchanged before training).
- **`speed_benchmark`** — a reasoning column measuring the band's added 1 Hz cost.

## Design notes (happy to adjust)
- The endpoint currently labels over the band's **current 3-axis taxonomy**; migrating the label space to the compositional action-relevant ontology is a follow-up — it grows through the same registry.
- It labels each horizon from its own frame (future frames as privileged offline information), rather than returning all horizons in one response. Both are valid; I can switch to a single-call horizons schema if preferred.

## Scope — NOT in this PR
The horizon-query cross-attention decoder, the pooled `reasoning_latent`, and the compositional action-relevant ontology are a separate follow-up PR — they build on this teacher/evaluation layer.

## Tests
`pytest Model/tests` → 370 passed, 4 skipped. `ruff` + `mypy` clean.
