### PR TITLE
fix(tests): run the NVIDIA FTheta calibration tests that CI has always skipped

### DIFF
--- a/Model/data_parsing/nvidia_physical_ai/camera.py
+++ b/Model/data_parsing/nvidia_physical_ai/camera.py
@@ -15,7 +15,6 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import torch
-from physical_ai_av.video import SeekVideoReader
 
 # Camera directories present in the NVIDIA PhysicalAI-Autonomous-Vehicles dataset.
 CAMERA_NAMES: list[str] = [
@@ -121,6 +120,14 @@ def load_camera_frame(
             timestamps_us = pd.read_parquet(timestamps_path)["timestamp"].to_numpy()
 
         frame_idx = _egomotion_ts_to_frame_idx(egomotion_timestamp_us, timestamps_us)
+
+        # Imported HERE, not at module scope. The NVIDIA SDK is a *runtime* dep of
+        # video decoding only, but an *import-time* dep of the whole package (this
+        # module is re-exported by __init__), so it also gated the pure-numpy FTheta
+        # calibration math in calibration.py — which never touches the SDK. That is
+        # why TestBuildFThetaFromCalibration cannot run without it. The SDK needs
+        # Python >= 3.11, so it also made the calibration path untestable on 3.10.
+        from physical_ai_av.video import SeekVideoReader
 
         video_data = io.BytesIO(video_path.read_bytes()) #TODO: major bottleneck for training - consider sampling images in a seperate data processing step.
         reader = SeekVideoReader(video_data=video_data)

--- a/Model/data_parsing/nvidia_physical_ai/egomotion.py
+++ b/Model/data_parsing/nvidia_physical_ai/egomotion.py
@@ -17,11 +17,14 @@ Downsamples to 10Hz and produces:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 import torch
-from physical_ai_av.egomotion import EgomotionState
+
+if TYPE_CHECKING:  # the SDK is a runtime dep of loading, not of importing (see below)
+    from physical_ai_av.egomotion import EgomotionState
 
 # Must match the planner's dimensions. Placing here for package export.
 _HISTORY_TIMESTEPS = 64         # 6.4 s of past context at 10 Hz
@@ -132,6 +135,13 @@ def load_egomotion(
 
     history_df = df.iloc[sample_idx - _HISTORY_TIMESTEPS:sample_idx].reset_index(drop=True)
     future_df = df.iloc[sample_idx + 1:sample_idx + 1 + _FUTURE_TIMESTEPS].reset_index(drop=True)
+
+    # Imported HERE, not at module scope. The NVIDIA SDK is a runtime dep of loading
+    # egomotion, but a module-scope import made it a dep of importing the package at
+    # all — which gated the pure-numpy FTheta calibration math in calibration.py that
+    # never touches the SDK, and (since the SDK needs Python >= 3.11) made that math
+    # untestable on 3.10 entirely. See camera.py for the same pattern.
+    from physical_ai_av.egomotion import EgomotionState
 
     history_signals = _to_history_signals(EgomotionState.from_egomotion_df(history_df))
     future_signals = _to_target_signals(EgomotionState.from_egomotion_df(future_df))

--- a/Model/tests/test_projection.py
+++ b/Model/tests/test_projection.py
@@ -373,8 +373,11 @@ class TestBuildFThetaFromCalibration:
             rotation=spt.Rotation.identity(), translation=np.zeros(3))
 
     def test_native_wh_and_max_theta_from_r2th(self):
-        pytest.importorskip("scipy")
-        pytest.importorskip("pandas")  # calibration import pulls the dataset pkg
+        # RigidTransform landed in scipy 1.16 (needs Python >= 3.11). Without the
+        # minversion the guard passes on 1.15 and the test dies on AttributeError
+        # instead of skipping -- a red suite that means nothing.
+        pytest.importorskip("scipy", minversion="1.16")
+        pytest.importorskip("pandas")
         from data_parsing.nvidia_physical_ai.calibration import build_ftheta_projection
         # Non-square native frame: normalization must use native (W,H), not 256.
         names = ["cam_a", "cam_b"]
@@ -405,8 +408,11 @@ class TestBuildFThetaFromCalibration:
         assert res.uv_norm[0, 0, 0, 1].item() == pytest.approx(v_exp, abs=1e-4)
 
     def test_no_r2th_leaves_max_theta_none(self):
-        pytest.importorskip("scipy")
-        pytest.importorskip("pandas")  # calibration import pulls the dataset pkg
+        # RigidTransform landed in scipy 1.16 (needs Python >= 3.11). Without the
+        # minversion the guard passes on 1.15 and the test dies on AttributeError
+        # instead of skipping -- a red suite that means nothing.
+        pytest.importorskip("scipy", minversion="1.16")
+        pytest.importorskip("pandas")
         from data_parsing.nvidia_physical_ai.calibration import build_ftheta_projection
         m = self._Model(800, 600)
         del m.r2th  # lens without a backward polynomial -> no derivable FOV bound
@@ -418,8 +424,11 @@ class TestBuildFThetaFromCalibration:
         """A rig where one lens has r2th (finite bound) and another does not
         (inf) must STILL mask behind-camera rays on the unbounded lens — the inf
         bound must fall back to the +Z hemisphere gate, not accept everything."""
-        pytest.importorskip("scipy")
-        pytest.importorskip("pandas")  # calibration import pulls the dataset pkg
+        # RigidTransform landed in scipy 1.16 (needs Python >= 3.11). Without the
+        # minversion the guard passes on 1.15 and the test dies on AttributeError
+        # instead of skipping -- a red suite that means nothing.
+        pytest.importorskip("scipy", minversion="1.16")
+        pytest.importorskip("pandas")
         from data_parsing.nvidia_physical_ai.calibration import build_ftheta_projection
         bounded = self._Model(1920, 1080)             # has r2th -> finite bound
         unbounded = self._Model(1920, 1080)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 mypy==2.1.0
 numpy==2.2.6
+pandas==2.3.3
 pytest==9.0.3
 ruff==0.15.16
+scipy==1.16.3
 timm==1.0.27
 torch==2.7.1


### PR DESCRIPTION
## Problem

`TestBuildFThetaFromCalibration` (4 tests) has never run in CI: `requirements.txt` has
no scipy, so `importorskip("scipy")` skips it every time. `build_ftheta_projection` is
green by default, not by test.

Adding scipy alone makes them error instead of skip: importing
`nvidia_physical_ai.calibration` pulls `camera.py`, which imports the NVIDIA SDK at
module scope, and the SDK is not in CI.

## Fix

- **`camera.py`, `egomotion.py`** — import the SDK inside the functions that use it. It
  is needed to decode video, not to import the package; `calibration.py` is pure numpy.
- **`test_projection.py`** — `importorskip("scipy", minversion="1.16")`. The tests use
  `RigidTransform`, new in 1.16; on 1.15 the guard passed and the test died on
  `AttributeError` instead of skipping.
- **`requirements.txt`** — `scipy==1.16.3`, `pandas==2.3.3`.

No test added; `build_ftheta_projection` is unchanged and correct.

## Verification

All four pass on Python 3.12. They were not failing — they were not running.
`pytest Model/tests` 290 passed locally (scipy < 1.16, so they skip cleanly). ruff +
mypy clean.

scipy 1.16 needs Python >= 3.11, so `make setup` now needs 3.11 (CI runs 3.12). If you
would rather not move that floor, the test can stub the pose — `calibration.py:67` only
calls `.as_matrix()` on it.
