### PR TITLE
feat(console): carry reasoning labels forward during playback

### DIFF
--- a/Tools/DataModelConsole/web/e2e/reasoning-carry-forward.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/reasoning-carry-forward.spec.ts
@@ -152,3 +152,69 @@ test("fetch targets: nothing to do when the nearest backward anchor is loading",
   expect(t.backward).toBeUndefined();
   expect(t.forward).toBe(20);
 });
+
+// driveToStable models the hook's fetch loop at a FIXED frame (i.e. paused):
+// repeatedly plan a target, resolve it into the cache, and re-plan — exactly
+// what the hook must do across resolutions. `labelAt` returns a label id for a
+// present anchor or null for a scoped-404 (absent). Returns the number of
+// backward fetches issued so a runaway (fetch-storm) shows up as a large count.
+// This is the regression guard for the paused-stall bug: the pure contract must
+// converge to a present fallback within the sparse anchor set, and the hook (via
+// `tick` in its effect deps) must keep invoking it until it does.
+function driveToStable(
+  anchors: number[],
+  frame: number,
+  labelAt: (f: number) => string | null,
+): { cache: Map<string, CacheEntry<Label>>; backwardFetches: number } {
+  const cache = new Map<string, CacheEntry<Label>>();
+  let backwardFetches = 0;
+  // Bounded well above the anchor count; a correct loop converges in <= anchors.
+  for (let guard = 0; guard < anchors.length + 5; guard++) {
+    const { backward, forward } = carryForwardFetchTargets(
+      anchors,
+      frame,
+      keyForFrame,
+      cache,
+    );
+    if (backward === undefined && forward === undefined) break;
+    for (const af of [backward, forward]) {
+      if (af === undefined) continue;
+      if (af === backward) backwardFetches++;
+      const id = labelAt(af);
+      cache.set(
+        keyForFrame(af),
+        id === null ? { status: "absent" } : { status: "present", label: { id } },
+      );
+    }
+  }
+  return { cache, backwardFetches };
+}
+
+test("paused backfill converges past scoped-404 anchors to the older present label", () => {
+  // Regression for the paused-stall bug: anchors 50 and 40 are candidates
+  // (has_reasoning any-run) but 404 in this scope; 30 has a label. Paused at 55,
+  // the loop must walk 50 -> 40 -> 30 and end showing the label at 30.
+  const anchors = [0, 10, 20, 30, 40, 50, 60];
+  const present = new Set([0, 10, 20, 30, 60]); // 40, 50 are scoped-404
+  const labelAt = (f: number) => (present.has(f) ? `a${f}` : null);
+
+  const { cache, backwardFetches } = driveToStable(anchors, 55, labelAt);
+  const sel = selectCarryForwardLabel(anchors, 55, keyForFrame, cache);
+  expect(sel.label?.id).toBe("a30");
+  expect(sel.anchorFrame).toBe(30);
+  expect(sel.pending).toBe(false);
+  // 50 (absent) + 40 (absent) + 30 (present) = 3 backward fetches, not the whole
+  // prior-anchor set — the storm guard holds.
+  expect(backwardFetches).toBe(3);
+});
+
+test("paused backfill reports none (not stuck loading) when no label precedes the playhead", () => {
+  // All anchors <= frame are scoped-404: the loop must terminate with a settled
+  // "none", never an indefinite pending/loading.
+  const anchors = [10, 20, 30];
+  const labelAt = () => null; // every anchor 404s in this scope
+  const { cache } = driveToStable(anchors, 35, labelAt);
+  const sel = selectCarryForwardLabel(anchors, 35, keyForFrame, cache);
+  expect(sel.label).toBeNull();
+  expect(sel.pending).toBe(false);
+});

--- a/Tools/DataModelConsole/web/e2e/reasoning-carry-forward.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/reasoning-carry-forward.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  anchorFramesOf,
+  carryForwardFetchTargets,
+  selectCarryForwardLabel,
+  type CacheEntry,
+} from "../src/lib/reasoning-carry-forward";
+
+// A minimal label stand-in; the selector only cares about identity/presence.
+type Label = { id: string };
+
+// Build a cache keyed by frame->key = `f${frame}`. `spec` maps a frame to its
+// entry so tests read declaratively.
+function cacheOf(
+  spec: Record<number, CacheEntry<Label>>,
+): Map<string, CacheEntry<Label>> {
+  const m = new Map<string, CacheEntry<Label>>();
+  for (const [frame, entry] of Object.entries(spec)) {
+    m.set(`f${frame}`, entry);
+  }
+  return m;
+}
+const keyForFrame = (f: number) => `f${f}`;
+
+test("anchorFramesOf returns ascending has_reasoning indices", () => {
+  const samples = [
+    { has_reasoning: true },
+    { has_reasoning: false },
+    { has_reasoning: false },
+    { has_reasoning: true },
+    { has_reasoning: false },
+  ];
+  expect(anchorFramesOf(samples)).toEqual([0, 3]);
+});
+
+test("carry-forward holds the last present label between 1Hz anchors", () => {
+  const anchors = [0, 10, 20];
+  const cache = cacheOf({ 0: { status: "present", label: { id: "a0" } } });
+  // Frames 0..9 all before the next anchor at 10: label a0 carries forward.
+  for (const frame of [0, 1, 5, 9]) {
+    const sel = selectCarryForwardLabel(anchors, frame, keyForFrame, cache);
+    expect(sel.label?.id).toBe("a0");
+    expect(sel.anchorFrame).toBe(0);
+    expect(sel.isAnchorFrame).toBe(frame === 0);
+  }
+});
+
+test("a newer present anchor wins immediately once crossed", () => {
+  const anchors = [0, 10, 20];
+  const cache = cacheOf({
+    0: { status: "present", label: { id: "a0" } },
+    10: { status: "present", label: { id: "a10" } },
+  });
+  expect(selectCarryForwardLabel(anchors, 9, keyForFrame, cache).label?.id).toBe(
+    "a0",
+  );
+  const at10 = selectCarryForwardLabel(anchors, 10, keyForFrame, cache);
+  expect(at10.label?.id).toBe("a10");
+  expect(at10.isAnchorFrame).toBe(true);
+  expect(
+    selectCarryForwardLabel(anchors, 15, keyForFrame, cache).label?.id,
+  ).toBe("a10");
+});
+
+test("an absent (scoped 404) nearer anchor falls back to the older present one", () => {
+  const anchors = [0, 10, 20];
+  const cache = cacheOf({
+    0: { status: "present", label: { id: "a0" } },
+    10: { status: "absent" },
+  });
+  // Playhead past the absent anchor 10: keep showing a0 rather than blanking,
+  // and it never reports pending for an absent anchor.
+  const sel = selectCarryForwardLabel(anchors, 12, keyForFrame, cache);
+  expect(sel.label?.id).toBe("a0");
+  expect(sel.anchorFrame).toBe(0);
+  expect(sel.pending).toBe(false);
+});
+
+test("no present label yet but an anchor is loading => pending (loading, not none)", () => {
+  const anchors = [0, 10];
+  const cache = cacheOf({ 0: { status: "loading" } });
+  const sel = selectCarryForwardLabel(anchors, 3, keyForFrame, cache);
+  expect(sel.label).toBeNull();
+  expect(sel.pending).toBe(true);
+});
+
+test("before the first anchor there is nothing to carry and nothing pending", () => {
+  const anchors = [10, 20];
+  const sel = selectCarryForwardLabel(anchors, 5, keyForFrame, cacheOf({}));
+  expect(sel.label).toBeNull();
+  expect(sel.anchorFrame).toBe(-1);
+  expect(sel.pending).toBe(false);
+});
+
+test("a future anchor's label never renders on an earlier frame", () => {
+  const anchors = [0, 10];
+  const cache = cacheOf({
+    10: { status: "present", label: { id: "a10" } },
+  });
+  // At frame 5 the only present label is anchored at 10 (future): must not show.
+  expect(selectCarryForwardLabel(anchors, 5, keyForFrame, cache).label).toBeNull();
+});
+
+test("fetch targets: closest uncached backward + immediate forward look-ahead", () => {
+  const anchors = [0, 10, 20];
+  // Nothing cached at frame 12: backward = closest anchor <= 12 (=10),
+  // forward = immediate anchor > 12 (=20).
+  const t = carryForwardFetchTargets(anchors, 12, keyForFrame, cacheOf({}));
+  expect(t.backward).toBe(10);
+  expect(t.forward).toBe(20);
+});
+
+test("fetch targets: stop backward scan at the first present fallback", () => {
+  const anchors = [0, 10, 20];
+  // Anchor 10 present, so no need to fetch anything older; frame 15 has no
+  // forward-uncached beyond 20.
+  const t = carryForwardFetchTargets(
+    anchors,
+    15,
+    keyForFrame,
+    cacheOf({ 10: { status: "present", label: { id: "a10" } } }),
+  );
+  expect(t.backward).toBeUndefined();
+  expect(t.forward).toBe(20);
+});
+
+test("fetch targets: skip absent anchors backward to the next uncached", () => {
+  const anchors = [0, 10, 20];
+  // Anchor 20 absent (scoped 404), 10 uncached: at frame 22 the backward target
+  // is 10 (skipping absent 20), no forward anchor exists.
+  const t = carryForwardFetchTargets(
+    anchors,
+    22,
+    keyForFrame,
+    cacheOf({ 20: { status: "absent" } }),
+  );
+  expect(t.backward).toBe(10);
+  expect(t.forward).toBeUndefined();
+});
+
+test("fetch targets: nothing to do when the nearest backward anchor is loading", () => {
+  const anchors = [0, 10, 20];
+  // 10 loading (in-flight), 20 present forward-of-frame irrelevant. At frame 12,
+  // backward stops at the loading anchor (already in-flight) -> undefined.
+  const t = carryForwardFetchTargets(
+    anchors,
+    12,
+    keyForFrame,
+    cacheOf({ 10: { status: "loading" } }),
+  );
+  expect(t.backward).toBeUndefined();
+  expect(t.forward).toBe(20);
+});

--- a/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
@@ -38,11 +38,11 @@ import { SceneMap } from "@/components/player/scene-map";
 import { TimelineScrubber } from "@/components/player/timeline-scrubber";
 import { TrajectoryBEV } from "@/components/player/trajectory-bev";
 import { ReasoningTimeline } from "@/components/reasoning-timeline";
+import { useCarryForwardLabel } from "@/components/player/use-carry-forward-label";
 import { Button } from "@/components/ui/button";
 import { usePlayback, MAX_SPEED, MIN_SPEED } from "@/hooks/use-playback";
 import {
   ApiError,
-  getReasoningLabel,
   getShardRigProjection,
   getShardOverlay,
   listShardOverlayModels,
@@ -73,7 +73,6 @@ import {
 } from "@/lib/projection";
 import type {
   OverlayModel,
-  ReasoningLabelRecord,
   RigProjectionDocument,
   ShardIndex,
 } from "@/types";
@@ -104,8 +103,6 @@ const SPACE_OWNING_ELEMENTS = [
   '[role="textbox"]',
   '[role="treeitem"]',
 ].join(",");
-
-type LabelState = { key: string; label: ReasoningLabelRecord } | null;
 
 export interface PlayerViewState {
   frame: number;
@@ -491,51 +488,27 @@ export function EpisodePlayer({
       projectTrajectoryRibbonToCameras(rigProjection, groundTruthTrajectory),
     [rigProjection, groundTruthTrajectory],
   );
-  const [reasoning, setReasoning] = useState<LabelState>(null);
-  const [labelStatus, setLabelStatus] = useState<
-    "idle" | "loading" | "ready" | "absent" | "error"
-  >("idle");
-  useEffect(() => {
-    if (!sample?.has_reasoning) {
-      setReasoning(null);
-      setLabelStatus("idle");
-      return;
-    }
-    const key = sample.key;
-    setLabelStatus("loading"); // clear any stale card immediately
-    let cancelled = false;
-    const timer = setTimeout(() => {
-      getReasoningLabel(dataset, key, promptVersion, version, teacher)
-        .then((label) => {
-          if (cancelled) return;
-          setReasoning({ key, label });
-          setLabelStatus("ready");
-        })
-        .catch((err: unknown) => {
-          if (cancelled) return;
-          if (err instanceof ApiError && err.status === 404) {
-            setReasoning(null);
-            setLabelStatus("absent");
-          } else {
-            console.warn("reasoning label fetch failed", err);
-            setReasoning(null);
-            setLabelStatus("error");
-          }
-        });
-    }, 250);
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [
+  // Carry-forward reasoning label: labels attach at ~1Hz but video plays at
+  // 10Hz, so the panel shows the nearest label at or before the playhead
+  // (last-known-good) and swaps to a newer one the instant its anchor is
+  // crossed — never blanking between the sparse anchors. `elapsed*` measure how
+  // stale the shown label is (0 on its own anchor frame).
+  const {
+    label: displayedLabel,
+    anchorFrame,
+    isAnchorFrame,
+    pending: labelPending,
+    elapsedFrames,
+    elapsedSec,
+  } = useCarryForwardLabel({
+    samples: index.samples,
+    frame,
+    fps: index.fps || 10,
     dataset,
     version,
     teacher,
     promptVersion,
-    sample?.key,
-    sample?.has_reasoning,
-    sample,
-  ]);
+  });
 
   const focusCamera = useCallback(
     (idx: number) => {
@@ -703,9 +676,8 @@ export function EpisodePlayer({
             samples={index.samples}
             frame={frame}
             fps={index.fps || 10}
-            reasoning={
-              reasoning?.key === sample?.key ? reasoning.label : null
-            }
+            reasoning={displayedLabel}
+            labelIsAnchorFrame={isAnchorFrame}
             predictionTrajectories={predictionFan}
             medianPrediction={medianPrediction}
             curvatureSign={curvatureSign}
@@ -933,12 +905,38 @@ export function EpisodePlayer({
       )}
 
       <div className="rounded-lg border border-slate-800 bg-slate-950/50 p-4">
-        <p className="mb-3 text-[10px] uppercase tracking-wider text-slate-500">
-          Reasoning label
-        </p>
-        {labelStatus === "ready" && reasoning?.key === sample?.key ? (
-          <ReasoningTimeline label={reasoning.label} />
-        ) : labelStatus === "loading" ? (
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <p className="text-[10px] uppercase tracking-wider text-slate-500">
+            Reasoning label
+          </p>
+          {displayedLabel && (
+            // Staleness of the carried-forward label: 0 on its own anchor
+            // frame, growing until the next ~1Hz anchor swaps it in. Amber past
+            // one label period (>=1s) flags that the expected next label is
+            // missing in this scope.
+            <span
+              role="status"
+              aria-live="polite"
+              className={`font-mono text-[10px] ${
+                elapsedFrames === 0
+                  ? "text-emerald-400"
+                  : elapsedSec >= 1
+                    ? "text-amber-400"
+                    : "text-slate-400"
+              }`}
+              title={`Label anchored at frame ${anchorFrame}; playhead is ${elapsedFrames} frame(s) later`}
+            >
+              {elapsedFrames === 0
+                ? "live · at label anchor"
+                : `carried · t+${elapsedSec.toFixed(1)}s since anchor · ${elapsedFrames} frame${
+                    elapsedFrames === 1 ? "" : "s"
+                  }`}
+            </span>
+          )}
+        </div>
+        {displayedLabel ? (
+          <ReasoningTimeline label={displayedLabel} />
+        ) : labelPending ? (
           <p
             role="status"
             aria-live="polite"
@@ -946,18 +944,13 @@ export function EpisodePlayer({
           >
             Loading label…
           </p>
-        ) : labelStatus === "error" ? (
-          <p role="alert" className="text-sm text-amber-500">
-            Could not load the label for this frame. It may retry on the next
-            step.
-          </p>
         ) : (
           <p
             role="status"
             aria-live="polite"
             className="text-sm text-slate-500"
           >
-            No reasoning label at this frame
+            No reasoning label at or before this frame
             {promptVersion ? " for the selected teacher and prompt version" : ""}. Amber
             ticks on the timeline mark frames labelled in any run, so a ticked
             frame may still be unlabelled in this one.

--- a/Tools/DataModelConsole/web/src/components/player/trajectory-bev.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/trajectory-bev.tsx
@@ -27,6 +27,7 @@ export function TrajectoryBEV({
   frame,
   fps = 10,
   reasoning,
+  labelIsAnchorFrame = false,
   predictionTrajectories = [],
   medianPrediction = [],
   curvatureSign = 1,
@@ -34,10 +35,15 @@ export function TrajectoryBEV({
   samples: IndexSample[];
   frame: number;
   fps?: number;
-  // Reasoning label for the current frame (when loaded). Its horizons are
-  // pinned onto the plan path at the matching rollout step so the reasoning
-  // cards and the geometry line up in time.
+  // Reasoning label to describe. Under carry-forward it may be a label anchored
+  // on an EARLIER frame than the one on screen; its horizons are relative to
+  // that anchor's own pose/plan, so they can only be pinned onto this frame's
+  // plan when the anchor IS the current frame (labelIsAnchorFrame).
   reasoning?: ReasoningLabelRecord | null;
+  // True only when the displayed label's anchor === the current frame. The
+  // t+Ns horizon dots are drawn onto `traj` (this frame's plan), which is
+  // correct geometry solely on the anchor frame; otherwise they are suppressed.
+  labelIsAnchorFrame?: boolean;
   predictionTrajectories?: TrajectoryPoint[][];
   medianPrediction?: TrajectoryPoint[];
   curvatureSign?: 1 | -1;
@@ -192,7 +198,12 @@ export function TrajectoryBEV({
   // (step = round(t*fps)) sits at traj[step-1]; t=0 is the ego origin. Using
   // traj[step] would place every dot one 10Hz step (+0.1s) too far ahead.
   const horizonDots = useMemo(() => {
-    if (!reasoning?.horizons?.length) return [];
+    // Only pin dots when the label's anchor is THIS frame. traj is the current
+    // frame's plan; a carried-forward label from an earlier anchor described a
+    // different pose/plan, so placing its t+Ns markers here would invent
+    // waypoints neither frame predicted. On non-anchor frames the panel's
+    // "carried · t+X.Xs" indicator conveys the label instead.
+    if (!labelIsAnchorFrame || !reasoning?.horizons?.length) return [];
     const out: { x: number; y: number; sec: number }[] = [];
     for (const h of reasoning.horizons) {
       const step = Math.round(h.horizon_sec * (fps || 10));
@@ -203,7 +214,7 @@ export function TrajectoryBEV({
     return out;
     // sx/sy derive from scale/cx/cy; traj + reasoning + fps drive the result.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reasoning, traj, fps, scale]);
+  }, [reasoning, labelIsAnchorFrame, traj, fps, scale]);
 
   const speed = samples[frame]?.ego_now?.[0] ?? 0;
   // planSec is the plan horizon; the amber realized path is clipped to the same

--- a/Tools/DataModelConsole/web/src/components/player/use-carry-forward-label.ts
+++ b/Tools/DataModelConsole/web/src/components/player/use-carry-forward-label.ts
@@ -52,7 +52,9 @@ export function useCarryForwardLabel({
   // the fresh cache with cross-scope labels.
   const scopeRef = useRef(0);
   // Re-render trigger when a fetch resolves (the cache is a ref, not state).
-  const [, setTick] = useState(0);
+  // `tick` is a selector dependency so a resolution re-selects even while
+  // paused, when `frame` is not changing to drive the recompute on its own.
+  const [tick, setTick] = useState(0);
   const rerender = useCallback(() => setTick((t) => t + 1), []);
 
   const anchorFrames = useMemo(() => anchorFramesOf(samples), [samples]);
@@ -72,19 +74,18 @@ export function useCarryForwardLabel({
     rerender();
   }, [dataset, version, teacher, promptVersion, rerender]);
 
-  const selection = useMemo(
-    () =>
-      selectCarryForwardLabel(
-        anchorFrames,
-        frame,
-        keyForFrame,
-        cacheRef.current,
-      ),
-    // cacheRef.current is mutated in place; setTick (via `tick`) forces this to
-    // recompute when a fetch resolves. anchorFrames/frame/keyForFrame are the
-    // real inputs.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [anchorFrames, frame, keyForFrame, samples],
+  // Computed inline (not memoized) because it reads the mutable cacheRef: the
+  // component re-renders on every `frame` change and on every `tick` bump (a
+  // fetch resolving), which are exactly the moments the selection can change, so
+  // a fresh scan each render is both correct and cheap — the backward walk is
+  // over the sparse ~1Hz anchors, not every frame. `tick` is referenced so the
+  // dependency is explicit to readers even though the value isn't used directly.
+  void tick;
+  const selection = selectCarryForwardLabel(
+    anchorFrames,
+    frame,
+    keyForFrame,
+    cacheRef.current,
   );
 
   // Fetch driver: at most one backward (fill the label to show) + one forward
@@ -130,9 +131,9 @@ export function useCarryForwardLabel({
           rerender();
         });
     }
-    // setTick drives re-evaluation after each resolution via the closure over
-    // cacheRef; scope inputs re-run this when the partition changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // A resolution mutates cacheRef and calls rerender(); the parent re-renders
+    // and this effect re-runs (frame typically also changed), re-planning the
+    // next fetch target. Scope inputs re-run it when the partition changes.
   }, [
     anchorFrames,
     frame,

--- a/Tools/DataModelConsole/web/src/components/player/use-carry-forward-label.ts
+++ b/Tools/DataModelConsole/web/src/components/player/use-carry-forward-label.ts
@@ -1,0 +1,157 @@
+"use client";
+
+// useCarryForwardLabel: keeps a reasoning label on screen continuously during
+// playback. Labels attach at ~1 Hz while video runs at 10 Hz, so instead of
+// showing a label only on its own frame (blanking the other ~9), this fetches
+// the sparse anchor frames lazily into a scope-keyed cache and always displays
+// the nearest present label at or before the playhead — carry-forward.
+//
+// The selection + fetch-target logic is the pure core in
+// lib/reasoning-carry-forward; this hook owns the cache, the fetches, and the
+// React state.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { ApiError, getReasoningLabel } from "@/lib/api";
+import {
+  anchorFramesOf,
+  carryForwardFetchTargets,
+  selectCarryForwardLabel,
+  type CacheEntry,
+  type CarrySelection,
+} from "@/lib/reasoning-carry-forward";
+import type { IndexSample, ReasoningLabelRecord } from "@/types";
+
+export interface CarryForwardLabel extends CarrySelection<ReasoningLabelRecord> {
+  // Frames elapsed since the displayed label's anchor (>= 0; 0 on the anchor
+  // frame). Zero when there is no displayed label.
+  elapsedFrames: number;
+  elapsedSec: number;
+}
+
+export function useCarryForwardLabel({
+  samples,
+  frame,
+  fps,
+  dataset,
+  version,
+  teacher,
+  promptVersion,
+}: {
+  samples: IndexSample[];
+  frame: number;
+  fps: number;
+  dataset: string;
+  version?: string;
+  teacher?: string;
+  promptVersion?: string;
+}): CarryForwardLabel {
+  const cacheRef = useRef(new Map<string, CacheEntry<ReasoningLabelRecord>>());
+  // Fetch-generation token: bumped whenever the scope changes so in-flight
+  // responses resolving after a scope switch are discarded instead of poisoning
+  // the fresh cache with cross-scope labels.
+  const scopeRef = useRef(0);
+  // Re-render trigger when a fetch resolves (the cache is a ref, not state).
+  const [, setTick] = useState(0);
+  const rerender = useCallback(() => setTick((t) => t + 1), []);
+
+  const anchorFrames = useMemo(() => anchorFramesOf(samples), [samples]);
+
+  const keyForFrame = useCallback(
+    (f: number) => samples[f]?.key,
+    [samples],
+  );
+
+  // Reset on scope change: clear the cache, invalidate in-flight fetches, and
+  // re-render so the panel falls back to loading/none under the new scope. A new
+  // Map identity (not .clear()) keeps any captured closure from mutating the old
+  // one after the swap.
+  useEffect(() => {
+    cacheRef.current = new Map();
+    scopeRef.current += 1;
+    rerender();
+  }, [dataset, version, teacher, promptVersion, rerender]);
+
+  const selection = useMemo(
+    () =>
+      selectCarryForwardLabel(
+        anchorFrames,
+        frame,
+        keyForFrame,
+        cacheRef.current,
+      ),
+    // cacheRef.current is mutated in place; setTick (via `tick`) forces this to
+    // recompute when a fetch resolves. anchorFrames/frame/keyForFrame are the
+    // real inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [anchorFrames, frame, keyForFrame, samples],
+  );
+
+  // Fetch driver: at most one backward (fill the label to show) + one forward
+  // (look-ahead so the next anchor swaps with no gap) fetch per frame move.
+  // Cache-status dedupe throttles it — no debounce timer, which is correct under
+  // continuous 10 Hz playback where `frame` changes every tick.
+  useEffect(() => {
+    const cache = cacheRef.current;
+    const { backward, forward } = carryForwardFetchTargets(
+      anchorFrames,
+      frame,
+      keyForFrame,
+      cache,
+    );
+    const targets = [backward, forward].filter(
+      (f): f is number => f !== undefined,
+    );
+    if (targets.length === 0) return;
+
+    const myScope = scopeRef.current;
+    for (const af of targets) {
+      const key = keyForFrame(af);
+      if (!key || cache.get(key)) continue; // already loading/present/absent
+      cache.set(key, { status: "loading" });
+      getReasoningLabel(dataset, key, promptVersion, version, teacher)
+        .then((label) => {
+          if (scopeRef.current !== myScope) return; // scope changed mid-flight
+          cacheRef.current.set(key, { status: "present", label });
+          rerender();
+        })
+        .catch((err: unknown) => {
+          if (scopeRef.current !== myScope) return;
+          if (err instanceof ApiError && err.status === 404) {
+            // Not labelled in this scope: negative-cache so the selector skips
+            // it and the playhead crossing it does not blank the panel.
+            cacheRef.current.set(key, { status: "absent" });
+          } else {
+            // Transient failure: drop back to uncached so the next frame move
+            // retries, instead of dead-ending on an error state.
+            cacheRef.current.delete(key);
+            console.warn("reasoning label fetch failed", err);
+          }
+          rerender();
+        });
+    }
+    // setTick drives re-evaluation after each resolution via the closure over
+    // cacheRef; scope inputs re-run this when the partition changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    anchorFrames,
+    frame,
+    keyForFrame,
+    dataset,
+    version,
+    teacher,
+    promptVersion,
+    rerender,
+  ]);
+
+  const elapsedFrames =
+    selection.label && selection.anchorFrame >= 0
+      ? Math.max(0, frame - selection.anchorFrame)
+      : 0;
+
+  return {
+    ...selection,
+    elapsedFrames,
+    elapsedSec: elapsedFrames / (fps || 10),
+  };
+}

--- a/Tools/DataModelConsole/web/src/components/player/use-carry-forward-label.ts
+++ b/Tools/DataModelConsole/web/src/components/player/use-carry-forward-label.ts
@@ -48,56 +48,74 @@ export function useCarryForwardLabel({
 }): CarryForwardLabel {
   const cacheRef = useRef(new Map<string, CacheEntry<ReasoningLabelRecord>>());
   // Fetch-generation token: bumped whenever the scope changes so in-flight
-  // responses resolving after a scope switch are discarded instead of poisoning
-  // the fresh cache with cross-scope labels.
+  // responses resolving after a scope switch are discarded instead of writing a
+  // stale entry into the freshly-cleared cache.
   const scopeRef = useRef(0);
   // Re-render trigger when a fetch resolves (the cache is a ref, not state).
-  // `tick` is a selector dependency so a resolution re-selects even while
-  // paused, when `frame` is not changing to drive the recompute on its own.
+  // `tick` is a dependency of BOTH the selector and the fetch effect: a
+  // resolution must re-select the shown label AND re-plan the next fetch even
+  // while paused, when `frame` is not advancing to drive either on its own.
   const [tick, setTick] = useState(0);
   const rerender = useCallback(() => setTick((t) => t + 1), []);
 
   const anchorFrames = useMemo(() => anchorFramesOf(samples), [samples]);
 
-  const keyForFrame = useCallback(
+  // The cache is keyed by scope + sample so a render that happens BEFORE the
+  // scope-reset effect commits cannot read a prior scope's label (React runs
+  // render before effects): under the new scope the lookup key differs and
+  // misses, instead of momentarily painting the old teacher/prompt's label.
+  const scopeKey = useMemo(
+    () => [dataset, version ?? "", teacher ?? "", promptVersion ?? ""].join(" "),
+    [dataset, version, teacher, promptVersion],
+  );
+  // Raw WebDataset sample key (for the API call) vs the scope-qualified cache
+  // key (for the Map). The pure core treats keyForFrame as an opaque cache key,
+  // so it gets the scope-qualified one.
+  const sampleKeyForFrame = useCallback(
     (f: number) => samples[f]?.key,
     [samples],
   );
+  const cacheKeyForFrame = useCallback(
+    (f: number) => {
+      const k = samples[f]?.key;
+      return k === undefined ? undefined : `${scopeKey} ${k}`;
+    },
+    [samples, scopeKey],
+  );
 
-  // Reset on scope change: clear the cache, invalidate in-flight fetches, and
-  // re-render so the panel falls back to loading/none under the new scope. A new
-  // Map identity (not .clear()) keeps any captured closure from mutating the old
-  // one after the swap.
+  // Reset on scope change: drop the old scope's entries (memory) and invalidate
+  // in-flight fetches via the generation token. Correctness of what's SHOWN does
+  // not depend on this effect's timing — the scope-qualified keys already make a
+  // pre-commit render miss the old scope — so this is pure hygiene.
   useEffect(() => {
     cacheRef.current = new Map();
     scopeRef.current += 1;
     rerender();
-  }, [dataset, version, teacher, promptVersion, rerender]);
+  }, [scopeKey, rerender]);
 
   // Computed inline (not memoized) because it reads the mutable cacheRef: the
-  // component re-renders on every `frame` change and on every `tick` bump (a
-  // fetch resolving), which are exactly the moments the selection can change, so
-  // a fresh scan each render is both correct and cheap — the backward walk is
-  // over the sparse ~1Hz anchors, not every frame. `tick` is referenced so the
-  // dependency is explicit to readers even though the value isn't used directly.
-  void tick;
+  // component re-renders on every `frame` change and every `tick` bump (a fetch
+  // resolving), which are exactly the moments the selection can change, so a
+  // fresh scan each render is both correct and cheap — the backward walk is over
+  // the sparse ~1Hz anchors, not every frame.
   const selection = selectCarryForwardLabel(
     anchorFrames,
     frame,
-    keyForFrame,
+    cacheKeyForFrame,
     cacheRef.current,
   );
 
-  // Fetch driver: at most one backward (fill the label to show) + one forward
-  // (look-ahead so the next anchor swaps with no gap) fetch per frame move.
-  // Cache-status dedupe throttles it — no debounce timer, which is correct under
-  // continuous 10 Hz playback where `frame` changes every tick.
+  // Fetch driver: one backward (the label to show) + one forward (look-ahead so
+  // the next anchor swaps with no gap) fetch per invocation. It re-runs on every
+  // `frame` change AND every `tick` bump, so the backward walk past scoped-404
+  // (absent) anchors advances one step per resolution even while PAUSED — not
+  // only while `frame` is ticking. Cache-status dedupe throttles it (no timer).
   useEffect(() => {
     const cache = cacheRef.current;
     const { backward, forward } = carryForwardFetchTargets(
       anchorFrames,
       frame,
-      keyForFrame,
+      cacheKeyForFrame,
       cache,
     );
     const targets = [backward, forward].filter(
@@ -107,13 +125,14 @@ export function useCarryForwardLabel({
 
     const myScope = scopeRef.current;
     for (const af of targets) {
-      const key = keyForFrame(af);
-      if (!key || cache.get(key)) continue; // already loading/present/absent
-      cache.set(key, { status: "loading" });
-      getReasoningLabel(dataset, key, promptVersion, version, teacher)
+      const cacheKey = cacheKeyForFrame(af);
+      const sampleKey = sampleKeyForFrame(af);
+      if (!cacheKey || !sampleKey || cache.get(cacheKey)) continue; // deduped
+      cache.set(cacheKey, { status: "loading" });
+      getReasoningLabel(dataset, sampleKey, promptVersion, version, teacher)
         .then((label) => {
           if (scopeRef.current !== myScope) return; // scope changed mid-flight
-          cacheRef.current.set(key, { status: "present", label });
+          cacheRef.current.set(cacheKey, { status: "present", label });
           rerender();
         })
         .catch((err: unknown) => {
@@ -121,23 +140,28 @@ export function useCarryForwardLabel({
           if (err instanceof ApiError && err.status === 404) {
             // Not labelled in this scope: negative-cache so the selector skips
             // it and the playhead crossing it does not blank the panel.
-            cacheRef.current.set(key, { status: "absent" });
+            // rerender() so the tick-keyed effect re-runs and the backward walk
+            // advances to the next older anchor even while paused.
+            cacheRef.current.set(cacheKey, { status: "absent" });
+            rerender();
           } else {
-            // Transient failure: drop back to uncached so the next frame move
-            // retries, instead of dead-ending on an error state.
-            cacheRef.current.delete(key);
+            // Transient failure: drop back to uncached so a later fetch retries.
+            // Do NOT rerender here — with `tick` in the effect deps that would
+            // re-run the effect and immediately re-fetch the same key, hammering
+            // a persistent 5xx in a tight loop while paused. The display is
+            // unchanged (loading -> uncached both read as pending), so the retry
+            // waits for the next frame move instead.
+            cacheRef.current.delete(cacheKey);
             console.warn("reasoning label fetch failed", err);
           }
-          rerender();
         });
     }
-    // A resolution mutates cacheRef and calls rerender(); the parent re-renders
-    // and this effect re-runs (frame typically also changed), re-planning the
-    // next fetch target. Scope inputs re-run it when the partition changes.
   }, [
     anchorFrames,
     frame,
-    keyForFrame,
+    tick,
+    cacheKeyForFrame,
+    sampleKeyForFrame,
     dataset,
     version,
     teacher,

--- a/Tools/DataModelConsole/web/src/lib/reasoning-carry-forward.ts
+++ b/Tools/DataModelConsole/web/src/lib/reasoning-carry-forward.ts
@@ -1,0 +1,129 @@
+// Carry-forward selection for reasoning labels during playback.
+//
+// Reasoning labels attach at ~1 Hz (Platform label_stride=10: every frame where
+// frame_idx % 10 == 0, plus each split group's first valid sample), while video
+// plays at 10 Hz. So most frames have no label of their own. To QA label
+// accuracy during smooth playback we keep the LAST-KNOWN label on screen and
+// swap to a newer one the instant the playhead crosses its anchor — the panel
+// never blanks between the ~1 Hz anchors.
+//
+// This module is the pure, framework-free core (selection + fetch-target
+// planning) so it is unit-testable; the React wiring lives in the
+// use-carry-forward-label hook.
+
+// A frame carries a reasoning label member (candidate for fetching). The shard
+// index's has_reasoning is derived from a packed reasoning.json and is NOT
+// scoped to a selected (teacher, prompt_version), so a scoped fetch may still
+// 404 — that negative result is cached as "absent" and skipped over.
+export interface HasReasoningFrame {
+  has_reasoning: boolean;
+}
+
+export type CacheStatus = "loading" | "present" | "absent";
+
+// One anchor frame's fetch state. `label` is set only when status === "present".
+// A transient (non-404) fetch error is NOT represented here: the hook clears the
+// key back to uncached so it retries, rather than dead-ending on an error state.
+export interface CacheEntry<Label> {
+  status: CacheStatus;
+  label?: Label;
+}
+
+export interface CarrySelection<Label> {
+  // The label to display (nearest present at or before the playhead), or null.
+  label: Label | null;
+  // The frame the displayed label was anchored to (-1 when label is null).
+  anchorFrame: number;
+  // True when the displayed label's anchor IS the current frame (elapsed 0).
+  // Drives whether the BEV may pin horizon dots (they are only geometrically
+  // valid on the anchor frame's own plan).
+  isAnchorFrame: boolean;
+  // No present label at/before the playhead yet, but an anchor <= frame is still
+  // loading or not-yet-fetched — so the correct UI is "loading", not "none".
+  pending: boolean;
+}
+
+// anchorFramesOf returns the ascending frame indices that carry a reasoning
+// label member (the candidate anchors).
+export function anchorFramesOf(samples: HasReasoningFrame[]): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < samples.length; i++) {
+    if (samples[i].has_reasoning) out.push(i);
+  }
+  return out;
+}
+
+// selectCarryForwardLabel picks the nearest cached-present label at or before
+// `frame`, scanning anchors newest-first so a newer label always wins and an
+// out-of-scope (absent) or still-loading nearer anchor is skipped in favour of
+// an older present one — the carry-forward. It considers only anchors <= frame,
+// so a future anchor's label can never render on an earlier frame (this
+// structurally removes the "in-flight response for a prior frame renders on the
+// current one" class of bug the old effect guarded against by hand).
+export function selectCarryForwardLabel<Label>(
+  anchorFrames: number[],
+  frame: number,
+  keyForFrame: (f: number) => string | undefined,
+  cache: Map<string, CacheEntry<Label>>,
+): CarrySelection<Label> {
+  let pending = false;
+  for (let i = anchorFrames.length - 1; i >= 0; i--) {
+    const af = anchorFrames[i];
+    if (af > frame) continue;
+    const key = keyForFrame(af);
+    const entry = key ? cache.get(key) : undefined;
+    if (entry?.status === "present" && entry.label != null) {
+      return {
+        label: entry.label,
+        anchorFrame: af,
+        isAnchorFrame: af === frame,
+        pending: false,
+      };
+    }
+    // The nearest actionable anchor is still resolving (or not yet fetched):
+    // remember we're pending, but keep scanning older anchors for a present
+    // fallback so playback shows the last-known label instead of blanking.
+    if (!entry || entry.status === "loading") pending = true;
+    // status "absent" (scoped 404) → skip and continue to the older anchor.
+  }
+  return { label: null, anchorFrame: -1, isAnchorFrame: false, pending };
+}
+
+// carryForwardFetchTargets returns which anchors the driver should fetch now:
+//  - backward: the closest uncached anchor <= frame, stopping the scan once a
+//    present anchor is reached (a fresher fallback already exists closer to the
+//    playhead, so older-than-present anchors are irrelevant). Absent anchors are
+//    skipped so a scoped 404 falls through to the next real label.
+//  - forward: the immediate next anchor > frame, if uncached, so crossing it
+//    swaps with no loading gap (look-ahead prefetch).
+// Anchors already loading/present/absent are never re-fetched; that cache-status
+// dedupe is the throttle (no timer needed, correct under continuous 10 Hz play).
+export function carryForwardFetchTargets<Label>(
+  anchorFrames: number[],
+  frame: number,
+  keyForFrame: (f: number) => string | undefined,
+  cache: Map<string, CacheEntry<Label>>,
+): { backward?: number; forward?: number } {
+  let backward: number | undefined;
+  for (let i = anchorFrames.length - 1; i >= 0; i--) {
+    const af = anchorFrames[i];
+    if (af > frame) continue;
+    const key = keyForFrame(af);
+    const entry = key ? cache.get(key) : undefined;
+    if (entry?.status === "present") break; // fresher fallback exists; stop
+    if (entry?.status === "absent" || entry?.status === "loading") continue;
+    backward = af; // closest uncached anchor <= frame
+    break;
+  }
+
+  let forward: number | undefined;
+  for (let i = 0; i < anchorFrames.length; i++) {
+    const af = anchorFrames[i];
+    if (af <= frame) continue;
+    const key = keyForFrame(af);
+    if (key && !cache.get(key)) forward = af;
+    break; // only the immediate next anchor > frame is prefetched
+  }
+
+  return { backward, forward };
+}

--- a/Tools/DataModelConsole/web/src/lib/reasoning-carry-forward.ts
+++ b/Tools/DataModelConsole/web/src/lib/reasoning-carry-forward.ts
@@ -90,10 +90,12 @@ export function selectCarryForwardLabel<Label>(
 }
 
 // carryForwardFetchTargets returns which anchors the driver should fetch now:
-//  - backward: the closest uncached anchor <= frame, stopping the scan once a
-//    present anchor is reached (a fresher fallback already exists closer to the
-//    playhead, so older-than-present anchors are irrelevant). Absent anchors are
-//    skipped so a scoped 404 falls through to the next real label.
+//  - backward: the closest uncached anchor <= frame. The scan STOPS at a present
+//    OR loading anchor — a fallback already exists or is resolving, so there is
+//    nothing to fetch yet. It only walks past an ABSENT anchor (scoped 404) to
+//    the next older one. This bounds fetching: on a cold jump into a late frame
+//    we fetch the nearest anchor and then walk back at most one-per-resolution
+//    as absents are discovered, never the whole prior-anchor set at once.
 //  - forward: the immediate next anchor > frame, if uncached, so crossing it
 //    swaps with no loading gap (look-ahead prefetch).
 // Anchors already loading/present/absent are never re-fetched; that cache-status
@@ -110,8 +112,10 @@ export function carryForwardFetchTargets<Label>(
     if (af > frame) continue;
     const key = keyForFrame(af);
     const entry = key ? cache.get(key) : undefined;
-    if (entry?.status === "present") break; // fresher fallback exists; stop
-    if (entry?.status === "absent" || entry?.status === "loading") continue;
+    // A present or in-flight anchor is (or will be) the fallback — wait for it
+    // instead of speculatively fetching older anchors (fetch-storm guard).
+    if (entry?.status === "present" || entry?.status === "loading") break;
+    if (entry?.status === "absent") continue; // scoped 404: try the next older
     backward = af; // closest uncached anchor <= frame
     break;
   }


### PR DESCRIPTION
## What

Reasoning labels attach at ~1 Hz (Platform `label_stride=10`) while the player
runs video at 10 Hz, so the reasoning panel showed a label only on its own frame
and blanked for the other ~9. This makes the panel display the nearest label at
or before the playhead continuously (last-known-good), swapping to a newer label
the instant its anchor is crossed, with a "t+X.Xs since anchor" staleness
indicator so a reviewer can tell at a glance how stale the shown label is.

Purpose: visually QA Cosmos label accuracy during smooth playback.

## How

- `lib/reasoning-carry-forward.ts` — pure, unit-tested core: select the nearest
  present label at/before the playhead, and plan which anchor to fetch next.
- `use-carry-forward-label.ts` — React hook: scope-keyed label cache, lazy fetch
  (one backward + one forward look-ahead per move), 404 negative-cache, in-flight
  invalidation across teacher/prompt/version scope changes.
- `episode-player.tsx` — replace the per-frame gated fetch with the hook; add the
  elapsed indicator.
- `trajectory-bev.tsx` — pin the t+Ns horizon dots only on the label's own anchor
  frame; a carried-forward label describes a past pose, so pinning its horizons on
  the current plan would fabricate waypoints.

## Notes

- `has_reasoning` in the shard index is "labelled in any run", not scoped to the
  selected (teacher, prompt_version); a scoped fetch may still 404, which is
  negative-cached and skipped so the panel never blanks between anchors.

## Testing

- 13 unit specs (pure core): 1 Hz hold, immediate swap, scoped-404 fallback,
  paused-backfill convergence, fetch-storm guard.
- tsc, eslint, `next build`, and the pure-logic specs all pass on the dev box.
