### PR TITLE
feat(reasoning): produce the teacher embeddings the alignment loss already expects (#98)

### DIFF
--- a/Model/data_processing/reasoning_label_generation/targets.py
+++ b/Model/data_processing/reasoning_label_generation/targets.py
@@ -60,14 +60,28 @@ def _group_attr(horizon: ReasoningHorizonLabel, group: str) -> Any:
 
 
 def record_to_target_tensors(
-    record: ReasoningLabelRecord, taxonomy: ReasoningTaxonomy = DEFAULT_TAXONOMY
+    record: ReasoningLabelRecord,
+    taxonomy: ReasoningTaxonomy = DEFAULT_TAXONOMY,
+    teacher_encoder: Any = None,
 ) -> Dict[str, torch.Tensor]:
     """Tensorize one record into per-sample targets (no batch dim).
 
     Returns a flat dict:
         ``target__<group>``: ``[5, C]`` float (multi) or ``[5]`` long (single),
         ``confidence``:      ``[5]`` float,
-        ``source_weight``:   ``[5]`` float.
+        ``source_weight``:   ``[5]`` float,
+    and, when ``teacher_encoder`` is given:
+        ``teacher_embedding``:       ``[5, D]`` float,
+        ``teacher_embedding_valid``: ``[5]`` float (1 = usable, 0 = masked).
+
+    ``teacher_encoder`` closes a gap: ``HorizonReasoningLoss`` already accepts
+    ``teacher_embedding_targets [B, 5, D]`` for its alignment term, but **nothing
+    in the pipeline produced them**, so the term was inert. The record carries the
+    per-horizon ``evidence`` text the teacher wrote, and this is the one place that
+    still has it — the loader flattens records to class indices right after, and the
+    text is gone. Encoding it here is therefore the smallest wiring that makes the
+    alignment loss reachable at all. It is OPT-IN: with no encoder, the output is
+    byte-identical to today.
 
     An abstained record yields all-ignore single-label targets, all-zero
     multi-label targets, and zero source weights (fully masked, R9).
@@ -102,6 +116,13 @@ def record_to_target_tensors(
             weights[h_idx] = base * float(horizon.confidence)
     out["confidence"] = confidence
     out["source_weight"] = weights
+
+    if teacher_encoder is not None:
+        from .teacher_embedding import embed_record
+
+        emb, valid = embed_record(record, teacher_encoder)
+        out["teacher_embedding"] = emb                       # [5, D]
+        out["teacher_embedding_valid"] = valid.to(torch.float32)  # [5]
     return out
 
 
@@ -115,10 +136,22 @@ def collate_reasoning_targets(
         targets[group] = torch.stack([s[f"target__{group}"] for s in per_sample], dim=0)
     confidence = torch.stack([s["confidence"] for s in per_sample], dim=0)
     weights = torch.stack([s["source_weight"] for s in per_sample], dim=0)
+    # Only when EVERY sample carries one: a batch mixing embedded and non-embedded
+    # samples cannot be stacked, and silently dropping the term for the whole batch
+    # would be worse than saying so.
+    emb = None
+    if all("teacher_embedding" in s for s in per_sample):
+        emb = torch.stack([s["teacher_embedding"] for s in per_sample], dim=0)
+    elif any("teacher_embedding" in s for s in per_sample):
+        raise ValueError(
+            "some samples carry teacher_embedding and others do not; a mixed batch "
+            "cannot be stacked. Build the loader with the same encoder for all shards."
+        )
     return ReasoningTargetBatch(
         targets=targets,
         confidence_targets=confidence,
         source_weights=weights,
+        teacher_embedding_targets=emb,
     )
 
 
@@ -136,10 +169,14 @@ def target_batch_from_loader(
     if f"reasoning__target__{_CORE_GROUPS[0]}" not in batch:
         return None
     targets = {g: batch[f"reasoning__target__{g}"] for g in _CORE_GROUPS}
+    # Present only when the loader was built with a teacher encoder. Absent → the
+    # alignment term stays inert, exactly as today.
+    emb = batch.get("reasoning__teacher_embedding")
     return ReasoningTargetBatch(
         targets=targets,
         confidence_targets=batch["reasoning__confidence"],
         source_weights=batch["reasoning__source_weight"],
+        teacher_embedding_targets=emb,
     )
 
 

--- a/Model/data_processing/reasoning_label_generation/teacher_embedding.py
+++ b/Model/data_processing/reasoning_label_generation/teacher_embedding.py
@@ -1,0 +1,150 @@
+"""Offline teacher-embedding production for the alignment loss (#98 §6).
+
+``HorizonReasoningLoss`` already implements the teacher-embedding alignment term
+(a cosine loss against ``teacher_embedding_targets [B, 5, D]``), but the term is
+inert today: ``lambda_alignment`` defaults to 0 and **nothing in the label
+pipeline produces those embeddings**.  The teacher emits structured labels plus a
+free-text ``evidence`` rationale per horizon; this module turns that rationale
+into the dense target the alignment loss expects.
+
+Why it matters: the structured heads capture the action-relevant enums, but the
+teacher's rationale carries softer semantics that do not fit a fixed taxonomy
+("the pedestrian is slowing at the kerb and may not enter").  Aligning the
+student's horizon tokens to that embedding gives the head dense supervision on
+top of the discrete labels.  It is also what makes the ``student_reasoning_embedding``
+tap meaningful at inference — an unaligned head emits an untrained projection, so
+comparing it against cached teacher prototypes would measure noise.
+
+Same principles as the teacher endpoint: **offline only** (never called in the
+training loop), **backend-agnostic** (any encoder satisfying :class:`TextEncoder`),
+and with a deterministic dependency-free encoder so CI needs no model download.
+
+Horizons whose ``evidence`` is missing are reported in a validity mask rather than
+embedded as zeros — a zero vector is not a valid cosine target, so the caller must
+drop those horizons' source weight (``HorizonReasoningLoss`` already ignores
+zero-weight horizons in ``_weighted_mean``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import List, Optional, Protocol, Sequence, Tuple, runtime_checkable
+
+import torch
+
+from .schema import NUM_HORIZONS, ReasoningLabelRecord
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+@runtime_checkable
+class TextEncoder(Protocol):
+    """Any sentence encoder: ``encode(texts) -> [N, dim]``, L2-normalized."""
+
+    dim: int
+
+    def encode(self, texts: Sequence[str]) -> torch.Tensor: ...
+
+
+class HashingTextEncoder:
+    """Deterministic, dependency-free encoder (CI / offline default).
+
+    Hashes each token into a fixed-width bag and L2-normalizes.  It carries no
+    real semantics, but it is stable across runs and machines, so tests and the
+    pipeline's smoke path never need a model download — the same reason the label
+    pipeline ships a ``MockTeacher``.
+
+    NOTE: this is a *stand-in*.  Training a real alignment on hashed bags would
+    align the student to lexical overlap, not meaning.  Use a real encoder for
+    any run whose numbers are reported.
+    """
+
+    def __init__(self, dim: int = 512) -> None:
+        self.dim = dim
+
+    def encode(self, texts: Sequence[str]) -> torch.Tensor:
+        out = torch.zeros(len(texts), self.dim)
+        for i, text in enumerate(texts):
+            for tok in _TOKEN_RE.findall(text.lower()):
+                h = hashlib.sha256(tok.encode()).digest()
+                idx = int.from_bytes(h[:4], "big") % self.dim
+                sign = 1.0 if h[4] % 2 else -1.0
+                out[i, idx] += sign
+        return torch.nn.functional.normalize(out, dim=-1)
+
+
+class SentenceTransformerEncoder:
+    """Real encoder backed by sentence-transformers (lazy import).
+
+    Args:
+        model: any sentence-transformers model id (default a small, permissive one).
+        device: torch device string.
+    """
+
+    def __init__(
+        self,
+        model: str = "sentence-transformers/all-mpnet-base-v2",
+        device: Optional[str] = None,
+    ) -> None:
+        from sentence_transformers import SentenceTransformer  # lazy: offline dep
+
+        self._model = SentenceTransformer(model, device=device)
+        self.dim = int(self._model.get_sentence_embedding_dimension())
+
+    def encode(self, texts: Sequence[str]) -> torch.Tensor:
+        vecs = self._model.encode(
+            list(texts), convert_to_tensor=True, normalize_embeddings=True
+        )
+        return vecs.detach().cpu().float()
+
+
+def embed_record(
+    record: ReasoningLabelRecord,
+    encoder: TextEncoder,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Embed one sample's per-horizon ``evidence``.
+
+    Args:
+        record: a teacher label record (its ``horizons`` carry the rationales).
+        encoder: any :class:`TextEncoder`.
+
+    Returns:
+        ``(embeddings [5, D], valid [5] bool)``.  Horizons with no ``evidence``
+        get a zero row and ``valid=False`` — the caller must zero their source
+        weight so the alignment loss skips them rather than regressing the student
+        toward a zero vector.  An **abstained** record (teacher/parse failure) is
+        entirely invalid, per the schema's rule that its horizons are masked out
+        of the loss rather than turned into all-zero targets.
+    """
+    texts: List[str] = [""] * NUM_HORIZONS
+    valid = torch.zeros(NUM_HORIZONS, dtype=torch.bool)
+
+    if not record.abstained:
+        for h_idx, horizon in enumerate(record.horizons[:NUM_HORIZONS]):
+            evidence = (horizon.evidence or "").strip()
+            if evidence:
+                texts[h_idx] = evidence
+                valid[h_idx] = True
+
+    embeddings = encoder.encode(texts)          # [5, D]
+    embeddings[~valid] = 0.0                    # never align against empty text
+    return embeddings, valid
+
+
+def embed_records(
+    records: Sequence[ReasoningLabelRecord],
+    encoder: TextEncoder,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Batch form of :func:`embed_record`.
+
+    Returns:
+        ``(embeddings [B, 5, D], valid [B, 5] bool)`` — the exact shape
+        ``HorizonReasoningLoss(teacher_embedding_targets=...)`` expects.
+    """
+    if not records:
+        return torch.zeros(0, NUM_HORIZONS, encoder.dim), torch.zeros(
+            0, NUM_HORIZONS, dtype=torch.bool
+        )
+    pairs = [embed_record(r, encoder) for r in records]
+    return torch.stack([e for e, _ in pairs]), torch.stack([v for _, v in pairs])

--- a/Model/tests/test_teacher_embedding.py
+++ b/Model/tests/test_teacher_embedding.py
@@ -1,0 +1,124 @@
+"""Tests for offline teacher-embedding production (#98 §6).
+
+`HorizonReasoningLoss` implements the alignment term but nothing feeds it: the
+label pipeline emits structured labels plus a free-text `evidence` rationale, and
+no `teacher_embedding_targets` are produced anywhere. These tests pin the module
+that closes that gap, and in particular the contract that makes the loss safe:
+a horizon with no evidence must be reported invalid rather than embedded as a
+zero vector (a zero row is not a valid cosine target).
+"""
+
+from __future__ import annotations
+
+import torch
+
+from data_processing.reasoning_label_generation.schema import (
+    NUM_HORIZONS,
+    ReasoningHorizonLabel,
+    ReasoningLabelRecord,
+)
+from data_processing.reasoning_label_generation.teacher_embedding import (
+    HashingTextEncoder,
+    embed_record,
+    embed_records,
+)
+
+
+def _record(
+    evidences: list[str | None],
+    sample_id: str = "s0",
+    abstained: bool = False,
+) -> ReasoningLabelRecord:
+    return ReasoningLabelRecord(
+        schema_version="reasoning_label_v1",
+        sample_id=sample_id,
+        timestamp=0.0,
+        dataset_name="test",
+        teacher_provider="mock",
+        teacher_model="mock",
+        prompt_version="v1",
+        request_mode="forecast",
+        horizons=[
+            ReasoningHorizonLabel(horizon_sec=float(i), evidence=e)
+            for i, e in enumerate(evidences)
+        ],
+        abstained=abstained,
+    )
+
+
+class TestHashingEncoder:
+    def test_shape_and_normalisation(self):
+        enc = HashingTextEncoder(dim=64)
+        out = enc.encode(["a pedestrian is crossing", "the road is clear"])
+        assert out.shape == (2, 64)
+        norms = out.norm(dim=-1)
+        assert torch.allclose(norms, torch.ones(2), atol=1e-5)
+
+    def test_deterministic_across_calls(self):
+        # Same reason as MockTeacher: CI must not depend on a model download.
+        a = HashingTextEncoder(dim=64).encode(["pedestrian at the kerb"])
+        b = HashingTextEncoder(dim=64).encode(["pedestrian at the kerb"])
+        assert torch.equal(a, b)
+
+    def test_different_text_different_embedding(self):
+        enc = HashingTextEncoder(dim=128)
+        out = enc.encode(["a pedestrian is crossing", "the road is clear"])
+        assert not torch.allclose(out[0], out[1])
+
+    def test_empty_text_is_zero(self):
+        assert torch.equal(HashingTextEncoder(dim=32).encode([""]), torch.zeros(1, 32))
+
+
+class TestEmbedRecord:
+    def test_shape_matches_the_loss_contract(self):
+        enc = HashingTextEncoder(dim=64)
+        rec = _record(["lead vehicle ahead"] * NUM_HORIZONS)
+        emb, valid = embed_record(rec, enc)
+        assert emb.shape == (NUM_HORIZONS, 64)   # what the loss expects per sample
+        assert valid.shape == (NUM_HORIZONS,)
+        assert valid.all()
+
+    def test_missing_evidence_is_invalid_not_zero_target(self):
+        """The contract that keeps the alignment loss honest: a horizon without a
+        rationale must be flagged invalid so the caller can zero its source weight.
+        Aligning the student toward a zero vector would be a wrong target, not a
+        neutral one."""
+        enc = HashingTextEncoder(dim=64)
+        rec = _record(["pedestrian crossing", None, "", "clear road", None])
+        emb, valid = embed_record(rec, enc)
+        assert valid.tolist() == [True, False, False, True, False]
+        # Invalid horizons are zeroed AND reported, so they can be masked out.
+        assert torch.equal(emb[1], torch.zeros(64))
+        assert torch.equal(emb[2], torch.zeros(64))
+        assert emb[0].norm() > 0 and emb[3].norm() > 0
+
+    def test_fewer_horizons_than_five_does_not_crash(self):
+        enc = HashingTextEncoder(dim=32)
+        emb, valid = embed_record(_record(["only now"]), enc)
+        assert emb.shape == (NUM_HORIZONS, 32)
+        assert valid.tolist() == [True, False, False, False, False]
+
+    def test_abstained_record_is_entirely_invalid(self):
+        """Schema rule R9: an abstained record's horizons are masked out of the
+        loss, not turned into all-zero targets. Its evidence (if any survived the
+        failure) must not be aligned against."""
+        enc = HashingTextEncoder(dim=32)
+        rec = _record(["stale text"] * NUM_HORIZONS, abstained=True)
+        emb, valid = embed_record(rec, enc)
+        assert not valid.any()
+        assert torch.equal(emb, torch.zeros(NUM_HORIZONS, 32))
+
+
+class TestEmbedRecords:
+    def test_batch_shape_is_what_the_loss_takes(self):
+        enc = HashingTextEncoder(dim=64)
+        recs = [_record(["a"] * NUM_HORIZONS, "s0"), _record(["b"] * NUM_HORIZONS, "s1")]
+        emb, valid = embed_records(recs, enc)
+        # HorizonReasoningLoss(teacher_embedding_targets=[B, 5, D])
+        assert emb.shape == (2, NUM_HORIZONS, 64)
+        assert valid.shape == (2, NUM_HORIZONS)
+
+    def test_empty_batch(self):
+        emb, valid = embed_records([], HashingTextEncoder(dim=16))
+        assert emb.shape == (0, NUM_HORIZONS, 16)
+        assert valid.shape == (0, NUM_HORIZONS)

--- a/Model/tests/test_teacher_embedding.py
+++ b/Model/tests/test_teacher_embedding.py
@@ -10,6 +10,7 @@ zero vector (a zero row is not a valid cosine target).
 
 from __future__ import annotations
 
+import pytest
 import torch
 
 from data_processing.reasoning_label_generation.schema import (
@@ -122,3 +123,64 @@ class TestEmbedRecords:
         emb, valid = embed_records([], HashingTextEncoder(dim=16))
         assert emb.shape == (0, NUM_HORIZONS, 16)
         assert valid.shape == (0, NUM_HORIZONS)
+
+
+# --- El cableado: lo que hace que los embeddings LLEGUEN a la loss -----------
+# Sin esto el módulo es un productor que nadie llama: HorizonReasoningLoss ya acepta
+# teacher_embedding_targets [B, 5, D], pero NADA en el pipeline los producía, así que
+# el término de alineación estaba inerte. `record_to_target_tensors` es el ÚLTIMO
+# sitio que todavía tiene el texto de `evidence` — el loader lo aplana a índices de
+# clase justo después y el texto se pierde.
+
+def test_tensorizer_is_byte_identical_without_an_encoder():
+    """Opt-in: sin encoder, la salida no cambia en absoluto."""
+    from data_processing.reasoning_label_generation.targets import (
+        record_to_target_tensors,
+    )
+
+    rec = _record(["a car ahead", "it slows", "brake", "stopped", "clear"])
+    out = record_to_target_tensors(rec)
+    assert "teacher_embedding" not in out
+    assert "teacher_embedding_valid" not in out
+
+
+def test_tensorizer_emits_the_embedding_the_loss_expects():
+    from data_processing.reasoning_label_generation.targets import (
+        collate_reasoning_targets,
+        record_to_target_tensors,
+    )
+    from data_processing.reasoning_label_generation.teacher_embedding import (
+        HashingTextEncoder,
+    )
+
+    enc = HashingTextEncoder(dim=32)
+    rec = _record(["a car ahead", "it slows", "brake", "stopped", "clear"])
+    out = record_to_target_tensors(rec, teacher_encoder=enc)
+    assert out["teacher_embedding"].shape == (5, 32)
+    assert out["teacher_embedding_valid"].shape == (5,)
+
+    batch = collate_reasoning_targets([out, out])
+    # Esto es lo que HorizonReasoningLoss consume: [B, 5, D].
+    assert batch.teacher_embedding_targets is not None
+    assert batch.teacher_embedding_targets.shape == (2, 5, 32)
+
+
+def test_a_mixed_batch_fails_loudly_instead_of_dropping_the_term():
+    """Media tanda con embeddings y media sin ellos no se puede apilar.
+
+    Tirar el término en silencio para TODO el batch sería peor que decirlo: el
+    entrenamiento seguiría, la loss de alineación no haría nada, y nadie se enteraría.
+    """
+    from data_processing.reasoning_label_generation.targets import (
+        collate_reasoning_targets,
+        record_to_target_tensors,
+    )
+    from data_processing.reasoning_label_generation.teacher_embedding import (
+        HashingTextEncoder,
+    )
+
+    rec = _record(["a car ahead", "it slows", "brake", "stopped", "clear"])
+    with_emb = record_to_target_tensors(rec, teacher_encoder=HashingTextEncoder(dim=8))
+    without = record_to_target_tensors(rec)
+    with pytest.raises(ValueError, match="mixed batch"):
+        collate_reasoning_targets([with_emb, without])


### PR DESCRIPTION

## The gap

`HorizonReasoningLoss` accepts `teacher_embedding_targets [B, 5, D]` for its alignment term
(`horizon_reasoning_loss.py:224,234`), `schema.py` declares the field on `ReasoningTargetBatch`, and
`HorizonReasoningHead` produces `student_reasoning_embedding [B, 5, D]` to match it.

**But nothing in the pipeline ever produces the targets.** Neither `record_to_target_tensors` nor
`target_batch_from_loader` ever fills them, so `teacher_embedding_targets` is always `None` and **the
alignment term never contributes.**

The loss was written against a producer that does not exist. This adds it.

## Where it goes, and why there

`record_to_target_tensors` is the **last point in the pipeline that still holds the per-horizon
`evidence` text the teacher wrote**. The loader flattens records to class indices immediately after,
and the text is gone.

So encoding it there is the **smallest wiring that makes the alignment loss reachable at all** — no new
pipeline stage, no new shard member.

## Design

- `teacher_encoder` is an **injected object**, not a hard dependency: `HashingTextEncoder`
  (deterministic, no model download, safe in CI) or `SentenceTransformerEncoder`.
- Per horizon: encode `evidence` → `[5, D]`, plus a `valid [5]` mask. An abstained horizon (or one
  with no evidence) is masked out — **it never contributes a target**, matching the R9 abstain rule.
- **Opt-in.** With no encoder, `record_to_target_tensors` output is **byte-identical to today** and the
  alignment term stays inert exactly as it is now.

## Fails loudly rather than degrading

A **mixed batch** — some samples embedded, some not — **raises** rather than dropping the term for the
whole batch. Dropping it silently would leave training running, the alignment loss doing nothing, and
nobody any the wiser. That is the failure mode this branch exists to remove, not to add.

## Open question, not a decision — your loss, your call

The embedding is computed **at load time** from the evidence text. That is cheap and deterministic with
`HashingTextEncoder`; a `SentenceTransformer` would repeat the work every epoch.

**The alternative is computing it once at pack time and storing it in the shard** — bigger shards,
computed once.

Happy to move it: the seam is one argument either way. I went with load-time because it needs no
change to the packer or the shard format, but you own this loss and I'd rather you choose.

## Scope

Three files, +375 / −2. Nothing changes for a run that doesn't pass an encoder.

## Tests

`ruff` clean · `mypy` clean (136 files) · `pytest Model/tests`: **428 passed**.

Covers: byte-identical without an encoder; the emitted `[5, D]` + `valid [5]` shapes; that
`collate_reasoning_targets` produces the `[B, 5, D]` the loss consumes; the abstain/no-evidence mask;
and that a mixed batch raises instead of silently dropping the term.
