### PR TITLE
feat(kit_scenes): drop the redundant ring-front view and add a tele crop of the long-range camera (#146)

### DIFF
--- a/Model/data_parsing/kit_scenes/README.md
+++ b/Model/data_parsing/kit_scenes/README.md
@@ -35,15 +35,29 @@ Without Lanelet2, map tiles fall back to zero tensors and the dataset still func
 
 ## Model inputs produced
 
-- `visual_tiles` `(6, 3, H, W)` — 6 camera frames
+- `visual_tiles` `(7, 3, H, W)` — 6 camera frames plus the derived tele view
 - `map_tile` `(3, H, W)` — BEV map tile (rasterization of Lanelet2 HD map)
 - `egomotion_history` `(256,)` — fixed model ABI: 64 past timesteps × 4 signals at 10 Hz
 - `visual_history` `(896,)` — zero-initialised placeholder; populated during sequential inference
 - `trajectory_target` `(128,)` — fixed model ABI: 64 future timesteps × 2 signals
-- `camera_params` `(6, 3, 4)` — projection matrices `P = K_scaled @ T_ref_to_cam` for the 6 camera views, computed from KITScenes calibration and scaled to match the backbone's resize/crop transform. 
+- `camera_params` `(7, 3, 4)` — projection matrices `P = K_scaled @ T_ref_to_cam` for the 7 views, computed from KITScenes calibration and scaled to match the backbone's resize/crop transform. 
 
 
-The 6 camera views are the long-range front camera (`camera_base_front_center`) plus 5 surround ring cameras (`CAMERA_NAMES` in `camera.py`). `camera_ring_front` is dropped as it duplicates the long-range camera's forward coverage (#146), and the stereo front pair stays out: at 63.3 deg HFOV it trades field of view for baseline.
+The 7 views are 6 physical cameras plus one derived view (`VIEW_NAMES` in `camera.py`):
+
+| view | source | HFOV | px/deg at 256 |
+|---|---|---|---|
+| `camera_base_front_center` | long-range camera, 5856x3104 | 88.2 deg | 2.90 |
+| 5 x `camera_ring_*` | surround cameras, 3504x2272 | 87.1 deg | 2.94 |
+| `tele_center` | 30 deg centre crop of the long-range camera, taken at native resolution | 30.0 deg | **8.54** |
+
+`camera_ring_front` is dropped: it points the same way as the long-range camera and covers the same
+field of view, so the two are redundant (#146). The stereo front pair stays out — at 63.3 deg it
+trades field of view for baseline and is not the long-range imager.
+
+The tele view exists because reach is set by pixels per degree reaching the model, not by sensor
+resolution: every view is resized to `image_size`, so the long-range camera's full frame arrives at
+the same 2.9 px/deg as a ring camera. Cropping before the resize is what preserves the advantage.
 
 ### Egomotion history signals `(256,) = 64 × 4`
 
@@ -112,7 +126,7 @@ for batch in loader:
     visual_history = batch["visual_history"].to(device)       # (B, 896)
     egomotion_history = batch["egomotion_history"].to(device) # (B, 256)
     trajectory_target = batch["trajectory_target"].to(device) # (B, 128)
-    camera_params = batch["camera_params"].to(device)         # (B, 6, 3, 4)
+    camera_params = batch["camera_params"].to(device)         # (B, 7, 3, 4)
 
     planner_loss, ego_hidden, future_visual_features = model(
         visual_tiles,

--- a/Model/data_parsing/kit_scenes/README.md
+++ b/Model/data_parsing/kit_scenes/README.md
@@ -35,15 +35,15 @@ Without Lanelet2, map tiles fall back to zero tensors and the dataset still func
 
 ## Model inputs produced
 
-- `visual_tiles` `(7, 3, H, W)` — 7 camera frames
+- `visual_tiles` `(6, 3, H, W)` — 6 camera frames
 - `map_tile` `(3, H, W)` — BEV map tile (rasterization of Lanelet2 HD map)
 - `egomotion_history` `(256,)` — fixed model ABI: 64 past timesteps × 4 signals at 10 Hz
 - `visual_history` `(896,)` — zero-initialised placeholder; populated during sequential inference
 - `trajectory_target` `(128,)` — fixed model ABI: 64 future timesteps × 2 signals
-- `camera_params` `(7, 3, 4)` — projection matrices `P = K_scaled @ T_ref_to_cam` for the 7 camera views, computed from KITScenes calibration and scaled to match the backbone's resize/crop transform. 
+- `camera_params` `(6, 3, 4)` — projection matrices `P = K_scaled @ T_ref_to_cam` for the 6 camera views, computed from KITScenes calibration and scaled to match the backbone's resize/crop transform. 
 
 
-The 7 camera views are the hi-res front camera plus the 6 surround ring cameras (`CAMERA_NAMES` in `camera.py`). The stereo front pair is dropped as it duplicates forward coverage.
+The 6 camera views are the long-range front camera (`camera_base_front_center`) plus 5 surround ring cameras (`CAMERA_NAMES` in `camera.py`). `camera_ring_front` is dropped as it duplicates the long-range camera's forward coverage (#146), and the stereo front pair stays out: at 63.3 deg HFOV it trades field of view for baseline.
 
 ### Egomotion history signals `(256,) = 64 × 4`
 
@@ -112,7 +112,7 @@ for batch in loader:
     visual_history = batch["visual_history"].to(device)       # (B, 896)
     egomotion_history = batch["egomotion_history"].to(device) # (B, 256)
     trajectory_target = batch["trajectory_target"].to(device) # (B, 128)
-    camera_params = batch["camera_params"].to(device)         # (B, 7, 3, 4)
+    camera_params = batch["camera_params"].to(device)         # (B, 6, 3, 4)
 
     planner_loss, ego_hidden, future_visual_features = model(
         visual_tiles,

--- a/Model/data_parsing/kit_scenes/__init__.py
+++ b/Model/data_parsing/kit_scenes/__init__.py
@@ -8,6 +8,8 @@ __all__ = [
     "KitScenesDataset",
     "load_camera_frame",
     "CAMERA_NAMES",
+    "VIEW_NAMES",
+    "TELE_VIEW_NAME",
     "load_egomotion",
     "poses_to_arrays",
     "generate_bev_map_tile",
@@ -21,11 +23,16 @@ def __getattr__(name: str) -> Any:
     if name == "KitScenesDataset":
         from .dataset import KitScenesDataset
         return KitScenesDataset
-    if name in {"load_camera_frame", "CAMERA_NAMES", "NUM_VIEWS"}:
-        from .camera import CAMERA_NAMES, NUM_VIEWS, load_camera_frame
+    if name in {"load_camera_frame", "CAMERA_NAMES", "NUM_VIEWS",
+                "VIEW_NAMES", "TELE_VIEW_NAME"}:
+        from .camera import (
+            CAMERA_NAMES, NUM_VIEWS, TELE_VIEW_NAME, VIEW_NAMES, load_camera_frame,
+        )
         return {
             "load_camera_frame": load_camera_frame,
             "CAMERA_NAMES": CAMERA_NAMES,
+            "VIEW_NAMES": VIEW_NAMES,
+            "TELE_VIEW_NAME": TELE_VIEW_NAME,
             "NUM_VIEWS": NUM_VIEWS,
         }[name]
     if name in {

--- a/Model/data_parsing/kit_scenes/camera.py
+++ b/Model/data_parsing/kit_scenes/camera.py
@@ -4,7 +4,8 @@ KIT Scenes stores per-frame JPEGs on disk (not videos), already at the 10 Hz
 reference timeline, so a single ``frame_idx`` indexes every camera and the ego
 poses alike. The ``kitscenes`` SDK's ``SensorDataLoader`` decodes a frame to an
 RGB ``np.ndarray``; this module resizes/normalises it for the AutoE2E backbone
-and stacks the 6 camera views into the tensor the model expects.
+and stacks the 7 views (6 cameras plus a derived tele crop) into the tensor
+the model expects.
 
 Camera projection matrices are computed from KITScenes calibration files, with
 intrinsics scaled to match the backbone's actual resize/crop transform.
@@ -12,11 +13,17 @@ intrinsics scaled to match the backbone's actual resize/crop transform.
 
 from __future__ import annotations
 
+import math
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import torch
-from kitscenes.sensors import SensorDataLoader
 from PIL import Image
 from torchvision.transforms import Compose
+
+if TYPE_CHECKING:  # the SDK is only needed for the loader's type, not at runtime
+    from kitscenes.sensors import SensorDataLoader
 
 # Shared, dataset-agnostic intrinsic scaling (re-exported for backward compat).
 from ..calibration import scale_intrinsic
@@ -49,8 +56,68 @@ CAMERA_NAMES: list[str] = [
     "camera_ring_rear_right",
 ]
 
-# Total views fed to the model = 6 cameras.
-NUM_VIEWS = 6
+# A seventh view, derived rather than physical: a narrow centre crop of the
+# long-range camera, taken at native resolution and then resized like any other
+# view (#146).
+#
+# Why it is needed. What sets how far the model can see is not the sensor's pixel
+# count but the pixels per degree that survive preprocessing, and every view is
+# resized to `image_size` (256 by default). At 256 px the full 88.2 deg frame of
+# the long-range camera carries 2.90 px/deg — the ring cameras carry 2.94 px/deg
+# over 87.1 deg. So feeding the long-range camera whole buys no extra reach: the
+# resize discards exactly the resolution that would have provided it.
+#
+# Cropping first keeps it. A centre crop of TELE_VIEW_HFOV_DEG taken before the
+# resize yields 256 / 30 = 8.5 px/deg, 2.9x what any full view carries today.
+TELE_VIEW_SOURCE = "camera_base_front_center"
+TELE_VIEW_NAME = "tele_center"
+TELE_VIEW_HFOV_DEG = 30.0
+
+# Slot order of the tensors handed to the model: the six physical cameras above,
+# then the derived tele view.
+VIEW_NAMES: list[str] = [*CAMERA_NAMES, TELE_VIEW_NAME]
+
+# Total views fed to the model = 6 cameras + 1 derived tele view.
+NUM_VIEWS = 7
+
+
+def tele_crop_box(
+    intrinsic: np.ndarray,
+    source_wh: tuple[int, int],
+    hfov_deg: float = TELE_VIEW_HFOV_DEG,
+) -> tuple[int, int, int]:
+    """Square centre crop of ``hfov_deg`` around the source camera's optical axis.
+
+    The crop is square so it survives the square resize without anisotropic
+    distortion, and it is centred on the principal point rather than on the image
+    centre, so the optical axis stays at the centre of the cropped frame.
+
+    Args:
+        intrinsic: ``(3, 3)`` pinhole matrix of the source camera.
+        source_wh: ``(width, height)`` of the source image in pixels.
+        hfov_deg: Field of view the crop should span, in degrees.
+
+    Returns:
+        ``(x0, y0, side)`` in source-image pixels.
+
+    Raises:
+        ValueError: if the requested field of view does not fit in the frame.
+    """
+    fx, cx, cy = float(intrinsic[0, 0]), float(intrinsic[0, 2]), float(intrinsic[1, 2])
+    side = int(round(2.0 * fx * math.tan(math.radians(hfov_deg) / 2.0)))
+    width, height = source_wh
+    if side > width or side > height:
+        raise ValueError(
+            f"tele crop of {hfov_deg} deg needs {side}px but the source frame is "
+            f"{width}x{height}"
+        )
+    x0 = int(round(cx - side / 2.0))
+    y0 = int(round(cy - side / 2.0))
+    # Keep the crop inside the frame if the principal point sits off-centre.
+    x0 = max(0, min(x0, width - side))
+    y0 = max(0, min(y0, height - side))
+    return x0, y0, side
+
 
 def compute_camera_projection_matrices(
     loader: SensorDataLoader,
@@ -66,8 +133,8 @@ def compute_camera_projection_matrices(
     Args:
         loader: ``SensorDataLoader`` for the scene.
         transform: Optional backbone transform used by the standalone parser.
-        camera_names: Cameras to compute matrices for, in slot order.
-            Defaults to ``CAMERA_NAMES``.
+        camera_names: Views to compute matrices for, in slot order. May include
+            the derived ``TELE_VIEW_NAME``. Defaults to ``VIEW_NAMES``.
         image_size: Optional packed output size as an int (square) or ``(H, W)``.
             This is the pipeline path and is mutually exclusive with transform.
  
@@ -76,7 +143,7 @@ def compute_camera_projection_matrices(
         Does not include a slot for the map tile.
     """
     if camera_names is None:
-        camera_names = CAMERA_NAMES
+        camera_names = VIEW_NAMES
     if (transform is None) == (image_size is None):
         raise ValueError("provide exactly one of transform or image_size")
 
@@ -85,31 +152,48 @@ def compute_camera_projection_matrices(
         target_hw = (image_size, image_size)
     else:
         target_hw = image_size
- 
+
     matrices = []
     for cam_name in camera_names:
-        calib = loader.get_camera_calibration(cam_name)
- 
+        is_tele = cam_name == TELE_VIEW_NAME
+        calib = loader.get_camera_calibration(
+            TELE_VIEW_SOURCE if is_tele else cam_name
+        )
+
         source_wh = calib.image_size
         if source_wh is None:
-            source_wh = loader.get_camera_image_size(cam_name, frame_idx=0)
+            source_wh = loader.get_camera_image_size(
+                TELE_VIEW_SOURCE if is_tele else cam_name, frame_idx=0
+            )
+
+        intrinsic = calib.intrinsic.astype(np.float64)
+        if is_tele:
+            # Cropping does not change focal length; it only moves the principal
+            # point into the cropped frame. Everything downstream then treats the
+            # crop as a narrower camera of its own.
+            x0, y0, side = tele_crop_box(intrinsic, source_wh)
+            intrinsic = intrinsic.copy()
+            intrinsic[0, 2] -= x0
+            intrinsic[1, 2] -= y0
+            source_wh = (side, side)
+
         if target_hw is not None:
             target_h, target_w = target_hw
             source_w, source_h = source_wh
-            K_scaled = calib.intrinsic.copy().astype(np.float64)
+            K_scaled = intrinsic.copy()
             K_scaled[0, :] *= target_w / source_w
             K_scaled[1, :] *= target_h / source_h
         else:
             assert transform is not None
-            K_scaled = scale_intrinsic(
-                calib.intrinsic, source_wh, transform
-            )
- 
-        # invert calib.extrinsic to get T_ref_to_cam.
+            K_scaled = scale_intrinsic(intrinsic, source_wh, transform)
+
+        # invert calib.extrinsic to get T_ref_to_cam. The tele view shares the
+        # source camera's pose: it is the same optical centre, seen through a
+        # narrower window.
         T_ref_to_cam = np.linalg.inv(calib.extrinsic)   # (4, 4)
         P = K_scaled @ T_ref_to_cam[:3, :]              # (3, 4)
         matrices.append(P)
- 
+
     return torch.tensor(np.stack(matrices, axis=0), dtype=torch.float32)  # (V, 3, 4)
 
 
@@ -127,8 +211,8 @@ def load_camera_frame(
             its per-scene caches are reused across __getitem__ calls.
         frame_idx: Index into the scene's reference timeline.
         transform: Optional backbone preprocessing transform.
-        camera_names: Ordered list of camera directory names to load.
-            Defaults to ``CAMERA_NAMES``.
+        camera_names: Ordered list of view names to load. May include the derived
+            ``TELE_VIEW_NAME``. Defaults to ``VIEW_NAMES``.
         image_size: Optional raw pipeline output size as an int (square) or
             ``(H, W)``. Images are resized but not normalized.
 
@@ -136,7 +220,7 @@ def load_camera_frame(
         Float tensor of shape ``(len(camera_names), 3, H, W)``.
     """
     if camera_names is None:
-        camera_names = CAMERA_NAMES
+        camera_names = VIEW_NAMES
 
     if transform is not None and image_size is not None:
         raise ValueError("transform and image_size are mutually exclusive")
@@ -149,8 +233,18 @@ def load_camera_frame(
 
     camera_tensors = []
     for cam_name in camera_names:
-        rgb_frame = loader.get_camera_image(cam_name, frame_idx)  # (H, W, 3) RGB
+        is_tele = cam_name == TELE_VIEW_NAME
+        source_name = TELE_VIEW_SOURCE if is_tele else cam_name
+        rgb_frame = loader.get_camera_image(source_name, frame_idx)  # (H, W, 3) RGB
         image = Image.fromarray(rgb_frame)
+        if is_tele:
+            # Crop at native resolution, before any resize: that is the whole
+            # point of this view, and cropping afterwards would preserve nothing.
+            calib = loader.get_camera_calibration(source_name)
+            x0, y0, side = tele_crop_box(
+                calib.intrinsic.astype(np.float64), (image.width, image.height)
+            )
+            image = image.crop((x0, y0, x0 + side, y0 + side))
         if transform is not None:
             camera_tensors.append(transform(image))
             continue

--- a/Model/data_parsing/kit_scenes/camera.py
+++ b/Model/data_parsing/kit_scenes/camera.py
@@ -4,7 +4,7 @@ KIT Scenes stores per-frame JPEGs on disk (not videos), already at the 10 Hz
 reference timeline, so a single ``frame_idx`` indexes every camera and the ego
 poses alike. The ``kitscenes`` SDK's ``SensorDataLoader`` decodes a frame to an
 RGB ``np.ndarray``; this module resizes/normalises it for the AutoE2E backbone
-and stacks the 7 camera views into the tensor the model expects.
+and stacks the 6 camera views into the tensor the model expects.
 
 Camera projection matrices are computed from KITScenes calibration files, with
 intrinsics scaled to match the backbone's actual resize/crop transform.
@@ -22,12 +22,26 @@ from torchvision.transforms import Compose
 from ..calibration import scale_intrinsic
 
 # Camera directories used as visual tiles for the KIT Scenes dataset.
-# Order: hi-res front, then the 6 surround ring cameras. The 2-camera stereo
-# pair (camera_base_front_left_rect/_right_rect) is intentionally dropped; it
-# duplicates forward coverage already given by the ring front camera.
+# Order: long-range front, then the 5 remaining surround ring cameras.
+#
+# Which camera is which (from the calibration published in the SDK's
+# notebooks/04_calibration_and_multimodal.ipynb; HFOV = 2*atan(W / 2*focal)):
+#
+#   camera_base_front_center       5856x3104   18.2 MPix   88.2 deg  <- long-range
+#   camera_ring_*                  3504x2272    8.0 MPix   87.1 deg
+#   camera_base_front_*_rect       2272x3488    7.9 MPix   63.3 deg  <- stereo pair
+#
+# Those three groups match the sensor suite in the dataset paper (arXiv:2606.02956):
+# one long-range 88.4 deg camera, six 87.1 deg surround cameras and a tilted 63.3 deg
+# stereo pair. So camera_base_front_center is the long-range imager, at 2.3x the
+# pixel count of the ring cameras over essentially the same field of view.
+#
+# camera_ring_front is dropped (#146): it points the same way as the long-range
+# camera and covers the same 87 deg, so it is the redundant one of the two. The
+# stereo pair stays out — at 63.3 deg it trades field of view for baseline, and it
+# is not the long-range imager.
 CAMERA_NAMES: list[str] = [
     "camera_base_front_center",
-    "camera_ring_front",
     "camera_ring_front_left",
     "camera_ring_front_right",
     "camera_ring_rear",
@@ -35,8 +49,8 @@ CAMERA_NAMES: list[str] = [
     "camera_ring_rear_right",
 ]
 
-# Total views fed to the model = 7 cameras.
-NUM_VIEWS = 7
+# Total views fed to the model = 6 cameras.
+NUM_VIEWS = 6
 
 def compute_camera_projection_matrices(
     loader: SensorDataLoader,
@@ -119,8 +133,7 @@ def load_camera_frame(
             ``(H, W)``. Images are resized but not normalized.
 
     Returns:
-        Float tensor of shape (7, 3, H, W):
-        7 camera views.
+        Float tensor of shape ``(len(camera_names), 3, H, W)``.
     """
     if camera_names is None:
         camera_names = CAMERA_NAMES
@@ -146,4 +159,4 @@ def load_camera_frame(
         array = np.asarray(image, dtype=np.uint8).copy()
         camera_tensors.append(torch.from_numpy(array).permute(2, 0, 1))
 
-    return torch.stack(camera_tensors, dim=0)  # (7, 3, H, W)
+    return torch.stack(camera_tensors, dim=0)  # (V, 3, H, W)

--- a/Model/tests/test_kitscenes_tele_view.py
+++ b/Model/tests/test_kitscenes_tele_view.py
@@ -1,0 +1,87 @@
+"""The derived tele view must buy angular resolution, not just exist (#146).
+
+The point of the view is that a centre crop taken *before* the resize keeps
+pixels per degree that the resize would otherwise throw away. These tests pin
+that property with the real calibration of camera_base_front_center, published
+in the KITScenes SDK notebook 04_calibration_and_multimodal.ipynb:
+
+    focal 3022.0 px, principal point (2924.0, 1545.0), frame 5856x3104
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from data_parsing.kit_scenes.camera import (
+    TELE_VIEW_HFOV_DEG,
+    TELE_VIEW_NAME,
+    TELE_VIEW_SOURCE,
+    VIEW_NAMES,
+    tele_crop_box,
+)
+
+FOCAL_PX = 3022.0
+FRAME_WH = (5856, 3104)
+INTRINSIC = np.array(
+    [[FOCAL_PX, 0.0, 2924.0], [0.0, FOCAL_PX, 1545.0], [0.0, 0.0, 1.0]]
+)
+PACKED_PX = 256
+
+
+def _hfov_deg(width_px: float, focal_px: float) -> float:
+    return 2.0 * math.degrees(math.atan(width_px / (2.0 * focal_px)))
+
+
+class TestTeleCropBox:
+    def test_crop_spans_the_requested_field_of_view(self):
+        _, _, side = tele_crop_box(INTRINSIC, FRAME_WH)
+        assert _hfov_deg(side, FOCAL_PX) == pytest.approx(TELE_VIEW_HFOV_DEG, abs=0.05)
+
+    def test_crop_is_centred_on_the_principal_point(self):
+        x0, y0, side = tele_crop_box(INTRINSIC, FRAME_WH)
+        # After cropping, the optical axis must land in the middle of the frame,
+        # otherwise the projection matrices and the pixels disagree.
+        assert INTRINSIC[0, 2] - x0 == pytest.approx(side / 2.0, abs=1.0)
+        assert INTRINSIC[1, 2] - y0 == pytest.approx(side / 2.0, abs=1.0)
+
+    def test_crop_fits_inside_the_source_frame(self):
+        x0, y0, side = tele_crop_box(INTRINSIC, FRAME_WH)
+        assert 0 <= x0 and x0 + side <= FRAME_WH[0]
+        assert 0 <= y0 and y0 + side <= FRAME_WH[1]
+
+    def test_rejects_a_field_of_view_that_does_not_fit(self):
+        with pytest.raises(ValueError, match="does not fit|needs"):
+            tele_crop_box(INTRINSIC, FRAME_WH, hfov_deg=170.0)
+
+
+class TestTeleViewBuysResolution:
+    def test_crop_carries_more_pixels_per_degree_than_the_full_frame(self):
+        """The reason this view exists. Without the crop the long-range camera
+        arrives at the same angular resolution as a ring camera, because both are
+        resized to the same square."""
+        _, _, side = tele_crop_box(INTRINSIC, FRAME_WH)
+        full_hfov = _hfov_deg(FRAME_WH[0], FOCAL_PX)
+        tele_hfov = _hfov_deg(side, FOCAL_PX)
+
+        full_px_per_deg = PACKED_PX / full_hfov
+        tele_px_per_deg = PACKED_PX / tele_hfov
+
+        assert tele_px_per_deg > 2.5 * full_px_per_deg
+
+    def test_full_long_range_frame_is_no_sharper_than_a_ring_camera(self):
+        """Control for the claim above: at 256 px the long-range camera's own
+        frame carries no more angular resolution than a ring camera, so simply
+        feeding it whole cannot extend range."""
+        long_range = PACKED_PX / _hfov_deg(FRAME_WH[0], FOCAL_PX)
+        ring = PACKED_PX / _hfov_deg(3504, 1841.0)  # camera_ring_front calibration
+        assert long_range == pytest.approx(ring, abs=0.1)
+
+
+class TestViewSlots:
+    def test_tele_view_is_the_last_slot(self):
+        assert VIEW_NAMES[-1] == TELE_VIEW_NAME
+        assert len(VIEW_NAMES) == 7
+
+    def test_tele_view_derives_from_a_camera_that_is_also_fed_whole(self):
+        assert TELE_VIEW_SOURCE in VIEW_NAMES


### PR DESCRIPTION

## Summary

- Drops `camera_ring_front` from the KITScenes view set: it is redundant with the long-range front
  camera, measurably so.
- Adds `tele_center`, a 30 deg centre crop of that same long-range camera taken at native
  resolution, so the model actually gains reach.
- Still 7 views. No pipeline, model or `image_size` changes.

## Why

**Which camera is the long-range one.** The calibration published in the SDK's [`notebooks/04_calibration_and_multimodal.ipynb`](https://github.com/KIT-MRT/kitscenes/blob/7765cdec5490894266070ab46e23724b58b3da42/notebooks/04_calibration_and_multimodal.ipynb), at the revision this repo pins (`KITSCENES_SDK_REVISION`), gives, with HFOV = 2·atan(W / 2·focal):

| camera | W x H | MPix | HFOV |
|---|---|---|---|
| `camera_base_front_center` | 5856 x 3104 | 18.2 | 88.2 deg |
| `camera_ring_*` (6) | 3504 x 2272 | 8.0 | 87.1 deg |
| `camera_base_front_*_rect` (2) | 2272 x 3488 | 7.9 | 63.3 deg |

Those three groups line up with the sensor suite in the dataset paper (arXiv:2606.02956): one
long-range camera at 88.4 deg, six surround cameras at 87.1 deg, and a tilted stereo pair at
63.3 deg. So the long-range imager is `camera_base_front_center` — which the model already feeds as
the first entry of `CAMERA_NAMES`.

**Why `camera_ring_front` goes.** It points the same way as the long-range camera and covers
essentially the same field of view at 2.3x fewer pixels. The two are redundant, so one of them is
paying compute for nothing.

**Why dropping it is not enough on its own.** Reach is set by the pixels per degree that reach the
model, not by the sensor's pixel count, and every view is resized to `image_size` (256 by default):

```
camera_base_front_center   5856 px over 88.2 deg  ->  256 px  ->  2.90 px/deg
camera_ring_front          3504 px over 87.2 deg  ->  256 px  ->  2.94 px/deg
```

At 256 px the long-range camera is no sharper than a ring camera — the resize discards exactly the
resolution that would have provided the extra range. Feeding it whole cannot extend how far the
model sees.

**What does.** Cropping before the resize keeps it. A 30 deg centre crop is 1619 px of the 5856 px
frame and lands at 256 px as **8.54 px/deg — 2.9x any full view**. Cropping does not change focal
length, so the crop is treated as a narrower camera sharing the source pose; only the principal
point moves. The crop is square, matching the square resize, and centred on the principal point so
the optical axis stays in the middle of the frame.

The alternative would be raising `image_size` instead. Matching 8.54 px/deg on the full frame needs
753 px of input rather than 256 — 8.6x the pixels per view, across all seven. The crop reaches the
same angular resolution at today's cost.

The result keeps peripheral context (the long-range camera whole, plus 5 ring cameras) and adds
distance (the same camera cropped), at the same 7 views as before.

The two are not co-located, so this does drop a viewpoint — but nothing in the model uses stereo or
disparity, so no path loses information. The crop's field of view is one constant
(`TELE_VIEW_HFOV_DEG`) if you want it narrower or wider.

## Validation

- `Model/tests/test_kitscenes_tele_view.py` (new, 8 tests): the crop spans the requested FOV, is
  centred on the principal point, fits inside the frame, and rejects a FOV that does not. Two tests
  pin the reason the view exists: the crop carries >2.5x the full frame's pixels per degree, and the
  full long-range frame is no sharper than a ring camera once resized.
- `ruff` clean. The KITScenes and view-fusion suites pass: 86 passed, 6 skipped.
- `num_views` is **derived from the packed shard manifests**, not hardcoded, so the change
  propagates on its own — but **existing shards must be repacked** for the new view set.
