### PR TITLE
feat(reasoning): unpooled BEV as a spatial context source — the architectural prerequisite from #121

### DIFF
--- a/Model/model_components/reactive_e2e.py
+++ b/Model/model_components/reactive_e2e.py
@@ -77,10 +77,24 @@ class ReactiveE2E(nn.Module):
         self.enable_reasoning = enable_reasoning
         self.reasoning_mode = reasoning_mode if enable_reasoning else "none"
         self.ReasoningHead = None
+        # TWO INDEPENDENT SWITCHES, deliberately not one:
+        #   bev_context_dim  -> the head SEES the unpooled BEV (#121's fix).
+        #   reasoning_bev_detach -> whether the reasoning loss also RESHAPES the
+        #       shared BEV/backbone through that path.
+        # This repo has twice found that routing an auxiliary gradient into the
+        # shared trunk HURTS at low data (the JEPA floor -> detach_backbone; the
+        # non-zero-init visual_history_proj). Flipping both at once would make a
+        # result unattributable, so the gradient path is opt-in and OFF by default.
+        self.reasoning_bev_detach = True
         if enable_reasoning:
             rkw = dict(reasoning_kwargs or {})
             rkw.setdefault("visual_history_dim", visual_history_dim)
             rkw.setdefault("ego_context_dim", egomotion_dim)
+            self.reasoning_bev_detach = bool(rkw.pop("bev_detach", True))
+            # The BEV the head attends is the FUSED map+image BEV, so its channel
+            # count is embed_dim. Derive it rather than making the caller repeat it.
+            if rkw.get("bev_context_dim") is True:
+                rkw["bev_context_dim"] = embed_dim
             self.ReasoningHead = HorizonReasoningHead(**rkw)
 
         # Trajectory decoder — swappable via planner_mode (gru, flow_matching).
@@ -155,9 +169,20 @@ class ReactiveE2E(nn.Module):
         reasoning_latent = None
         reasoning_horizon_tokens = None
         if self.ReasoningHead is not None:
+            # fused_features is already computed above, so the BEV is sitting at
+            # the call site: no reordering needed. Detached by default -> the head
+            # SEES the spatial BEV without the reasoning loss reshaping the shared
+            # trunk (see the two-switch note in __init__).
+            bev_context = None
+            if self.ReasoningHead.bev_tokenizer is not None:
+                bev_context = (
+                    fused_features.detach() if self.reasoning_bev_detach
+                    else fused_features
+                )
             reasoning_pred = self.ReasoningHead(
                 visual_ctx, ego_ctx,
                 route_context=route_context, map_context=map_context,
+                bev_context=bev_context,
             )
             reasoning_latent = reasoning_pred.reasoning_latent
             reasoning_horizon_tokens = reasoning_pred.horizon_tokens

--- a/Model/model_components/reasoning/horizon_reasoning_head.py
+++ b/Model/model_components/reasoning/horizon_reasoning_head.py
@@ -69,6 +69,54 @@ class AttentionPool(nn.Module):
         return pooled.squeeze(1)                   # [B, D]
 
 
+class BevContextTokenizer(nn.Module):
+    """Turn the unpooled BEV ``[B, C, H, W]`` into spatial context tokens.
+
+    Motivation (the #121 root cause): the head's inputs (``visual_history`` +
+    ``ego_context``) are a strict subset of the planner's, so by the
+    data-processing inequality its latent cannot carry trajectory information the
+    planner lacks — and the coupling correctly learns ``alpha ~ 0``. The one
+    signal the planner *discards* is the BEV's spatial structure: the bezier
+    planner reduces it with ``bev_features.mean(dim=(2, 3))``. Giving the head the
+    UNPOOLED BEV gives it *where* a hazard is, which the mean-pooled planner
+    context provably cannot reconstruct.
+
+    Attending the BEV cell-per-token is not viable (the default grid is 450x300 =
+    135k cells), so it is adaptively pooled to a coarse ``grid`` (default 16x16 =
+    256 tokens): cheap enough for a 1 Hz branch, but still *spatial* — unlike the
+    mean pool, it preserves location. ``grid`` is the natural ablation knob.
+
+    Args:
+        in_channels: BEV feature channels (the fused ``embed_dim``).
+        hidden_dim: decoder model dimension the tokens are projected to.
+        grid: coarse grid the BEV is pooled to, ``(h, w)``.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_dim: int,
+        grid: tuple = (16, 16),
+    ) -> None:
+        super().__init__()
+        self.grid = grid
+        self.pool = nn.AdaptiveAvgPool2d(grid)
+        self.proj = nn.Linear(in_channels, hidden_dim)
+        self.norm = nn.LayerNorm(hidden_dim)
+        # Learned 2-D position, flattened row-major like the tokens, so the
+        # decoder can tell cells apart. Without it the grid is a bag of cells and
+        # the whole point (location) is lost again.
+        self.pos_embed = nn.Parameter(
+            torch.randn(1, grid[0] * grid[1], hidden_dim) * 0.02
+        )
+
+    def forward(self, bev: torch.Tensor) -> torch.Tensor:
+        """``[B, C, H, W]`` -> ``[B, grid_h * grid_w, hidden_dim]``."""
+        pooled = self.pool(bev)                       # [B, C, gh, gw]
+        tokens = pooled.flatten(2).transpose(1, 2)    # [B, gh*gw, C]
+        return self.norm(self.proj(tokens) + self.pos_embed)
+
+
 class HorizonReasoningHead(nn.Module):
     """Predict action-relevant reasoning over five horizons from the 896 history.
 
@@ -80,13 +128,19 @@ class HorizonReasoningHead(nn.Module):
         num_layers / num_heads / dropout: horizon-decoder config.
         route_context_dim / map_context_dim: optional extra context sources;
             omit (None) to not build the corresponding token/projection.
+        bev_context_dim: if set, build a :class:`BevContextTokenizer` over the
+            fused BEV's channel count, so the horizon queries also attend the
+            UNPOOLED BEV grid (the #121 fix). None (default) keeps the head's
+            inputs exactly as they are today.
+        bev_grid: coarse grid the BEV is pooled to (ablation knob).
         taxonomy: label registry (defaults to :data:`DEFAULT_TAXONOMY`).
         teacher_embedding_dim: if set, build a training-only alignment head
             producing ``student_reasoning_embedding [B, 5, D]`` (default None).
 
     Forward:
         head(visual_history[B,896], ego_context[B,256],
-             route_context=None, map_context=None) -> HorizonReasoningPrediction
+             route_context=None, map_context=None,
+             bev_context=None) -> HorizonReasoningPrediction
     """
 
     def __init__(
@@ -100,6 +154,8 @@ class HorizonReasoningHead(nn.Module):
         dropout: float = 0.1,
         route_context_dim: Optional[int] = None,
         map_context_dim: Optional[int] = None,
+        bev_context_dim: Optional[int] = None,
+        bev_grid: tuple = (16, 16),
         taxonomy: Optional[ReasoningTaxonomy] = None,
         teacher_embedding_dim: Optional[int] = None,
     ) -> None:
@@ -129,6 +185,12 @@ class HorizonReasoningHead(nn.Module):
         self.map_proj = (
             _context_mlp(map_context_dim, hidden_dim)
             if map_context_dim is not None else None
+        )
+        # The BEV is the one SPATIAL source: the others are [B, D] vectors that
+        # each become a single token, while this becomes grid_h*grid_w tokens.
+        self.bev_tokenizer = (
+            BevContextTokenizer(bev_context_dim, hidden_dim, grid=bev_grid)
+            if bev_context_dim is not None else None
         )
 
         # Five learned horizon queries: now, +1s, +2s, +3s, +4s.
@@ -175,6 +237,7 @@ class HorizonReasoningHead(nn.Module):
         ego_context: torch.Tensor,
         route_context: Optional[torch.Tensor],
         map_context: Optional[torch.Tensor],
+        bev_context: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Stack the available per-source tokens into ``[B, N_context, hidden]``.
 
@@ -186,7 +249,15 @@ class HorizonReasoningHead(nn.Module):
             tokens.append(self.route_proj(route_context))
         if self.map_proj is not None and map_context is not None:
             tokens.append(self.map_proj(map_context))
-        return torch.stack(tokens, dim=1)  # [B, N_context, hidden]
+        context = torch.stack(tokens, dim=1)  # [B, N_vector, hidden]
+
+        # The BEV contributes a SEQUENCE of spatial tokens, not one vector token,
+        # so it is concatenated rather than stacked. The decoder interface is
+        # unchanged: only the context set grows.
+        if self.bev_tokenizer is not None and bev_context is not None:
+            bev_tokens = self.bev_tokenizer(bev_context)  # [B, gh*gw, hidden]
+            context = torch.cat([context, bev_tokens], dim=1)
+        return context
 
     def forward(
         self,
@@ -194,6 +265,7 @@ class HorizonReasoningHead(nn.Module):
         ego_context: torch.Tensor,
         route_context: Optional[torch.Tensor] = None,
         map_context: Optional[torch.Tensor] = None,
+        bev_context: Optional[torch.Tensor] = None,
     ) -> HorizonReasoningPrediction:
         """Run the reasoning head.
 
@@ -202,13 +274,15 @@ class HorizonReasoningHead(nn.Module):
             ego_context: ``[B, ego_context_dim]`` ego context from TemporalMemory.
             route_context / map_context: optional extra context (omitted if None
             or if the head was built without the corresponding projection).
+            bev_context: optional UNPOOLED BEV ``[B, C, H, W]``. Omitted if None
+            or if the head was built without ``bev_context_dim``.
 
         Returns:
             :class:`HorizonReasoningPrediction`.
         """
         B = visual_history.shape[0]
         context_tokens = self._context_tokens(
-            visual_history, ego_context, route_context, map_context
+            visual_history, ego_context, route_context, map_context, bev_context
         )  # [B, N_context, hidden]
 
         queries = self.horizon_queries.unsqueeze(0).expand(B, -1, -1)  # [B, 5, hidden]

--- a/Model/tests/test_reasoning_bev_context.py
+++ b/Model/tests/test_reasoning_bev_context.py
@@ -1,0 +1,113 @@
+"""The BEV as a spatial context source for HorizonReasoningHead (#121).
+
+What these pin down, and why each one matters:
+
+1. Without ``bev_context_dim`` the head is byte-identical to today. The BEV path
+   must be strictly additive — a run that does not ask for it must not change.
+2. The head actually USES location. This is the whole hypothesis: the planner
+   destroys *where* with ``bev_features.mean(dim=(2, 3))``, so a head fed the
+   unpooled grid must distinguish two BEVs that share a mean but differ in layout.
+   If it cannot, the extra tokens are decoration and the ablation is pointless.
+3. The two switches are independent: ``bev_detach`` controls whether the reasoning
+   loss reshapes the SHARED trunk, separately from whether the head sees the BEV.
+   The repo has twice found auxiliary gradient into the trunk hurts at low data,
+   so a result must be attributable to one or the other.
+"""
+
+import pytest
+import torch
+
+from model_components.reasoning.horizon_reasoning_head import (
+    BevContextTokenizer,
+    HorizonReasoningHead,
+)
+
+B, C, H, W = 2, 256, 45, 30
+HID = 256
+
+
+def _head(**kw):
+    return HorizonReasoningHead(hidden_dim=HID, **kw)
+
+
+def test_tokenizer_shape_and_grid_is_the_ablation_knob():
+    for grid in [(8, 8), (16, 16)]:
+        tok = BevContextTokenizer(C, HID, grid=grid)
+        out = tok(torch.randn(B, C, H, W))
+        assert out.shape == (B, grid[0] * grid[1], HID)
+
+
+def test_head_without_bev_ignores_the_bev_argument():
+    """Strictly additive: a head built without bev_context_dim is unchanged."""
+    head = _head().eval()
+    vh, ego = torch.randn(B, 896), torch.randn(B, 256)
+    bev = torch.randn(B, C, H, W)
+
+    assert head.bev_tokenizer is None
+    with torch.no_grad():
+        a = head(vh, ego).reasoning_latent
+        b = head(vh, ego, bev_context=bev).reasoning_latent
+    torch.testing.assert_close(a, b)
+
+
+def test_context_token_count_grows_by_the_grid():
+    head = _head(bev_context_dim=C, bev_grid=(16, 16))
+    vh, ego = torch.randn(B, 896), torch.randn(B, 256)
+    bev = torch.randn(B, C, H, W)
+
+    plain = head._context_tokens(vh, ego, None, None, None)
+    with_bev = head._context_tokens(vh, ego, None, None, bev)
+    assert plain.shape[1] == 2                      # visual + ego
+    assert with_bev.shape[1] == 2 + 16 * 16         # + the spatial grid
+
+
+def test_head_sees_WHERE_not_just_what():
+    """The hypothesis, as a test.
+
+    Two BEVs with the SAME per-channel mean but a different spatial layout: a
+    mean-pooled context cannot tell them apart (that is exactly what the bezier
+    planner throws away). The head must.
+    """
+    head = _head(bev_context_dim=C, bev_grid=(16, 16)).eval()
+    vh, ego = torch.randn(1, 896), torch.randn(1, 256)
+
+    left = torch.zeros(1, C, H, W)
+    left[:, :, :, : W // 2] = 1.0        # mass on the left half
+    right = torch.zeros(1, C, H, W)
+    right[:, :, :, W // 2:] = 1.0        # mass on the right half
+
+    # Precondition: mean-pooling really is blind to the difference.
+    torch.testing.assert_close(left.mean(dim=(2, 3)), right.mean(dim=(2, 3)))
+
+    with torch.no_grad():
+        a = head(vh, ego, bev_context=left).reasoning_latent
+        b = head(vh, ego, bev_context=right).reasoning_latent
+    assert not torch.allclose(a, b, atol=1e-6), (
+        "the head produced the same latent for two spatially different BEVs — "
+        "the spatial tokens are not carrying location"
+    )
+
+
+def test_gradient_reaches_the_bev_when_not_detached():
+    head = _head(bev_context_dim=C, bev_grid=(8, 8))
+    vh, ego = torch.randn(B, 896), torch.randn(B, 256)
+    bev = torch.randn(B, C, H, W, requires_grad=True)
+
+    head(vh, ego, bev_context=bev).reasoning_latent.sum().backward()
+    assert bev.grad is not None and bev.grad.abs().sum() > 0
+
+
+@pytest.mark.parametrize("detach", [True, False])
+def test_detach_switch_controls_the_shared_trunk_gradient(detach):
+    """The second switch: does the reasoning loss RESHAPE the shared BEV?"""
+    head = _head(bev_context_dim=C, bev_grid=(8, 8))
+    vh, ego = torch.randn(B, 896), torch.randn(B, 256)
+
+    trunk = torch.randn(B, C, H, W, requires_grad=True)
+    fed = trunk.detach() if detach else trunk
+
+    head(vh, ego, bev_context=fed).reasoning_latent.sum().backward()
+    if detach:
+        assert trunk.grad is None, "see-only arm leaked gradient into the trunk"
+    else:
+        assert trunk.grad is not None and trunk.grad.abs().sum() > 0

--- a/Platform/pipelines/workflows.py
+++ b/Platform/pipelines/workflows.py
@@ -704,6 +704,20 @@ def train_il(
     # (legacy in-sample behaviour). The split is a stable per-sample hash of
     # __key__, so train and eval never share a sample and both tasks agree.
     val_fraction: float = 0.0,
+    # --- Spatial BEV context for the reasoning head (#121) ---
+    # Flat scalars rather than a reasoning_kwargs dict: these are the knobs a
+    # Flyte run is launched with from the CLI, and a dict parameter cannot be set
+    # there. TWO switches, deliberately not one:
+    #   reasoning_bev_input  -> the head SEES the unpooled BEV.
+    #   reasoning_bev_detach -> whether the reasoning loss also RESHAPES the
+    #                           shared trunk through that path.
+    # This repo has twice found auxiliary gradient into the shared backbone hurts
+    # at low data (the JEPA floor -> detach_backbone; the non-zero-init
+    # visual_history_proj). Flipping both at once makes a result unattributable,
+    # so see-but-don't-reshape is the default and the gradient path is opt-in.
+    reasoning_bev_input: bool = False,
+    reasoning_bev_grid: int = 16,
+    reasoning_bev_detach: bool = True,
 ) -> TrainOutput:
     """Train AutoE2E model on pre-extracted WebDataset shards.
 
@@ -790,14 +804,41 @@ def train_il(
 
     # Model. fusion_mode is gone (BEV hardcoded inside ReactiveE2E); the model
     # now also owns the map branch, so its forward requires a map_input tensor.
+    reasoning_kwargs: Optional[dict] = None
+    if enable_reasoning and reasoning_bev_input:
+        # bev_context_dim=True -> ReactiveE2E derives the channel count from the
+        # FUSED BEV (embed_dim), so the two cannot drift apart.
+        reasoning_kwargs = {
+            "bev_context_dim": True,
+            "bev_grid": (reasoning_bev_grid, reasoning_bev_grid),
+            "bev_detach": reasoning_bev_detach,
+        }
+
     model = AutoE2E(
         backbone=bb, num_views=num_views, embed_dim=256,
         is_pretrained=True,
         enable_reasoning=enable_reasoning, reasoning_mode=reasoning_mode,
+        reasoning_kwargs=reasoning_kwargs,
         enable_world_model=enable_world_model,
     ).to(device)
     print(f"Reasoning: {'on' if enable_reasoning else 'off'}"
           + (f" (mode={reasoning_mode})" if enable_reasoning else ""))
+    if enable_reasoning and reasoning_bev_input:
+        print(f"  spatial BEV context: {reasoning_bev_grid}x{reasoning_bev_grid} grid, "
+              f"gradient to shared trunk: {'OFF (see-only)' if reasoning_bev_detach else 'ON'}")
+        # Say the geometry out loud, from the shard manifests. The whole point of
+        # feeding the head the unpooled BEV is that it carries WHERE a hazard is.
+        # On a dataset without calibration the grid is a learned warp (a cell maps
+        # to nowhere), so a null result would be uninterpretable — we could not tell
+        # whether the idea is wrong or the BEV is meaningless. Better a loud line in
+        # the log than a silently worthless run.
+        from data_parsing.pre_extracted import load_projection_from_manifest
+        for sd in shard_dirs:
+            _, geom = load_projection_from_manifest(sd)
+            note = ("  <-- WARNING: pseudo geometry. The BEV grid is a learned warp, "
+                    "not a bird's-eye view; a null result here is not interpretable."
+                    if geom == "pseudo" else "")
+            print(f"  geometry[{os.path.basename(str(sd))}]: {geom!r}{note}")
     print(f"World Model: {'on' if enable_world_model else 'off'}")
 
     # Optimizer + Loss


### PR DESCRIPTION
## Why

In #121 you traced the reasoning coupling to a **learned no-op** (`reasoning_coupling.alpha ≈ 0.004`
after 60 epochs, from its zero init) and gave the reason: the head consumes `visual_history` +
`ego_context`, which is a **strict subset** of what the planner consumes (`visual_history` + `ego` +
**pooled** BEV). By the data-processing inequality the reasoning latent cannot carry trajectory
information the planner lacks, so `alpha → 0` is the optimizer being **correct**, not a bug.

And you named the one principled fix:

> *"Feed the reasoning head the UNPOOLED spatial BEV that the bezier planner discards via
> `bev_features.mean(dim=(2,3))`. Attending the full `[B,C,H,W]` BEV gives the reasoning latent
> spatial hazard information the mean-pooled planner context cannot reconstruct."*

**This PR implements that.** Without it, the reasoning branch we are about to merge is — by your own
analysis — a branch the model provably ignores.

## What this adds

**`BevContextTokenizer`** — turns the unpooled BEV `[B, C, H, W]` into spatial context tokens:
adaptive-average-pool to a coarse grid (default 16×16), project each cell to `hidden_dim`, add a
learned 2-D positional embedding.

Attending the BEV cell-per-token is not viable — the default grid is 450×300, i.e. **135k cells**. The
coarse grid keeps *where* a hazard is (which the mean-pool destroys) while keeping the token count
sane for a 1 Hz branch. **The grid size is the ablation knob.**

## Design — it fits your head without touching the decoder

The BEV enters `HorizonReasoningHead` as a **third context source**, alongside the `route_context_dim`
/ `map_context_dim` slots **you already left open**. It is the only *spatial* source, so it
contributes a **sequence** of tokens (`cat`) rather than a single vector token (`stack`) — but the
decoder interface is unchanged: only the context set grows.

`fused_features` is already computed at the call site in `ReactiveE2E`, so **no reordering is needed**.

### Two independent switches, deliberately not one

- **`reasoning_bev_input`** — the head **sees** the spatial BEV.
- **`reasoning_bev_detach`** — whether the reasoning loss also **reshapes** the shared trunk through
  that path.

This repo has **twice** found that routing auxiliary gradient into the shared backbone **hurts at low
data** (the JEPA loss floor → `detach_backbone`; the non-zero-init `visual_history_proj`). Flipping
both at once would make a result unattributable, so **see-but-don't-reshape is the default** and the
gradient path is opt-in — as you asked for in #121.

## Also: `train_il` never passed `reasoning_kwargs`

`train_il` builds `AutoE2E` without threading `reasoning_kwargs` (`workflows.py:793-798`), so
`HorizonReasoningHead`'s optional context slots — `route`, `map`, and now the BEV — **cannot be turned
on by any training run in the repo**. The feature exists and is unreachable.

This PR threads three flat scalars (`reasoning_bev_input`, `reasoning_bev_grid`,
`reasoning_bev_detach`) rather than a dict, because those are the knobs a Flyte run is launched with
from the CLI and a dict parameter cannot be set there.

When the BEV is on, the run also **prints each shard's geometry**. The whole argument for the unpooled
BEV is that it carries *where* a hazard is; on a dataset without calibration the grid is a learned
warp and a cell maps to nowhere, so a null result there would be uninterpretable. Better a loud line
in the log than a silently worthless run.

## Cost — measured, and it is the capacity control

| Arm | Params | Peak, `bs=1` (RTX 3090, fp32, WM off) |
|---|---|---|
| imitation only | 91.35 M | 9.97 GB |
| reasoning, current inputs | 93.91 M | 9.98 GB |
| **reasoning + unpooled BEV** | **94.04 M** | **9.98 GB** |

**The BEV costs +0.132 M params (+0.14 %) and under 10 MB.** That is deliberate: **if the BEV arm beats
the no-BEV arm, it cannot be capacity — there is no capacity to attribute. It can only be the
information.** Fixed *ex ante*, before any run.

Grid as the ablation knob: 8×8 → +0.083 M · 16×16 → +0.132 M · 32×32 → +0.328 M.

## Strictly additive

Built without `bev_context_dim`, the head is **byte-identical to today** (`test_head_without_bev_
ignores_the_bev_argument`). Default off.

## Scope — not in this PR

- The episode-count sweep and the `alpha` curve. That needs the data scaling #121 tracks, and I'd
  rather report a curve than promise a number.
- The `sample_uid` prerequisite — that's yours, and I won't duplicate it.

## Tests

Four files, +256 / −3. `ruff` clean · `mypy` clean (135 files) · `pytest Model/tests`: **422 passed**.

The tests pin the hypothesis itself: **two BEVs with the same per-channel mean but a different spatial
layout must produce different latents.** If the head cannot tell them apart, the extra tokens are
decoration and the ablation is pointless. Plus the two switches (see-only leaks no gradient into the
trunk; the gradient path does), and the byte-identical-without-the-BEV check.
