### PR TITLE
fix(model): reject removed geometry kwargs instead of silently dropping calibration

### DIFF
--- a/Model/README.md
+++ b/Model/README.md
@@ -14,22 +14,46 @@
 
 **AutoE2E outputs a prediction of:**
 - Future driving trajectory (modelled as future acceleration and curvature values over a 6.4s future horizon at 10Hz sampling rate)
-- `ego_hidden` — 256-dim final GRU hidden state from `TrajectoryPlanner` summarising the planner's intent over the prediction horizon. Conditions `FutureState`; replaces the legacy compressed visual feature vector / rolling visual history buffer.
 
 **During training, and for purposes of model introspection, AutoE2E also predicts:**
-- Future visual features at 1.6s intervals for a 6.4s future horizon (what does the future feature representation of the scene look like, this is used for a feature reconstruction loss similar to JEPA)
+- Future visual features at 1.6s intervals for a 6.4s future horizon (what does the future feature representation of the scene look like, this is used for a feature reconstruction loss similar to JEPA). Opt-in via `enable_world_model=True`.
 
 **Forward signature:**
 ```python
-trajectory, ego_hidden, future_visual_features = model(
-    visual_tiles,        # (B, V, 3, H, W) — 7 cameras
-    map_tile,            # (B, 3, H_map, W_map) — BEV nav-map image
+trajectory = model(
+    camera_tiles,        # (B, V, 3, H, W) — 7 cameras
+    map_input,           # (B, 3, H_map, W_map) — BEV nav-map image
     visual_history,      # (B, 896) — frame-to-frame visual memory
     egomotion_history,   # (B, 256)
-    camera_params=None,  # (B, V, 3, 4) optional, used by BEV fusion
-    mode="train",        # "train" returns future_visual_features; otherwise None
+    projection=None,     # CameraProjectionModel operator — the geometry ABI
+    geometry_type=None,  # "pinhole" | "rectified_pinhole" | "ftheta" | "pseudo"
+    mode="infer",
 )
 ```
+
+`forward` returns the trajectory `(B, num_timesteps * num_signals)`, or the tuple
+`(trajectory, future_state_pred)` when the World Model is enabled **and**
+`mode="train"`. The pre-#94 3-tuple return no longer exists.
+
+**Camera geometry is an operator, not a matrix.** There is no `camera_params`
+argument: `#77`/`#107` replaced the `(B, V, 3, 4)` matrix with a projection
+operator, so that fisheye (F-Theta) calibration is expressible and the
+geometry travels with the data.
+
+```python
+from model_components.view_fusion.projection import PinholeProjection
+
+trajectory = model(
+    camera_tiles, map_input, visual_history, egomotion_history,
+    projection=PinholeProjection(camera_params),  # (B, V, 3, 4) intrinsic @ extrinsic
+    geometry_type="pinhole", mode="infer",
+)
+```
+
+Passing no `projection` falls back to `geometry_type="pseudo"` — a **learned
+spatial prior, not real geometry** (shape-testing and ablation only). Passing the
+removed `camera_params=` argument now raises `TypeError` rather than being
+absorbed by `**kwargs` and silently dropping your calibration.
 
 **To learn the driving policy:**
 - Imitation Learning is used to penalize trajectory prediction as well as World Model Simulation based Reinforcement Learning

--- a/Model/data_parsing/kit_scenes/forward_pass_test.py
+++ b/Model/data_parsing/kit_scenes/forward_pass_test.py
@@ -44,6 +44,7 @@ sys.path.insert(0, str(_MODEL_DIR))
 
 from data_parsing.kit_scenes import KitScenesDataset  # noqa: E402
 from model_components.auto_e2e import AutoE2E  # noqa: E402
+from model_components.view_fusion.projection import PinholeProjection  # noqa: E402
 
 
 def load_dataset(
@@ -94,6 +95,18 @@ def load_dataset(
     return dataset, batch_device
 
 
+def build_projection(batch: dict) -> PinholeProjection:
+    """Wrap KITScenes' (B, V, 3, 4) pinhole matrices as a projection operator.
+
+    KITScenes ships per-camera intrinsic @ extrinsic matrices already scaled to the
+    backbone's resize/crop transform, which is exactly what PinholeProjection
+    consumes — so the geometry needs no conversion, only wrapping. Passing the raw
+    matrix as `camera_params=` (the pre-#77/#107 signature) now raises TypeError;
+    before, `**kwargs` swallowed it and the model ran on `pseudo` geometry.
+    """
+    return PinholeProjection(batch["camera_params"])
+
+
 def test_bev_infer_mode(
     batch: dict,
     device: torch.device,
@@ -108,19 +121,19 @@ def test_bev_infer_mode(
     ).to(device)
 
     t0 = time.time()
-    trajectory, ego_hidden, _ = model(
+    trajectory = model(
         batch["visual_tiles"],
         batch["map_tile"],
         batch["visual_history"],
         batch["egomotion_history"],
-        camera_params=batch["camera_params"],
+        projection=build_projection(batch),
+        geometry_type="pinhole",
         mode="infer",
     )
     t_forward = time.time() - t0
 
     print(f"[bev_infer] Forward pass time: {t_forward:.2f}s")
-    print(f"[bev_infer] Trajectory shape: {trajectory.shape}")
-    print(f"[bev_infer] Ego Hidden shape: {tuple(ego_hidden.shape)}")
+    print(f"[bev_infer] Trajectory shape: {tuple(trajectory.shape)}")
     print("[bev_infer] PASSED")
 
 
@@ -129,30 +142,36 @@ def test_bev_train_mode(
     device: torch.device,
     pretrained_backbone: bool,
 ) -> None:
-    """Test forward pass with BEV fusion in training mode."""
+    """Test forward pass with BEV fusion + World Model in training mode."""
     print("[bev_train] Testing forward pass with BEV fusion in train mode")
 
     torch.cuda.empty_cache()
+    # enable_world_model=True is what makes mode="train" return the JEPA future
+    # state alongside the trajectory. forward returns the TRAJECTORY, not a loss:
+    # the planner objective is computed by the training loop, not inside forward.
     model = AutoE2E(
         is_pretrained=pretrained_backbone,
+        enable_world_model=True,
     ).to(device)
 
     t0 = time.time()
-    planner_loss, ego_hidden, future_visual_features = model(
+    trajectory, future_state_pred = model(
         batch["visual_tiles"],
         batch["map_tile"],
         batch["visual_history"],
         batch["egomotion_history"],
-        camera_params=batch["camera_params"],
+        projection=build_projection(batch),
+        geometry_type="pinhole",
         trajectory_target=batch["trajectory_target"],
         mode="train",
     )
     t_forward = time.time() - t0
 
     print(f"[bev_train] Forward pass time: {t_forward:.2f}s")
-    print(f"[bev_train] Planner loss: {planner_loss.item():.4f}")
-    print(f"[bev_train] Ego Hidden shape: {tuple(ego_hidden.shape)}")
-    print(f"[bev_train] Future Visual Features shapes: {[tuple(f.shape) for f in future_visual_features]}")
+    print(f"[bev_train] Trajectory shape: {tuple(trajectory.shape)}")
+    # predict_future returns a LIST of num_future_steps feature tensors, not a tensor.
+    print(f"[bev_train] Future state prediction: "
+          f"{[tuple(f.shape) for f in future_state_pred]}")
     print("[bev_train] PASSED")
 
 

--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -5,6 +5,17 @@ import torch.nn as nn
 from .reactive_e2e import ReactiveE2E
 from .world_action_model import RollingHistoryBuffer, WorldActionModel
 
+# Geometry arguments from the pre-#77/#107 forward signature. They are no longer
+# parameters, so **kwargs would absorb them and forward on to the planner, which
+# also takes **kwargs — the value is dropped without a word and the run silently
+# falls back to geometry_type="pseudo", a LEARNED PRIOR, not real geometry. A
+# caller passing calibration gets a model that never receives it, and nothing in
+# the logs or the outputs says so. Reject them by name instead.
+_REMOVED_GEOMETRY_KWARGS = (
+    "camera_params", "camera_matrices", "calib", "calibration",
+    "intrinsics", "extrinsics", "projection_matrix",
+)
+
 
 class AutoE2E(nn.Module):
     def __init__(self, backbone="swin_v2_tiny", num_views=7, embed_dim=256,
@@ -123,7 +134,25 @@ class AutoE2E(nn.Module):
 
         Returns:
             trajectory, or (trajectory, aux_outputs) in train mode with a branch on.
+
+        Raises:
+            TypeError: if a removed geometry kwarg (e.g. ``camera_params``) is
+                passed. See ``_REMOVED_GEOMETRY_KWARGS``.
         """
+        removed = sorted(set(kwargs) & set(_REMOVED_GEOMETRY_KWARGS))
+        if removed:
+            raise TypeError(
+                f"{type(self).__name__}.forward() got removed geometry argument(s) "
+                f"{removed}. The [B,V,3,4] matrix argument was replaced by the "
+                f"projection ABI (#77/#107):\n\n"
+                f"    from model_components.view_fusion.projection import PinholeProjection\n"
+                f"    model(camera_tiles, map_input, visual_history, egomotion_history,\n"
+                f"          projection=PinholeProjection(camera_params),  # [B,V,3,4]\n"
+                f"          geometry_type='pinhole', mode=...)\n\n"
+                f"This is an error and not a warning because **kwargs would otherwise "
+                f"absorb the argument silently and the model would run on "
+                f"geometry_type='pseudo' — a learned spatial prior, not your calibration."
+            )
 
         # World Action Model (1 Hz): produce the Encoded Visual History fed to the
         # reactive planner + reasoning branch, and (in training) the predicted

--- a/Model/tests/test_auto_e2e.py
+++ b/Model/tests/test_auto_e2e.py
@@ -283,3 +283,67 @@ class TestFullPipelineRobustness:
 
         assert traj.shape == (1, 128)
         assert torch.isfinite(traj).all()
+
+
+# ---------------------------------------------------------------------------
+# Removed geometry kwargs must fail loudly, not silently
+# ---------------------------------------------------------------------------
+
+class TestRemovedGeometryKwargs:
+    """A caller passing pre-#77/#107 geometry must get an error, not pseudo BEV.
+
+    ``forward`` takes ``**kwargs`` and hands them to the planner, which also takes
+    ``**kwargs``. So ``camera_params=<calibration>`` used to be absorbed at every
+    layer and dropped without a word, leaving the model on ``geometry_type="pseudo"``
+    — a learned prior. The run trains, converges and reports numbers; nothing says
+    the calibration was discarded. That is the failure this pins.
+    """
+
+    def test_camera_params_raises(self, build_mock_model, device):
+        model = build_mock_model(num_views=7, device=device)
+        model.eval()
+        visual, map_input, vis_hist, ego, camera_params = make_inputs(
+            2, 7, device, include_camera_params=True)
+
+        with pytest.raises(TypeError, match="camera_params"):
+            model(visual, map_input, vis_hist, ego,
+                  camera_params=camera_params, mode="infer")
+
+    @pytest.mark.parametrize(
+        "name", ["calib", "calibration", "intrinsics", "extrinsics",
+                 "projection_matrix", "camera_matrices"])
+    def test_other_removed_names_raise(self, build_mock_model, device, name):
+        model = build_mock_model(num_views=7, device=device)
+        model.eval()
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
+
+        with pytest.raises(TypeError, match=name):
+            model(visual, map_input, vis_hist, ego,
+                  mode="infer", **{name: torch.randn(2, 7, 3, 4, device=device)})
+
+    def test_error_names_the_replacement(self, build_mock_model, device):
+        """The message must be actionable: whoever hits it should not have to
+        go read the diff of #77 to find out what to pass instead."""
+        model = build_mock_model(num_views=7, device=device)
+        model.eval()
+        visual, map_input, vis_hist, ego, camera_params = make_inputs(
+            2, 7, device, include_camera_params=True)
+
+        with pytest.raises(TypeError) as exc:
+            model(visual, map_input, vis_hist, ego,
+                  camera_params=camera_params, mode="infer")
+
+        msg = str(exc.value)
+        assert "PinholeProjection" in msg
+        assert "projection=" in msg
+        assert "pseudo" in msg
+
+    def test_unrelated_kwargs_still_pass_through(self, build_mock_model, device):
+        """Only the geometry names are rejected — **kwargs stays open for the
+        planner, so this guard must not become a general kwargs whitelist."""
+        model = build_mock_model(num_views=7, device=device)
+        model.eval()
+        visual, map_input, vis_hist, ego = make_inputs(2, 7, device)
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
+
+        assert traj.shape == (2, 128)


### PR DESCRIPTION

## Problem

`Model/data_parsing/kit_scenes/forward_pass_test.py` does not run against the current
model. Both of its modes crash:

```
test_bev_infer_mode   ValueError: not enough values to unpack (expected 3, got 1)
test_bev_train_mode   ValueError: not enough values to unpack (expected 3, got 1)
```

It is not wrong — it follows `Model/README.md`, which still documents the pre-#77/#107
signature: `camera_params=` and a 3-tuple return. Neither exists any more.

The crash has an obvious fix — delete the third return value — and that fix is the real
problem. `forward` takes `**kwargs` and hands them to `ReactiveE2E.forward`, which hands
them to the planner; all three absorb them. So `camera_params=<calib>` is dropped without
a word and the model falls back to `geometry_type="pseudo"`, which `projection.py:268`
calls "NOT real geometry, a learnable spatial prior (shape-testing / ablation only)".

Measured on main, same weights and inputs:

| call | trajectory[0, :3] |
| --- | --- |
| no geometry | `0.21758756, 0.15876013, 0.19457541` |
| `camera_params=<calib>` | `0.21758756, 0.15876013, 0.19457541` |
| `projection=PinholeProjection(<same calib>)` | `0.21374298, 0.15579164, 0.19097323` |

Bit for bit identical: the calibration never entered the computation. The control shows
real geometry does move the output, so the route is broken, not the calibration. Fix the
crash and the test passes, prints a plausible trajectory, and throws KITScenes'
calibration away. The `ValueError` is the only thing warning us, and it is the first
thing anyone will delete.

No training run is affected: `train_il` passes `projection=` + `geometry_type=`
correctly, and `e2e_pipeline_smoke.py:135` asserts `"camera_params" not in batch`.

## Fix

- **`Model/model_components/auto_e2e.py`** — `forward` raises `TypeError` on the removed
  geometry kwargs (`camera_params`, `calib`, `intrinsics`, ...), naming the replacement.
  An error rather than a warning, because the failure mode is a silently wrong run and
  nobody reads a warning in a five-hour training log. `**kwargs` stays open for the
  planner; only the geometry names are rejected.
- **`Model/README.md`** — the real signature and the projection ABI.
- **`kit_scenes/forward_pass_test.py`** — ported to `projection=` + `geometry_type=` and
  to the 1-or-2 return contract. It also unpacked a `planner_loss` that `forward` has
  never returned.
- **`Model/tests/test_auto_e2e.py`** — 9 tests pinning the guard.

Not here: wiring KITScenes end to end (it still needs a `projection_spec`, and its map
tiles need Lanelet2). This only makes its forward test run, and makes a dropped
calibration impossible to miss.

## Verification

ruff + mypy clean (91 files), `pytest Model/tests` 299 passed / 4 skipped.
