### PR TITLE
feat(console): KITScenes 3x2 camera grid with matched aspect ratio

### DIFF
--- a/Tools/DataModelConsole/web/e2e/rig-layout.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/rig-layout.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  camLabel,
+  displayAspectRatio,
+  gridDimensions,
+  isHiddenCam,
+  rigCam,
+} from "../src/lib/rig";
+
+// The camera members packed in a KITScenes shard (cam_0..cam_6), and the set
+// the console displays after hiding the redundant ring-front (cam_1).
+const KIT_PACKED = [
+  "cam_0",
+  "cam_1",
+  "cam_2",
+  "cam_3",
+  "cam_4",
+  "cam_5",
+  "cam_6",
+];
+const kitDisplayed = KIT_PACKED.filter((c) => !isHiddenCam("kitscenes", c));
+
+test("KITScenes hides only the redundant ring-front (cam_1)", () => {
+  expect(isHiddenCam("kitscenes", "cam_1")).toBe(true);
+  expect(kitDisplayed).toEqual([
+    "cam_0",
+    "cam_2",
+    "cam_3",
+    "cam_4",
+    "cam_5",
+    "cam_6",
+  ]);
+  // Other datasets hide nothing.
+  expect(isHiddenCam("nvidia_av", "cam_1")).toBe(false);
+  expect(isHiddenCam("l2d", "cam_1")).toBe(false);
+});
+
+test("KITScenes displayed cameras form a filled 3x2 grid (no gaps, no ego cell)", () => {
+  const { rows, cols } = gridDimensions("kitscenes", kitDisplayed);
+  expect({ rows, cols }).toEqual({ rows: 2, cols: 3 });
+
+  // Every one of the 6 cells is claimed exactly once by a displayed camera.
+  const cells = kitDisplayed.map((cam, i) => {
+    const c = rigCam("kitscenes", cam, i);
+    return `${c.row}:${c.col}`;
+  });
+  expect(new Set(cells).size).toBe(6);
+  expect([...cells].sort()).toEqual([
+    "1:1",
+    "1:2",
+    "1:3",
+    "2:1",
+    "2:2",
+    "2:3",
+  ]);
+
+  // The centre cell the ego tile would occupy — ceil(rows/2)=1, ceil(cols/2)=2 —
+  // is claimed by front-center, so the mosaic's egoInFreeCell check drops the
+  // ego tile (the car icon).
+  const egoCell = `${Math.ceil(rows / 2)}:${Math.ceil(cols / 2)}`;
+  expect(cells).toContain(egoCell);
+});
+
+test("forward cameras are on the top row, rear on the bottom, left-to-right", () => {
+  const at = (cam: string) => rigCam("kitscenes", cam, 0);
+  expect(at("cam_2")).toMatchObject({ label: "front-left", row: 1, col: 1 });
+  expect(at("cam_0")).toMatchObject({ label: "front-center", row: 1, col: 2 });
+  expect(at("cam_3")).toMatchObject({ label: "front-right", row: 1, col: 3 });
+  expect(at("cam_5")).toMatchObject({ label: "rear-left", row: 2, col: 1 });
+  expect(at("cam_4")).toMatchObject({ label: "rear", row: 2, col: 2 });
+  expect(at("cam_6")).toMatchObject({ label: "rear-right", row: 2, col: 3 });
+});
+
+test("NVIDIA and L2D rigs are unchanged (still 3x3, ego cell free)", () => {
+  const nvidia = ["cam_0", "cam_1", "cam_2", "cam_3", "cam_4", "cam_5", "cam_6"];
+  expect(gridDimensions("nvidia_av", nvidia)).toEqual({ rows: 3, cols: 3 });
+  // NVIDIA centre (2,2) is the ego cell and no camera claims it.
+  const nvidiaCells = nvidia.map((cam, i) => {
+    const c = rigCam("nvidia_av", cam, i);
+    return `${c.row}:${c.col}`;
+  });
+  expect(nvidiaCells).not.toContain("2:2");
+
+  const l2d = ["cam_0", "cam_1", "cam_2", "cam_3", "cam_4", "cam_5"];
+  expect(gridDimensions("l2d", l2d)).toEqual({ rows: 3, cols: 3 });
+});
+
+test("displayAspectRatio matches the packed image shape per dataset", () => {
+  // KITScenes cameras are packed 256x256 (1:1).
+  expect(displayAspectRatio("kitscenes")).toBe(1);
+  // Others keep the 16:9 default (unchanged layout).
+  expect(displayAspectRatio("nvidia_av")).toBeCloseTo(16 / 9, 6);
+  expect(displayAspectRatio("l2d")).toBeCloseTo(16 / 9, 6);
+  expect(displayAspectRatio("unknown")).toBeCloseTo(16 / 9, 6);
+});
+
+test("unknown datasets fall back to sequential placement and raw labels", () => {
+  expect(rigCam("mystery", "cam_0", 0)).toMatchObject({
+    label: "cam_0",
+    row: 1,
+    col: 1,
+  });
+  expect(rigCam("mystery", "cam_4", 4)).toMatchObject({ row: 2, col: 2 });
+  expect(camLabel("mystery", "cam_0")).toBe("cam_0");
+});

--- a/Tools/DataModelConsole/web/src/components/player/camera-mosaic.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/camera-mosaic.tsx
@@ -18,7 +18,7 @@ import type {
   ScreenPoint,
   ScreenRibbon,
 } from "@/lib/projection";
-import { camLabel, gridDimensions, rigCam } from "@/lib/rig";
+import { camLabel, displayAspectRatio, gridDimensions, rigCam } from "@/lib/rig";
 import { cn } from "@/lib/utils";
 import type { IndexSample } from "@/types";
 
@@ -159,6 +159,7 @@ function CanvasTile({
   predictionRibbons,
   groundTruthRibbons,
   className,
+  aspectRatio,
   onClick,
   selected = false,
 }: {
@@ -166,11 +167,14 @@ function CanvasTile({
   frame: number;
   cam: string;
   label: string;
-  ordinal?: number; // 1-based badge matching the "1-7" focus shortcut
+  ordinal?: number; // 1-based badge matching the number-key focus shortcut
   predictionPaths?: ScreenPoint[][];
   predictionRibbons?: ScreenRibbon[];
   groundTruthRibbons?: ScreenRibbon[];
   className?: string;
+  // width/height the tile frame reserves; matches the packed image so there is
+  // no letterbox gap. Omit to keep the CSS-class-driven ratio.
+  aspectRatio?: number;
   onClick: () => void;
   selected?: boolean;
 }) {
@@ -269,6 +273,7 @@ function CanvasTile({
         "relative block overflow-hidden rounded-md border border-slate-800 bg-slate-900 p-0 text-left transition-colors hover:border-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-slate-300",
         className,
       )}
+      style={aspectRatio ? { aspectRatio } : undefined}
       onClick={onClick}
       aria-label={`${label} camera`}
       aria-pressed={selected}
@@ -389,6 +394,9 @@ export function CameraMosaic({
   const hasGroundTruth = Object.values(groundTruthRibbons ?? {}).some(
     (ribbons) => ribbons.length > 0,
   );
+  // Tile frame shape for this dataset (KITScenes is 256x256 square; others 16:9)
+  // so the frame matches the packed image with no letterbox gap.
+  const aspectRatio = displayAspectRatio(dataset);
   if (mode === "focus") {
     const focusedIdx = Math.min(Math.max(focusCam, 0), cams.length - 1);
     const focused = cams[focusedIdx];
@@ -407,7 +415,8 @@ export function CameraMosaic({
             predictionPaths={predictionPaths?.[focused]}
             predictionRibbons={predictionRibbons?.[focused]}
             groundTruthRibbons={groundTruthRibbons?.[focused]}
-            className="aspect-video w-full"
+            className="w-full"
+            aspectRatio={aspectRatio}
             onClick={onToggleFocus}
             selected
           />
@@ -438,9 +447,10 @@ export function CameraMosaic({
               predictionRibbons={predictionRibbons?.[cam]}
               groundTruthRibbons={groundTruthRibbons?.[cam]}
               className={cn(
-                "aspect-video min-w-28 basis-28 shrink-0 grow",
+                "min-w-28 basis-28 shrink-0 grow",
                 cam === focused && "ring-1 ring-blue-500",
               )}
+              aspectRatio={aspectRatio}
               onClick={() => onSelectCam(i)}
               selected={cam === focused}
             />
@@ -493,7 +503,8 @@ export function CameraMosaic({
                 predictionPaths={predictionPaths?.[cam]}
                 predictionRibbons={predictionRibbons?.[cam]}
                 groundTruthRibbons={groundTruthRibbons?.[cam]}
-                className="aspect-video w-full"
+                className="w-full"
+                aspectRatio={aspectRatio}
                 onClick={() => onSelectCam(i)}
                 selected={false}
               />

--- a/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
@@ -675,7 +675,7 @@ export function EpisodePlayer({
       ref={containerRef}
       tabIndex={0}
       className="space-y-4 outline-none focus-visible:ring-1 focus-visible:ring-slate-600 rounded-lg"
-      aria-label="Episode player (keyboard: space, arrows, 1-7, f, ? for help)"
+      aria-label={`Episode player (keyboard: space, arrows, 1-${Math.min(9, cams.length)}, f, ? for help)`}
     >
       <OverlaySelectionBar
         models={overlayModels}

--- a/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
@@ -8,7 +8,7 @@
 //   ArrowLeft/Right  step one frame
 //   , / .        step one frame back/forward
 //   [ / - and ] / +  slower/faster
-//   1-7          focus camera n
+//   1-N          focus camera n (N = displayed camera count)
 //   f            toggle focus/grid
 //   Esc          back to grid
 
@@ -48,6 +48,7 @@ import {
   listShardOverlayModels,
 } from "@/lib/api";
 import { FrameStore } from "@/lib/frame-store";
+import { isHiddenCam } from "@/lib/rig";
 import {
   decodeEgo,
   integrateInterleavedControl,
@@ -190,8 +191,9 @@ export function EpisodePlayer({
     return Object.keys(first.members)
       .filter((m) => m.match(/^cam_\d+\.jpg$/))
       .map((m) => m.replace(/\.jpg$/, ""))
+      .filter((cam) => !isHiddenCam(dataset, cam))
       .sort();
-  }, [index]);
+  }, [index, dataset]);
 
   const [overlayModels, setOverlayModels] = useState<OverlayModel[]>([]);
   const [selectedModelID, setSelectedModelID] = useState(
@@ -642,8 +644,10 @@ export function EpisodePlayer({
           setMode("grid");
           break;
         default: {
+          // Number keys focus the nth displayed camera (1-based). Cap by the
+          // actual camera count so a hidden/absent camera has no dead key.
           const n = parseInt(e.key, 10);
-          if (n >= 1 && n <= 7) {
+          if (n >= 1 && n <= Math.min(9, cams.length)) {
             e.preventDefault();
             focusCamera(n - 1);
           }
@@ -652,7 +656,7 @@ export function EpisodePlayer({
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [toggle, step, setSpeed, speed, focusCamera, dismissHint]);
+  }, [toggle, step, setSpeed, speed, focusCamera, dismissHint, cams.length]);
 
   if (!store || cams.length === 0) {
     return (
@@ -916,7 +920,10 @@ export function EpisodePlayer({
               ["→ / .", "step forward one frame"],
               ["[ / -", "slower"],
               ["] / +", "faster"],
-              ["1 - 7", "focus camera n"],
+              [
+                cams.length > 1 ? `1 - ${Math.min(9, cams.length)}` : "1",
+                "focus camera n",
+              ],
               ["f", "toggle focus / grid"],
               ["Esc", "back to grid"],
               ["?", "toggle this help"],

--- a/Tools/DataModelConsole/web/src/lib/rig.ts
+++ b/Tools/DataModelConsole/web/src/lib/rig.ts
@@ -53,16 +53,20 @@ const L2D_RIG: Record<string, RigCam> = {
   cam_6: { label: "map", row: 1, col: 1 },
 };
 
-// Four columns keep both forward-facing cameras visible without occupying the
-// ego cell. The surround ring still reads left-to-right around the vehicle.
+// Six distinct cameras in a bird's-eye 3-col x 2-row grid: the forward row on
+// top, the rear row on the bottom, left cameras on the left. cam_1 (ring_front)
+// is hidden (see HIDDEN_CAMS) because it points the same way as cam_0
+// (base_front_center) and covers essentially the same FOV. With all six cells
+// filled there is no free centre cell, so the ego readout tile is omitted.
+//   (1,1) front-left    (1,2) front-center  (1,3) front-right
+//   (2,1) rear-left     (2,2) rear          (2,3) rear-right
 const KITSCENES_RIG: Record<string, RigCam> = {
   cam_0: { label: "front-center", row: 1, col: 2 },
-  cam_1: { label: "ring-front", row: 1, col: 3 },
   cam_2: { label: "front-left", row: 1, col: 1 },
-  cam_3: { label: "front-right", row: 1, col: 4 },
-  cam_4: { label: "rear", row: 3, col: 2 },
-  cam_5: { label: "rear-left", row: 3, col: 1 },
-  cam_6: { label: "rear-right", row: 3, col: 4 },
+  cam_3: { label: "front-right", row: 1, col: 3 },
+  cam_4: { label: "rear", row: 2, col: 2 },
+  cam_5: { label: "rear-left", row: 2, col: 1 },
+  cam_6: { label: "rear-right", row: 2, col: 3 },
 };
 
 const RIGS: Record<string, Record<string, RigCam>> = {
@@ -70,6 +74,22 @@ const RIGS: Record<string, Record<string, RigCam>> = {
   l2d: L2D_RIG,
   kitscenes: KITSCENES_RIG,
 };
+
+// Cameras that are packed in the shard but the console intentionally does not
+// display. KITScenes cam_1 (ring_front) duplicates cam_0 (base_front_center) —
+// same heading, essentially the same field of view — so it is the redundant
+// camera the model itself dropped (kit_scenes/camera.py, #146). Hiding it in the
+// viewer leaves the six distinct views for a clean 3x2 grid.
+const HIDDEN_CAMS: Record<string, Set<string>> = {
+  kitscenes: new Set(["cam_1"]),
+};
+
+// isHiddenCam reports whether a shard camera member should be omitted from the
+// mosaic for a dataset. Filtering happens on the displayed camera list, so the
+// hidden camera never claims a grid cell, a focus slot, or a keyboard ordinal.
+export function isHiddenCam(dataset: string, cam: string): boolean {
+  return HIDDEN_CAMS[dataset]?.has(cam) ?? false;
+}
 
 // rigCam returns the rig position + grid cell for a "cam_N" identifier.
 // Falls back to a sequential cell + the raw id for unknown datasets/cameras.
@@ -85,14 +105,31 @@ export function camLabel(dataset: string, cam: string): string {
   return RIGS[dataset]?.[cam]?.label ?? cam;
 }
 
+// displayAspectRatio is the width/height a camera tile should reserve for a
+// dataset, so the frame matches the packed image and there is no letterbox gap.
+// KITScenes cameras are packed 256x256 (1:1); the default 16:9 is kept for the
+// other datasets to avoid changing their existing layout. The canvas still
+// object-contain-fits the real bitmap, so a stray off-ratio image is letterboxed
+// rather than stretched — this only sets the frame's shape.
+const DATASET_ASPECT_RATIO: Record<string, number> = {
+  kitscenes: 1,
+};
+export function displayAspectRatio(dataset: string): number {
+  return DATASET_ASPECT_RATIO[dataset] ?? 16 / 9;
+}
+
 // gridDimensions returns the number of rows/cols spanned by a dataset's rig,
-// so the mosaic can size its CSS grid. Defaults to 3x3.
+// so the mosaic can size its CSS grid. It is the exact extent of the cameras'
+// placed cells (min 1x1) — NOT floored to 3x3. A rig that only spans 2 rows
+// (KITScenes: forward + rear) must report rows=2, or the grid emits a phantom
+// empty third row AND the ego cell lands in row 2 (ceil(3/2)) on top of a
+// camera. `cams` should already be the DISPLAYED set (hidden cams filtered).
 export function gridDimensions(dataset: string, cams: string[]): {
   rows: number;
   cols: number;
 } {
-  let rows = 3;
-  let cols = 3;
+  let rows = 1;
+  let cols = 1;
   cams.forEach((cam, i) => {
     const c = rigCam(dataset, cam, i);
     rows = Math.max(rows, c.row);


### PR DESCRIPTION
## What

KITScenes shards pack 7 cameras where `cam_0` (base_front_center) and `cam_1`
(ring_front) point the same way with essentially the same field of view — the
redundancy the model itself dropped in #146. The console still showed both, in a
sparse 4-column layout with a centre ego "car" tile and 16:9 frames that
letterboxed the square 256x256 images.

This hides `cam_1` and lays the six distinct cameras out in a clean 3-column x
2-row bird's-eye grid (forward row on top, rear row on the bottom). With all six
cells filled the centre cell is claimed, so the ego tile is naturally omitted.
Tiles are sized to the dataset's real image aspect ratio (KITScenes 1:1), so the
frame matches the image with no letterbox gap.

## How

- `lib/rig.ts` — `KITSCENES_RIG` becomes a filled 3x2; add `isHiddenCam`
  (KITScenes hides `cam_1`) and `displayAspectRatio` (KITScenes 1:1, others keep
  16:9). Stop flooring `gridDimensions` at 3x3 so a 2-row rig reports 2 rows and
  the ego cell doesn't collide onto a camera.
- `episode-player.tsx` — filter `isHiddenCam` from the camera list at the source,
  so the hidden camera never reaches the grid, focus mode, prefetch, or a key
  ordinal. Cap number-key focus + the help label + the aria-label at the actual
  displayed count instead of a hardcoded 7.
- `camera-mosaic.tsx` — drive the tile frame from `displayAspectRatio` via inline
  `aspect-ratio`; the canvas still object-contain-fits the real bitmap.

## Notes

- NVIDIA and L2D are unchanged (still 3x3 with a free centre ego cell).
- Current v2.2 shards still pack `cam_1`; hiding it is a display choice, so no
  re-pack is required and older shards render correctly.

## Testing

- New `rig-layout.spec.ts` (7 cases): KITScenes hides only ring-front, fills a
  3x2 grid with no gaps, claims the centre cell (ego omitted), keeps rows
  ordered, leaves NVIDIA/L2D at 3x3, and returns the per-dataset aspect ratio.
- tsc, eslint, all pure-logic specs, and `next build` pass on the dev box.
- Verified the rendered layout against the reference frame (3x2, square tiles,
  no gap, no car icon).
