### PR TITLE
fix(data_ingest): NVIDIA calibration never arrives — the run silently falls back to pseudo geometry

### DIFF
--- a/Platform/pipelines/workflows.py
+++ b/Platform/pipelines/workflows.py
@@ -193,8 +193,18 @@ def data_ingest(
                     import pickle
                     ds.download_clip_features(
                         clip_id, features=["camera_intrinsics", "sensor_extrinsics"])
-                    intr = ds.get_clip_feature(clip_id, "camera_intrinsics")
-                    extr = ds.get_clip_feature(clip_id, "sensor_extrinsics")
+                    # maybe_stream=True, exactly as the camera/egomotion reads above.
+                    # get_clip_feature defaults to maybe_stream=False, which resolves
+                    # the chunk through the SDK's local cache; under the local_dir
+                    # layout data_ingest uses, that lookup misses and the SDK raises
+                    # "not found in cache; set maybe_stream=True". The except below
+                    # then swallows it into a WARN, projection_spec returns None, and
+                    # the run silently continues on geometry_type='pseudo' — a learned
+                    # prior — while every reader downstream assumes real f-theta.
+                    intr = ds.get_clip_feature(
+                        clip_id, "camera_intrinsics", maybe_stream=True)
+                    extr = ds.get_clip_feature(
+                        clip_id, "sensor_extrinsics", maybe_stream=True)
                     calib_dir = out / "calibration"
                     calib_dir.mkdir(parents=True, exist_ok=True)
                     with open(calib_dir / "intrinsics.pkl", "wb") as f:
@@ -205,6 +215,20 @@ def data_ingest(
                     print(f"Saved NVIDIA calibration from clip {clip_id}")
                 except Exception as e:
                     print(f"WARN: no calibration for clip {clip_id}: {e}")
+        # NVIDIA ships real calibration for every clip, so an empty calibration dir
+        # is a FAILURE, not an absence. Falling through to pseudo geometry here would
+        # be a silent invalidation: the BEV becomes a learned warp instead of a
+        # bird's-eye view, and nothing downstream can tell the difference. Fail loudly
+        # rather than train on a grid whose cells map to nowhere.
+        if dataset == Dataset.NVIDIA_PHYSICAL_AI and not calib_saved:
+            raise RuntimeError(
+                "NVIDIA ingest produced no calibration: every clip failed to yield "
+                "camera_intrinsics/sensor_extrinsics (see the WARN lines above). "
+                "Without it NvidiaAVDataset.projection_spec returns None and the run "
+                "falls back to geometry_type='pseudo' (a learned spatial prior, not "
+                "real geometry). Refusing to ingest a dataset whose one distinguishing "
+                "property — real f-theta calibration — silently did not arrive."
+            )
         print(f"Ingested {dataset.value}: {len(clip_ids)} clips → {out_dir}")
         return FlyteDirectory(out_dir)
 


### PR DESCRIPTION

## The bug

`data_ingest` reads the cameras and the calibration differently, in the same function:

```python
# workflows.py:186,189 — cameras and egomotion
with ds.open_file(cf, maybe_stream=True) as f:            # correct

# workflows.py:196,197 — calibration
intr = ds.get_clip_feature(clip_id, "camera_intrinsics")  # no maybe_stream
extr = ds.get_clip_feature(clip_id, "sensor_extrinsics")  # no maybe_stream
```

`PhysicalAIAVDatasetInterface.get_clip_feature` defaults to **`maybe_stream: bool = False`**
(`physical_ai_av/dataset.py:151`). Under the `local_dir` layout `data_ingest` uses, that cache lookup
misses and the SDK raises:

> `filename='calibration/camera_intrinsics/camera_intrinsics.chunk_0000.parquet' not found in cache;
> set maybe_stream=True to enable streaming from HF Hub.`

The `except` on `workflows.py:207` demotes that to `WARN: no calibration for clip {id}` and the
ingest completes.

## What happens next

No `.pkl` is written → `NvidiaAVDataset.projection_spec` returns `None` → the run continues on
**`geometry_type='pseudo'`** — `PseudoProjection`, which describes itself as *"NOT real geometry ...
a learnable spatial prior"*: a single `[3,4]` matrix expanded across all seven cameras and
initialised from noise.

**So the model trains on a learned warp while every reader downstream assumes real f-theta — and the
only trace is one WARN line in a log of thousands.**

**NVIDIA is the only dataset in the pipeline that ships real calibration, and it has never received
it. The f-theta path added in #77/#107 has never been exercised on real data.**

## Reproduction

Real ingest of the first 10 clips (RTX 3090, 14 GB downloaded): **every clip logged the WARN and the
calibration directory was empty.** With the fix, the same ingest writes `intrinsics.pkl` (3,665 B)
and `extrinsics.pkl` (3,544 B), and `projection_spec` returns `type='ftheta'` with **7 per-camera
matrices**.

## The fix

1. **Pass `maybe_stream=True`**, matching the two reads seven lines above.
2. **Raise if the NVIDIA ingest ends with no calibration at all.** For NVIDIA a missing calibration
   is a **failure, not an absence**: silently degrading to a learned prior is exactly what the
   explicit pseudo path exists to prevent — per the comment at `workflows.py:167`, *"never a silent
   real-geometry claim"*.

There is a **second door to the same failure**: the NVIDIA dataset is gated on HF. If the Flyte
`hf-token` secret has not accepted NVIDIA's terms, the ingest fails → same WARN → same pseudo
geometry. The `raise` closes both.

## Scope

One file, +26 / −2. Nothing outside the NVIDIA branch of `data_ingest` changes. The pseudo fallback
stays exactly as it is for datasets that genuinely have no calibration (L2D).

## Tests

`ruff` clean · `mypy` clean (134 files) · `pytest Model/tests`: **415 passed, 6 skipped**.