### PR TITLE
Add per-encoder BEV diagnostics to DataModelConsole

### DIFF
--- a/Model/model_components/view_fusion/bev_fusion.py
+++ b/Model/model_components/view_fusion/bev_fusion.py
@@ -138,13 +138,20 @@ class BEVViewFusion(nn.Module):
         These represent the 3D ego/vehicle-frame locations that each BEV
         query should attend to.
         """
-        xs = torch.linspace(0.5, self.bev_w - 0.5, self.bev_w) / self.bev_w
-        ys = torch.linspace(0.5, self.bev_h - 0.5, self.bev_h) / self.bev_h
+        rows = torch.linspace(0.5, self.bev_h - 0.5, self.bev_h) / self.bev_h
+        cols = torch.linspace(0.5, self.bev_w - 0.5, self.bev_w) / self.bev_w
         zs = torch.linspace(0.5, self.num_points_in_pillar - 0.5,
                             self.num_points_in_pillar) / self.num_points_in_pillar
 
-        grid_y, grid_x, grid_z = torch.meshgrid(ys, xs, zs, indexing='ij')
-        ref_3d = torch.stack([grid_x, grid_y, grid_z], dim=-1)
+        grid_row, grid_col, grid_z = torch.meshgrid(
+            rows, cols, zs, indexing='ij'
+        )
+        # Raster contract: row 0 is forward (+X), column 0 is left (+Y).
+        # _ego_reference_homo maps normalized X/Y from pc_range minima to maxima,
+        # so both raster axes are reversed here.
+        ref_3d = torch.stack(
+            [1.0 - grid_row, 1.0 - grid_col, grid_z], dim=-1
+        )
         ref_3d = ref_3d.reshape(self.bev_h * self.bev_w, self.num_points_in_pillar, 3)
 
         self.register_buffer('reference_points_3d', ref_3d)

--- a/Model/tests/test_overlay_artifact.py
+++ b/Model/tests/test_overlay_artifact.py
@@ -8,6 +8,8 @@ import numpy as np
 import pytest
 
 from Platform.pipelines.overlay import (
+    BEV_HEATMAP_NAMES,
+    BEV_HEATMAP_SIZE,
     FLAG_DETERMINISTIC_PLANNER,
     decode_overlay,
     encode_overlay,
@@ -25,17 +27,24 @@ def _fixture():
     ]
     controls = np.arange(3 * 2 * 64 * 2, dtype=np.float32).reshape(3, 2, 64, 2)
     v0 = np.array([3.5, 4.5, 5.5], dtype=np.float32)
-    return uids, controls, v0
+    heatmaps = np.linspace(
+        0.0,
+        6.0,
+        3 * len(BEV_HEATMAP_NAMES) * BEV_HEATMAP_SIZE * BEV_HEATMAP_SIZE,
+        dtype=np.float32,
+    ).reshape(3, len(BEV_HEATMAP_NAMES), BEV_HEATMAP_SIZE, BEV_HEATMAP_SIZE)
+    return uids, controls, v0, heatmaps
 
 
 def test_overlay_roundtrip_and_sorted_directory():
-    uids, controls, v0 = _fixture()
+    uids, controls, v0, heatmaps = _fixture()
     payload = encode_overlay(
         uids,
         controls,
         v0,
         base_seeds=(0, 7),
         deterministic_planner=True,
+        bev_heatmaps=heatmaps,
     )
     decoded = decode_overlay(payload)
 
@@ -46,20 +55,38 @@ def test_overlay_roundtrip_and_sorted_directory():
     )
     np.testing.assert_array_equal(decoded.controls, controls)
     np.testing.assert_array_equal(decoded.v0, v0)
+    np.testing.assert_allclose(
+        decoded.bev_heatmap_scales,
+        heatmaps.max(axis=(1, 2, 3)),
+    )
+    np.testing.assert_allclose(
+        decoded.bev_heatmaps,
+        heatmaps,
+        atol=float(decoded.bev_heatmap_scales.max()) / 255.0,
+    )
 
 
 def test_overlay_gzip_bytes_are_deterministic():
-    uids, controls, v0 = _fixture()
-    first = encode_overlay(uids, controls, v0, base_seeds=(0, 1))
-    second = encode_overlay(uids, controls, v0, base_seeds=(0, 1))
+    uids, controls, v0, heatmaps = _fixture()
+    first = encode_overlay(
+        uids, controls, v0, base_seeds=(0, 1), bev_heatmaps=heatmaps
+    )
+    second = encode_overlay(
+        uids, controls, v0, base_seeds=(0, 1), bev_heatmaps=heatmaps
+    )
     assert first == second
 
 
 def test_overlay_writer_returns_body_pointer_metadata(tmp_path):
-    uids, controls, v0 = _fixture()
+    uids, controls, v0, heatmaps = _fixture()
     path = tmp_path / "overlay.bin.gz"
     artifact = write_overlay(
-        path, uids, controls, v0, base_seeds=(0, 7)
+        path,
+        uids,
+        controls,
+        v0,
+        base_seeds=(0, 7),
+        bev_heatmaps=heatmaps,
     )
     assert artifact.path == path
     assert artifact.sample_count == 3
@@ -69,7 +96,7 @@ def test_overlay_writer_returns_body_pointer_metadata(tmp_path):
 
 
 def test_overlay_validation_rejects_ambiguous_or_bad_data():
-    uids, controls, v0 = _fixture()
+    uids, controls, v0, heatmaps = _fixture()
     with pytest.raises(ValueError, match="unique"):
         encode_overlay([uids[0]] * 3, controls, v0, base_seeds=(0, 1))
     with pytest.raises(ValueError, match="shape"):
@@ -78,13 +105,30 @@ def test_overlay_validation_rejects_ambiguous_or_bad_data():
     bad[0, 0, 0, 0] = np.nan
     with pytest.raises(ValueError, match="NaN"):
         encode_overlay(uids, bad, v0, base_seeds=(0, 1))
+    with pytest.raises(ValueError, match="shape"):
+        encode_overlay(
+            uids,
+            controls,
+            v0,
+            base_seeds=(0, 1),
+            bev_heatmaps=heatmaps[:, :2],
+        )
+
+
+def test_overlay_decoder_accepts_legacy_v1_without_heatmaps():
+    uids, controls, v0, _ = _fixture()
+    decoded = decode_overlay(
+        encode_overlay(uids, controls, v0, base_seeds=(0, 1))
+    )
+    assert decoded.bev_heatmaps is None
+    assert decoded.bev_heatmap_scales is None
 
 
 def test_overlay_key_is_split_free_and_validates_segments():
     model_id = "a" * 64
     key = overlay_s3_key(model_id, "l2d", "v2.1", "train-000001.tar")
     assert key == (
-        "overlays/schema=v1/model=" + model_id
+        "overlays/schema=v2/model=" + model_id
         + "/dataset=l2d/version=v2.1/shard=train-000001.tar/overlay.bin.gz"
     )
     assert "split=" not in key and "source=" not in key

--- a/Model/tests/test_overlay_artifact.py
+++ b/Model/tests/test_overlay_artifact.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import gzip
 import hashlib
+import struct
 
 import numpy as np
 import pytest
@@ -46,6 +48,72 @@ def _fixture():
         ]
     )
     return uids, controls, v0, heatmaps
+
+
+def _legacy_payload(version, uids, controls, v0, heatmaps):
+    base_seeds = (0, 1)
+    raw_v4 = gzip.decompress(
+        encode_overlay(
+            uids,
+            controls,
+            v0,
+            base_seeds=base_seeds,
+            bev_heatmaps=heatmaps,
+        )
+    )
+    prefix_size = (
+        20
+        + len(base_seeds) * 8
+        + len(uids) * 12
+        + controls.size * 4
+        + v0.size * 4
+    )
+    if version == 1:
+        raw = (
+            struct.pack(
+                "<4sHHIHHHH",
+                b"AOVL",
+                version,
+                0,
+                len(uids),
+                len(base_seeds),
+                64,
+                2,
+                0,
+            )
+            + raw_v4[20:prefix_size]
+        )
+        return gzip.compress(raw, compresslevel=6, mtime=0), (), None
+
+    indices = (0, 3, 5) if version == 2 else tuple(range(6))
+    selected = heatmaps[:, indices]
+    scales = selected.max(axis=(1, 2, 3)).astype("<f4")
+    divisors = np.where(scales > 0, scales, 1.0).reshape(-1, 1, 1, 1)
+    quantised = np.rint(
+        np.clip(selected / divisors, 0.0, 1.0) * 255.0
+    ).astype(np.uint8)
+    raw = (
+        struct.pack(
+            "<4sHHIHHHH",
+            b"AOVL",
+            version,
+            0,
+            len(uids),
+            len(base_seeds),
+            64,
+            2,
+            len(indices),
+        )
+        + raw_v4[20:prefix_size]
+        + scales.tobytes(order="C")
+        + quantised.tobytes(order="C")
+    )
+    names = (
+        ("image", "navigation", "fused")
+        if version == 2
+        else BEV_HEATMAP_NAMES
+    )
+    return gzip.compress(raw, compresslevel=6, mtime=0), names, selected
 
 
 def test_overlay_roundtrip_and_sorted_directory():
@@ -114,13 +182,31 @@ def test_overlay_writer_returns_body_pointer_metadata(tmp_path):
 def test_overlay_validation_rejects_ambiguous_or_bad_data():
     uids, controls, v0, heatmaps = _fixture()
     with pytest.raises(ValueError, match="unique"):
-        encode_overlay([uids[0]] * 3, controls, v0, base_seeds=(0, 1))
+        encode_overlay(
+            [uids[0]] * 3,
+            controls,
+            v0,
+            base_seeds=(0, 1),
+            bev_heatmaps=heatmaps,
+        )
     with pytest.raises(ValueError, match="shape"):
-        encode_overlay(uids, controls[:, :1], v0, base_seeds=(0, 1))
+        encode_overlay(
+            uids,
+            controls[:, :1],
+            v0,
+            base_seeds=(0, 1),
+            bev_heatmaps=heatmaps,
+        )
     bad = controls.copy()
     bad[0, 0, 0, 0] = np.nan
     with pytest.raises(ValueError, match="NaN"):
-        encode_overlay(uids, bad, v0, base_seeds=(0, 1))
+        encode_overlay(
+            uids,
+            bad,
+            v0,
+            base_seeds=(0, 1),
+            bev_heatmaps=heatmaps,
+        )
     with pytest.raises(ValueError, match="shape"):
         encode_overlay(
             uids,
@@ -129,16 +215,55 @@ def test_overlay_validation_rejects_ambiguous_or_bad_data():
             base_seeds=(0, 1),
             bev_heatmaps=heatmaps[:, :2],
         )
+    invalid_heatmaps = heatmaps.copy()
+    invalid_heatmaps[0, 0, 0, 0] = -1.0
+    with pytest.raises(ValueError, match="non-negative"):
+        encode_overlay(
+            uids,
+            controls,
+            v0,
+            base_seeds=(0, 1),
+            bev_heatmaps=invalid_heatmaps,
+        )
+    invalid_heatmaps[0, 0, 0, 0] = np.inf
+    with pytest.raises(ValueError, match="infinity"):
+        encode_overlay(
+            uids,
+            controls,
+            v0,
+            base_seeds=(0, 1),
+            bev_heatmaps=invalid_heatmaps,
+        )
 
 
-def test_overlay_decoder_accepts_legacy_v1_without_heatmaps():
-    uids, controls, v0, _ = _fixture()
-    decoded = decode_overlay(
-        encode_overlay(uids, controls, v0, base_seeds=(0, 1))
+@pytest.mark.parametrize("version", [1, 2, 3])
+def test_overlay_decoder_accepts_legacy_formats(version):
+    uids, controls, v0, heatmaps = _fixture()
+    payload, names, selected = _legacy_payload(
+        version,
+        uids,
+        controls,
+        v0,
+        heatmaps,
     )
-    assert decoded.bev_heatmaps is None
-    assert decoded.bev_heatmap_scales is None
-    assert decoded.bev_heatmap_names == ()
+    decoded = decode_overlay(payload)
+
+    np.testing.assert_array_equal(decoded.controls, controls)
+    np.testing.assert_array_equal(decoded.v0, v0)
+    assert decoded.bev_heatmap_names == names
+    if version == 1:
+        assert decoded.bev_heatmaps is None
+        assert decoded.bev_heatmap_scales is None
+        return
+
+    assert selected is not None
+    expected_scales = selected.max(axis=(1, 2, 3))
+    np.testing.assert_array_equal(decoded.bev_heatmap_scales, expected_scales)
+    quantization_error = np.abs(decoded.bev_heatmaps - selected)
+    assert np.all(
+        quantization_error
+        <= expected_scales[:, None, None, None] / 255.0
+    )
 
 
 def test_overlay_key_is_split_free_and_validates_segments():

--- a/Model/tests/test_overlay_artifact.py
+++ b/Model/tests/test_overlay_artifact.py
@@ -64,6 +64,7 @@ def test_overlay_roundtrip_and_sorted_directory():
         heatmaps,
         atol=float(decoded.bev_heatmap_scales.max()) / 255.0,
     )
+    assert decoded.bev_heatmap_names == BEV_HEATMAP_NAMES
 
 
 def test_overlay_gzip_bytes_are_deterministic():
@@ -122,13 +123,14 @@ def test_overlay_decoder_accepts_legacy_v1_without_heatmaps():
     )
     assert decoded.bev_heatmaps is None
     assert decoded.bev_heatmap_scales is None
+    assert decoded.bev_heatmap_names == ()
 
 
 def test_overlay_key_is_split_free_and_validates_segments():
     model_id = "a" * 64
     key = overlay_s3_key(model_id, "l2d", "v2.1", "train-000001.tar")
     assert key == (
-        "overlays/schema=v2/model=" + model_id
+        "overlays/schema=v3/model=" + model_id
         + "/dataset=l2d/version=v2.1/shard=train-000001.tar/overlay.bin.gz"
     )
     assert "split=" not in key and "source=" not in key

--- a/Model/tests/test_overlay_artifact.py
+++ b/Model/tests/test_overlay_artifact.py
@@ -71,10 +71,10 @@ def test_overlay_roundtrip_and_sorted_directory():
         decoded.bev_heatmap_scales,
         heatmaps.max(axis=(2, 3)),
     )
-    np.testing.assert_allclose(
-        decoded.bev_heatmaps,
-        heatmaps,
-        atol=decoded.bev_heatmap_scales[:, :, None, None] / 255.0,
+    quantization_error = np.abs(decoded.bev_heatmaps - heatmaps)
+    assert np.all(
+        quantization_error
+        <= decoded.bev_heatmap_scales[:, :, None, None] / 255.0
     )
     assert np.unique(
         decoded.bev_heatmaps[0, 0],

--- a/Model/tests/test_overlay_artifact.py
+++ b/Model/tests/test_overlay_artifact.py
@@ -27,12 +27,24 @@ def _fixture():
     ]
     controls = np.arange(3 * 2 * 64 * 2, dtype=np.float32).reshape(3, 2, 64, 2)
     v0 = np.array([3.5, 4.5, 5.5], dtype=np.float32)
-    heatmaps = np.linspace(
+    base = np.linspace(
         0.0,
-        6.0,
-        3 * len(BEV_HEATMAP_NAMES) * BEV_HEATMAP_SIZE * BEV_HEATMAP_SIZE,
+        1.0,
+        BEV_HEATMAP_SIZE * BEV_HEATMAP_SIZE,
         dtype=np.float32,
-    ).reshape(3, len(BEV_HEATMAP_NAMES), BEV_HEATMAP_SIZE, BEV_HEATMAP_SIZE)
+    ).reshape(BEV_HEATMAP_SIZE, BEV_HEATMAP_SIZE)
+    branch_scales = np.array(
+        [0.01, 30.0, 0.2, 28.0, 0.5, 1.0],
+        dtype=np.float32,
+    )
+    heatmaps = np.stack(
+        [
+            np.stack(
+                [base * scale * (row + 1) for scale in branch_scales]
+            )
+            for row in range(3)
+        ]
+    )
     return uids, controls, v0, heatmaps
 
 
@@ -57,13 +69,16 @@ def test_overlay_roundtrip_and_sorted_directory():
     np.testing.assert_array_equal(decoded.v0, v0)
     np.testing.assert_allclose(
         decoded.bev_heatmap_scales,
-        heatmaps.max(axis=(1, 2, 3)),
+        heatmaps.max(axis=(2, 3)),
     )
     np.testing.assert_allclose(
         decoded.bev_heatmaps,
         heatmaps,
-        atol=float(decoded.bev_heatmap_scales.max()) / 255.0,
+        atol=decoded.bev_heatmap_scales[:, :, None, None] / 255.0,
     )
+    assert np.unique(
+        decoded.bev_heatmaps[0, 0],
+    ).size > 200
     assert decoded.bev_heatmap_names == BEV_HEATMAP_NAMES
 
 
@@ -130,7 +145,7 @@ def test_overlay_key_is_split_free_and_validates_segments():
     model_id = "a" * 64
     key = overlay_s3_key(model_id, "l2d", "v2.1", "train-000001.tar")
     assert key == (
-        "overlays/schema=v3/model=" + model_id
+        "overlays/schema=v4/model=" + model_id
         + "/dataset=l2d/version=v2.1/shard=train-000001.tar/overlay.bin.gz"
     )
     assert "split=" not in key and "source=" not in key

--- a/Model/tests/test_overlay_inference.py
+++ b/Model/tests/test_overlay_inference.py
@@ -13,6 +13,8 @@ from Platform.pipelines.inference import (
     stable_seed64,
 )
 from Platform.pipelines.overlay_precompute import (
+    _BEVActivationRecorder,
+    _downsample_features,
     _spatial_feature_deviation,
     infer_loader_controls,
     infer_loader_overlay,
@@ -274,6 +276,33 @@ def test_spatial_feature_deviation_preserves_channel_direction_changes():
         heatmap,
         [[[1.0, 1.0], [0.0, 0.0]]],
     )
+
+
+def test_spatial_feature_deviation_uses_each_channel_spatial_mean():
+    features = torch.tensor(
+        [[[[1.0, 3.0], [5.0, 7.0]]]]
+    )
+
+    heatmap = _spatial_feature_deviation(features)
+
+    np.testing.assert_allclose(
+        heatmap,
+        [[[3.0, 1.0], [1.0, 3.0]]],
+    )
+
+
+def test_activation_recorder_rejects_incompatible_models_and_outputs():
+    with pytest.raises(ValueError, match="does not expose"):
+        _BEVActivationRecorder(torch.nn.Identity())
+    with pytest.raises(ValueError, match="must be a"):
+        _downsample_features(torch.zeros(1, 2, 3), "image")
+
+    recorder = _BEVActivationRecorder(_DiagnosticPolicy())
+    try:
+        with pytest.raises(RuntimeError, match="hooks did not run"):
+            recorder.take(_batch(1), 1)
+    finally:
+        recorder.close()
 
 
 def test_overlay_inference_applies_checkpoint_data_sanitization():

--- a/Model/tests/test_overlay_inference.py
+++ b/Model/tests/test_overlay_inference.py
@@ -12,7 +12,10 @@ from Platform.pipelines.inference import (
     sha256_file,
     stable_seed64,
 )
-from Platform.pipelines.overlay_precompute import infer_loader_controls
+from Platform.pipelines.overlay_precompute import (
+    infer_loader_controls,
+    infer_loader_overlay,
+)
 from training.dataset_policy import KITSCENES_TRAINING_POLICY
 
 
@@ -79,6 +82,39 @@ class _NoiseEchoPolicy(torch.nn.Module):
         **kwargs,
     ):
         self.last_egomotion_history = egomotion_history.detach().clone()
+        return initial_noise + self.anchor
+
+
+class _AddFusion(torch.nn.Module):
+    def forward(self, image_bev, navigation_bev):
+        return image_bev + navigation_bev
+
+
+class _DiagnosticReactive:
+    TrajectoryPlanner = _FakePlanner()
+    FeatureFusion = torch.nn.Identity()
+    NavigationEncoder = torch.nn.Identity()
+    MapBEVFusion = _AddFusion()
+
+
+class _DiagnosticPolicy(_NoiseEchoPolicy):
+    def __init__(self):
+        super().__init__()
+        self.Reactive_E2E = _DiagnosticReactive()
+
+    def forward(
+        self,
+        camera_tiles,
+        map_context,
+        visual_history,
+        egomotion_history,
+        *,
+        initial_noise,
+        **kwargs,
+    ):
+        image_bev = self.Reactive_E2E.FeatureFusion(camera_tiles[:, 0])
+        navigation_bev = self.Reactive_E2E.NavigationEncoder(map_context)
+        self.Reactive_E2E.MapBEVFusion(image_bev, navigation_bev)
         return initial_noise + self.anchor
 
 
@@ -160,6 +196,39 @@ def test_infer_loader_controls_emits_seed_fan_and_v0():
     np.testing.assert_array_equal(v0, [3.0, 4.0, 5.0])
     assert seeds == (0, 1)
     assert not np.array_equal(controls[:, 0], controls[:, 1])
+
+
+def test_infer_loader_overlay_captures_channel_rms_without_extra_forward():
+    model = _DiagnosticPolicy().eval()
+    batch = _batch(2)
+    batch["sample_uid"] = [
+        "l2d-v1-e000001-f000064",
+        "l2d-v1-e000001-f000065",
+    ]
+    batch["visual_tiles"][:, 0, 0] = 3.0
+    batch["visual_tiles"][:, 0, 1] = 4.0
+    batch["map_context"][:, 0] = 1.0
+    batch["map_context"][:, 1:] = 2.0
+
+    class Loader(list):
+        projection = None
+        geometry_type = "pseudo"
+
+    _, controls, _, seeds, heatmaps = infer_loader_overlay(
+        model,
+        Loader([batch]),
+        model_artifact_id="model-sha",
+        dataset_manifest_digest="manifest-sha",
+        base_seeds=(0, 1),
+        device="cpu",
+    )
+
+    assert controls.shape == (2, 2, 64, 2)
+    assert seeds == (0, 1)
+    assert heatmaps.shape == (2, 3, 32, 32)
+    np.testing.assert_allclose(heatmaps[:, 0], np.sqrt(25.0 / 3.0))
+    np.testing.assert_allclose(heatmaps[:, 1], np.sqrt(9.0 / 3.0))
+    np.testing.assert_allclose(heatmaps[:, 2], np.sqrt(56.0 / 3.0))
 
 
 def test_overlay_inference_applies_checkpoint_data_sanitization():

--- a/Model/tests/test_overlay_inference.py
+++ b/Model/tests/test_overlay_inference.py
@@ -13,6 +13,7 @@ from Platform.pipelines.inference import (
     stable_seed64,
 )
 from Platform.pipelines.overlay_precompute import (
+    _spatial_feature_deviation,
     infer_loader_controls,
     infer_loader_overlay,
 )
@@ -246,12 +247,33 @@ def test_infer_loader_overlay_isolates_encoder_contributions():
     assert controls.shape == (2, 2, 64, 2)
     assert seeds == (0, 1)
     assert heatmaps.shape == (2, 6, 32, 32)
-    np.testing.assert_allclose(heatmaps[:, 0], np.sqrt(25.0 / 3.0))
-    np.testing.assert_allclose(heatmaps[:, 1], np.sqrt(9.0 / 3.0))
+    np.testing.assert_array_equal(heatmaps[:, 0], 0.0)
+    np.testing.assert_array_equal(heatmaps[:, 1], 0.0)
     np.testing.assert_allclose(heatmaps[:, 2], np.sqrt(14.0 / 3.0))
-    np.testing.assert_allclose(heatmaps[:, 3], np.sqrt(45.0 / 3.0))
+    np.testing.assert_array_equal(heatmaps[:, 3], 0.0)
     np.testing.assert_allclose(heatmaps[:, 4], np.sqrt(45.0 / 3.0))
-    np.testing.assert_allclose(heatmaps[:, 5], np.sqrt(114.0 / 3.0))
+    np.testing.assert_array_equal(heatmaps[:, 5], 0.0)
+
+
+def test_spatial_feature_deviation_preserves_channel_direction_changes():
+    features = torch.tensor(
+        [
+            [
+                [[1.0, -1.0], [0.0, 0.0]],
+                [[-1.0, 1.0], [0.0, 0.0]],
+            ]
+        ]
+    )
+
+    heatmap = _spatial_feature_deviation(
+        features,
+        preserve_zero_cells=True,
+    )
+
+    np.testing.assert_allclose(
+        heatmap,
+        [[[1.0, 1.0], [0.0, 0.0]]],
+    )
 
 
 def test_overlay_inference_applies_checkpoint_data_sanitization():

--- a/Model/tests/test_overlay_inference.py
+++ b/Model/tests/test_overlay_inference.py
@@ -90,11 +90,23 @@ class _AddFusion(torch.nn.Module):
         return image_bev + navigation_bev
 
 
+class _DiagnosticNavigationEncoder(torch.nn.Module):
+    def forward(self, navigation_input):
+        map_context = navigation_input[:, :3]
+        route = navigation_input[:, 3:5]
+        route_effect = torch.cat(
+            [route[:, :1], route[:, 1:2], route.sum(dim=1, keepdim=True)],
+            dim=1,
+        )
+        return map_context + route_effect
+
+
 class _DiagnosticReactive:
     TrajectoryPlanner = _FakePlanner()
     FeatureFusion = torch.nn.Identity()
-    NavigationEncoder = torch.nn.Identity()
+    NavigationEncoder = _DiagnosticNavigationEncoder()
     MapBEVFusion = _AddFusion()
+    route_channels = 2
 
 
 class _DiagnosticPolicy(_NoiseEchoPolicy):
@@ -109,11 +121,16 @@ class _DiagnosticPolicy(_NoiseEchoPolicy):
         visual_history,
         egomotion_history,
         *,
+        route_mask,
+        route_valid,
         initial_noise,
         **kwargs,
     ):
         image_bev = self.Reactive_E2E.FeatureFusion(camera_tiles[:, 0])
-        navigation_bev = self.Reactive_E2E.NavigationEncoder(map_context)
+        gated_route = route_mask * route_valid.reshape(-1, 1, 1, 1)
+        navigation_bev = self.Reactive_E2E.NavigationEncoder(
+            torch.cat([map_context, gated_route], dim=1)
+        )
         self.Reactive_E2E.MapBEVFusion(image_bev, navigation_bev)
         return initial_noise + self.anchor
 
@@ -198,7 +215,7 @@ def test_infer_loader_controls_emits_seed_fan_and_v0():
     assert not np.array_equal(controls[:, 0], controls[:, 1])
 
 
-def test_infer_loader_overlay_captures_channel_rms_without_extra_forward():
+def test_infer_loader_overlay_isolates_encoder_contributions():
     model = _DiagnosticPolicy().eval()
     batch = _batch(2)
     batch["sample_uid"] = [
@@ -209,6 +226,9 @@ def test_infer_loader_overlay_captures_channel_rms_without_extra_forward():
     batch["visual_tiles"][:, 0, 1] = 4.0
     batch["map_context"][:, 0] = 1.0
     batch["map_context"][:, 1:] = 2.0
+    batch["route_mask"][:, 0] = 1.0
+    batch["route_mask"][:, 1] = 2.0
+    batch["route_valid"][:] = True
 
     class Loader(list):
         projection = None
@@ -225,10 +245,13 @@ def test_infer_loader_overlay_captures_channel_rms_without_extra_forward():
 
     assert controls.shape == (2, 2, 64, 2)
     assert seeds == (0, 1)
-    assert heatmaps.shape == (2, 3, 32, 32)
+    assert heatmaps.shape == (2, 6, 32, 32)
     np.testing.assert_allclose(heatmaps[:, 0], np.sqrt(25.0 / 3.0))
     np.testing.assert_allclose(heatmaps[:, 1], np.sqrt(9.0 / 3.0))
-    np.testing.assert_allclose(heatmaps[:, 2], np.sqrt(56.0 / 3.0))
+    np.testing.assert_allclose(heatmaps[:, 2], np.sqrt(14.0 / 3.0))
+    np.testing.assert_allclose(heatmaps[:, 3], np.sqrt(45.0 / 3.0))
+    np.testing.assert_allclose(heatmaps[:, 4], np.sqrt(45.0 / 3.0))
+    np.testing.assert_allclose(heatmaps[:, 5], np.sqrt(114.0 / 3.0))
 
 
 def test_overlay_inference_applies_checkpoint_data_sanitization():

--- a/Model/tests/test_overlay_tasks.py
+++ b/Model/tests/test_overlay_tasks.py
@@ -294,6 +294,39 @@ def test_overlay_set_upgrade_cutover_requires_the_staged_source():
     assert request["ExpressionAttributeValues"][":previous_schema"] == "v3"
 
 
+def test_overlay_set_upgrade_accepts_retry_after_ready_publication():
+    target = {
+        **_ready_item(),
+        "status": "building",
+        "overlay_schema": "v4",
+        "request_identity": "d" * 64,
+        "cache_identity": "",
+        "n_shards": 0,
+        "n_samples": 0,
+        "manifest_key": "",
+        "created_at": "2026-07-27T00:00:00Z",
+    }
+    table = _Table()
+    table.item = {
+        **target,
+        "status": "ready",
+        "cache_identity": "e" * 64,
+        "n_shards": 404,
+        "n_samples": 42667,
+        "manifest_key": "manifest-v4.json",
+    }
+    table.fail_put_count = 1
+
+    _stage_overlay_set_upgrade(
+        table,
+        target,
+        {
+            "previous_overlay_schema": "v3",
+            "previous_request_identity": "a" * 64,
+        },
+    )
+
+
 def _overlay_pointer(schema: str) -> dict:
     return {
         "pk": "SHARD#kitscenes#v3.0#part-000000.tar",

--- a/Model/tests/test_overlay_tasks.py
+++ b/Model/tests/test_overlay_tasks.py
@@ -234,6 +234,8 @@ def test_gate_token_keeps_the_winning_creation_time_and_ready_state():
     token = _gate_token(item, "d" * 64)
     gate = _parse_gate(token)
     assert gate["status"] == "ready"
+    assert gate["created_at"] == "2026-07-15T00:00:00Z"
+    assert gate["request_identity"] == "a" * 64
 
 
 def test_overlay_set_upgrade_stages_without_hiding_ready_schema():
@@ -350,8 +352,6 @@ def test_overlay_schema_version_requires_positive_numeric_suffix(
 def test_overlay_schema_version_rejects_noncanonical_values(schema):
     with pytest.raises(ValueError, match="invalid overlay schema"):
         _overlay_schema_version(schema)
-    assert gate["created_at"] == "2026-07-15T00:00:00Z"
-    assert gate["request_identity"] == "a" * 64
 
 
 class _MLflowClient:

--- a/Model/tests/test_overlay_tasks.py
+++ b/Model/tests/test_overlay_tasks.py
@@ -25,6 +25,7 @@ from Platform.pipelines.overlay_tasks import (
     _resolve_model_version_for_execution,
     _stage_overlay_set_upgrade,
     _validate_empty_overlay_partition,
+    _validate_overlay_upgrade_coverage,
     _validate_selected_checkpoint_payload,
 )
 
@@ -210,6 +211,17 @@ def _ready_item() -> dict:
     }
 
 
+def _upgrade_gate() -> dict:
+    return {
+        "previous_overlay_schema": "v3",
+        "previous_request_identity": "a" * 64,
+        "previous_created_at": "2026-07-15T00:00:00Z",
+        "previous_seeds": [0],
+        "previous_n_shards": 2,
+        "previous_n_samples": 20,
+    }
+
+
 def test_ready_publication_only_transitions_from_compatible_building():
     item = _ready_item()
     table = _Table()
@@ -264,6 +276,7 @@ def test_overlay_set_upgrade_stages_without_hiding_ready_schema():
     assert staged["previous_request_identity"] == "a" * 64
     gate = _parse_gate(_gate_token(staged, "e" * 64))
     assert gate["previous_overlay_schema"] == "v3"
+    assert gate["previous_n_shards"] == 2
 
 
 def test_overlay_set_upgrade_cutover_requires_the_staged_source():
@@ -278,10 +291,7 @@ def test_overlay_set_upgrade_cutover_requires_the_staged_source():
         "manifest_key": "",
         "created_at": "2026-07-27T00:00:00Z",
     }
-    gate = {
-        "previous_overlay_schema": "v3",
-        "previous_request_identity": "a" * 64,
-    }
+    gate = _upgrade_gate()
     table = _Table()
 
     _stage_overlay_set_upgrade(table, target, gate)
@@ -292,6 +302,7 @@ def test_overlay_set_upgrade_cutover_requires_the_staged_source():
         "ConditionExpression"
     ]
     assert request["ExpressionAttributeValues"][":previous_schema"] == "v3"
+    assert request["ExpressionAttributeValues"][":previous_n_shards"] == 2
 
 
 def test_overlay_set_upgrade_accepts_retry_after_ready_publication():
@@ -320,11 +331,50 @@ def test_overlay_set_upgrade_accepts_retry_after_ready_publication():
     _stage_overlay_set_upgrade(
         table,
         target,
-        {
-            "previous_overlay_schema": "v3",
-            "previous_request_identity": "a" * 64,
-        },
+        _upgrade_gate(),
     )
+
+
+def test_overlay_set_upgrade_accepts_normalized_deterministic_seeds():
+    existing = _ready_item()
+    existing["overlay_schema"] = "v3"
+    target = {
+        **existing,
+        "status": "building",
+        "overlay_schema": "v4",
+        "request_identity": "d" * 64,
+        "seeds": [0, 1],
+    }
+    table = _Table()
+    table.item = existing
+    table.fail_put_count = 1
+
+    staged = _prepare_overlay_set_item(table, target)
+
+    assert staged["previous_seeds"] == [0]
+    assert staged["seeds"] == [0, 1]
+
+
+def test_overlay_upgrade_coverage_must_match_live_set():
+    gate = _upgrade_gate()
+
+    _validate_overlay_upgrade_coverage(
+        gate,
+        n_shards=2,
+        n_samples=20,
+    )
+    with pytest.raises(RuntimeError, match="changed dataset coverage"):
+        _validate_overlay_upgrade_coverage(
+            gate,
+            n_shards=1,
+            n_samples=20,
+        )
+    with pytest.raises(RuntimeError, match="changed dataset coverage"):
+        _validate_overlay_upgrade_coverage(
+            gate,
+            n_shards=2,
+            n_samples=19,
+        )
 
 
 def _overlay_pointer(schema: str) -> dict:

--- a/Model/tests/test_overlay_tasks.py
+++ b/Model/tests/test_overlay_tasks.py
@@ -14,12 +14,16 @@ from Platform.pipelines.overlay_tasks import (
     OVERLAY_TASK_ENV,
     _gate_token,
     _metric_at_epoch,
+    _overlay_schema_version,
     _parse_gate,
+    _prepare_overlay_set_item,
+    _publish_overlay_pointer,
     _publish_overlay_set_ready,
     _put_dynamo_immutable,
     _put_s3_immutable,
     _register_selected_checkpoint_version,
     _resolve_model_version_for_execution,
+    _stage_overlay_set_upgrade,
     _validate_empty_overlay_partition,
     _validate_selected_checkpoint_payload,
 )
@@ -97,10 +101,12 @@ class _Table:
         self.put_calls = []
         self.item = None
         self.fail_put = False
+        self.fail_put_count = 0
 
     def put_item(self, **kwargs):
         self.put_calls.append(kwargs)
-        if self.fail_put:
+        if self.fail_put or self.fail_put_count > 0:
+            self.fail_put_count = max(0, self.fail_put_count - 1)
             raise _client_error(
                 "ConditionalCheckFailedException", "PutItem"
             )
@@ -228,6 +234,122 @@ def test_gate_token_keeps_the_winning_creation_time_and_ready_state():
     token = _gate_token(item, "d" * 64)
     gate = _parse_gate(token)
     assert gate["status"] == "ready"
+
+
+def test_overlay_set_upgrade_stages_without_hiding_ready_schema():
+    existing = _ready_item()
+    existing["overlay_schema"] = "v3"
+    target = {
+        **existing,
+        "status": "building",
+        "overlay_schema": "v4",
+        "request_identity": "d" * 64,
+        "cache_identity": "",
+        "n_shards": 0,
+        "n_samples": 0,
+        "manifest_key": "",
+        "created_at": "2026-07-27T00:00:00Z",
+    }
+    table = _Table()
+    table.item = dict(existing)
+    table.fail_put_count = 1
+
+    staged = _prepare_overlay_set_item(table, target)
+
+    assert table.item == existing
+    assert staged["status"] == "building"
+    assert staged["previous_overlay_schema"] == "v3"
+    assert staged["previous_request_identity"] == "a" * 64
+    gate = _parse_gate(_gate_token(staged, "e" * 64))
+    assert gate["previous_overlay_schema"] == "v3"
+
+
+def test_overlay_set_upgrade_cutover_requires_the_staged_source():
+    target = {
+        **_ready_item(),
+        "status": "building",
+        "overlay_schema": "v4",
+        "request_identity": "d" * 64,
+        "cache_identity": "",
+        "n_shards": 0,
+        "n_samples": 0,
+        "manifest_key": "",
+        "created_at": "2026-07-27T00:00:00Z",
+    }
+    gate = {
+        "previous_overlay_schema": "v3",
+        "previous_request_identity": "a" * 64,
+    }
+    table = _Table()
+
+    _stage_overlay_set_upgrade(table, target, gate)
+
+    request = table.put_calls[0]
+    assert request["Item"] == target
+    assert "overlay_schema = :previous_schema" in request[
+        "ConditionExpression"
+    ]
+    assert request["ExpressionAttributeValues"][":previous_schema"] == "v3"
+
+
+def _overlay_pointer(schema: str) -> dict:
+    return {
+        "pk": "SHARD#kitscenes#v3.0#part-000000.tar",
+        "sk": "MODEL#" + "e" * 64,
+        "s3_key": f"overlays/schema={schema}/overlay.bin.gz",
+        "sha256": "f" * 64,
+        "byte_size": 123,
+        "sample_count": 22,
+        "overlay_schema": schema,
+        "dataset_manifest_sha256": "c" * 64,
+        "cache_identity": "b" * 64,
+        "status": "ready",
+    }
+
+
+def test_overlay_pointer_upgrade_is_conditional_and_retryable():
+    table = _Table()
+    table.item = _overlay_pointer("v3")
+    table.fail_put_count = 1
+    target = _overlay_pointer("v4")
+
+    _publish_overlay_pointer(table, target)
+
+    assert table.item == target
+    request = table.put_calls[1]
+    assert "overlay_schema = :previous_schema" in request[
+        "ConditionExpression"
+    ]
+    assert request["ExpressionAttributeValues"][":previous_schema"] == "v3"
+
+    table.fail_put_count = 1
+    _publish_overlay_pointer(table, target)
+
+
+def test_overlay_pointer_rejects_schema_downgrade():
+    table = _Table()
+    table.item = _overlay_pointer("v4")
+    table.fail_put_count = 1
+
+    with pytest.raises(RuntimeError, match="different identity"):
+        _publish_overlay_pointer(table, _overlay_pointer("v3"))
+
+
+@pytest.mark.parametrize(
+    ("schema", "version"),
+    [("v1", 1), ("v4", 4), ("v12", 12)],
+)
+def test_overlay_schema_version_requires_positive_numeric_suffix(
+    schema,
+    version,
+):
+    assert _overlay_schema_version(schema) == version
+
+
+@pytest.mark.parametrize("schema", ["v0", "V4", "v4-beta", ""])
+def test_overlay_schema_version_rejects_noncanonical_values(schema):
+    with pytest.raises(ValueError, match="invalid overlay schema"):
+        _overlay_schema_version(schema)
     assert gate["created_at"] == "2026-07-15T00:00:00Z"
     assert gate["request_identity"] == "a" * 64
 

--- a/Model/tests/test_overlay_tasks.py
+++ b/Model/tests/test_overlay_tasks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
@@ -253,6 +254,9 @@ def test_gate_token_keeps_the_winning_creation_time_and_ready_state():
 def test_overlay_set_upgrade_stages_without_hiding_ready_schema():
     existing = _ready_item()
     existing["overlay_schema"] = "v3"
+    existing["seeds"] = [Decimal(0)]
+    existing["n_shards"] = Decimal(2)
+    existing["n_samples"] = Decimal(20)
     target = {
         **existing,
         "status": "building",
@@ -274,6 +278,9 @@ def test_overlay_set_upgrade_stages_without_hiding_ready_schema():
     assert staged["status"] == "building"
     assert staged["previous_overlay_schema"] == "v3"
     assert staged["previous_request_identity"] == "a" * 64
+    assert staged["previous_seeds"] == [0]
+    assert staged["previous_n_shards"] == 2
+    assert staged["previous_n_samples"] == 20
     gate = _parse_gate(_gate_token(staged, "e" * 64))
     assert gate["previous_overlay_schema"] == "v3"
     assert gate["previous_n_shards"] == 2

--- a/Model/tests/test_trajectory_visualization.py
+++ b/Model/tests/test_trajectory_visualization.py
@@ -14,7 +14,12 @@ import pytest
 from PIL import Image
 
 from evaluation.metrics import integrate_trajectory
-from Platform.pipelines.overlay import write_overlay
+from Platform.pipelines.overlay import (
+    BEV_HEATMAP_NAMES,
+    BEV_HEATMAP_SIZE,
+    OVERLAY_SCHEMA,
+    write_overlay,
+)
 from Tools.trajectory_visualization.artifacts import read_shard_samples
 from Tools.trajectory_visualization.kinematics import (
     AOVL_V1_CONTROL_CONTRACT,
@@ -46,6 +51,18 @@ def _jpeg(color: str) -> bytes:
     output = io.BytesIO()
     Image.new("RGB", (64, 64), color).save(output, format="JPEG")
     return output.getvalue()
+
+
+def _blank_diagnostics(sample_count: int) -> np.ndarray:
+    return np.zeros(
+        (
+            sample_count,
+            len(BEV_HEATMAP_NAMES),
+            BEV_HEATMAP_SIZE,
+            BEV_HEATMAP_SIZE,
+        ),
+        dtype=np.float32,
+    )
 
 
 def _write_shard(
@@ -145,7 +162,7 @@ def _write_publication_manifests(
         "num_inference_steps": 1,
         "inference_contract_version": "v1",
         "noise_policy_version": "v1",
-        "overlay_binary_schema": "v1",
+        "overlay_binary_schema": OVERLAY_SCHEMA,
         "shards": [{
             "shard": shard.name,
             "s3_key": "overlays/example/overlay.bin.gz",
@@ -253,6 +270,7 @@ def test_report_joins_aovl_by_uid_and_writes_scene_artifacts(tmp_path):
         list(reversed(sample_uids)),
         controls,
         np.array([8.0, 9.0], dtype=np.float32),
+        bev_heatmaps=_blank_diagnostics(2),
     )
     dataset_manifest, overlay_manifest = _write_publication_manifests(
         tmp_path,
@@ -321,6 +339,7 @@ def test_report_uses_explicit_scene_frame_selection(tmp_path):
         sample_uids,
         np.zeros((3, 1, 64, 2), dtype=np.float32),
         np.array([8.0, 9.0, 10.0], dtype=np.float32),
+        bev_heatmaps=_blank_diagnostics(3),
     )
     dataset_manifest, overlay_manifest = _write_publication_manifests(
         tmp_path,
@@ -386,6 +405,7 @@ def test_report_rejects_overlay_rows_outside_the_shard(tmp_path):
         [sample_uid, "l2d-v1-e000001-f000065"],
         np.zeros((2, 1, 64, 2), dtype=np.float32),
         np.array([8.0, 9.0], dtype=np.float32),
+        bev_heatmaps=_blank_diagnostics(2),
     )
     dataset_manifest, overlay_manifest = _write_publication_manifests(
         tmp_path,
@@ -414,6 +434,7 @@ def test_report_rejects_overlay_speed_mismatched_with_shard(tmp_path):
         [sample_uid],
         np.zeros((1, 1, 64, 2), dtype=np.float32),
         np.array([99.0], dtype=np.float32),
+        bev_heatmaps=_blank_diagnostics(1),
     )
     dataset_manifest, overlay_manifest = _write_publication_manifests(
         tmp_path,
@@ -442,6 +463,7 @@ def test_report_rejects_changed_dataset_manifest(tmp_path):
         [sample_uid],
         np.zeros((1, 1, 64, 2), dtype=np.float32),
         np.array([8.0], dtype=np.float32),
+        bev_heatmaps=_blank_diagnostics(1),
     )
     dataset_manifest, overlay_manifest = _write_publication_manifests(
         tmp_path,
@@ -477,6 +499,7 @@ def test_report_rejects_noncanonical_shard_rig(tmp_path):
         [sample_uid],
         np.zeros((1, 1, 64, 2), dtype=np.float32),
         np.array([8.0], dtype=np.float32),
+        bev_heatmaps=_blank_diagnostics(1),
     )
     dataset_manifest, overlay_manifest = _write_publication_manifests(
         tmp_path,
@@ -523,6 +546,7 @@ def test_report_rejects_overlay_body_digest_mismatch(tmp_path):
         [sample_uid],
         np.zeros((1, 1, 64, 2), dtype=np.float32),
         np.array([8.0], dtype=np.float32),
+        bev_heatmaps=_blank_diagnostics(1),
     )
     dataset_manifest, overlay_manifest = _write_publication_manifests(
         tmp_path,

--- a/Model/tests/test_view_fusion.py
+++ b/Model/tests/test_view_fusion.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import torch
 import sys
@@ -10,6 +11,7 @@ from model_components.view_fusion.projection import (
     FThetaProjection,
     PinholeProjection,
 )
+from navigation.geometry import DEFAULT_NAVIGATION_GEOMETRY
 
 
 def make_inputs(batch_size, num_views, device, include_camera_params=False):
@@ -178,6 +180,31 @@ class TestBEVFusion:
         assert fusion.bev_h == 450
         assert fusion.bev_w == 300
         assert fusion.pc_range == (-60.0, -60.0, -5.0, 120.0, 60.0, 3.0)
+
+    def test_reference_grid_matches_navigation_raster(self):
+        """Every camera BEV cell must use the navigation raster's ego-FLU point."""
+        geometry = DEFAULT_NAVIGATION_GEOMETRY
+        fusion = BEVViewFusion(
+            num_views=7,
+            embed_dim=8,
+            **geometry.camera_bev_kwargs(),
+        )
+
+        ego_points = fusion._ego_reference_homo(
+            fusion.reference_points_3d
+        ).reshape(
+            geometry.height_px,
+            geometry.width_px,
+            fusion.num_points_in_pillar,
+            4,
+        )
+        actual_xy = ego_points[:, :, 0, :2]
+        expected_x, expected_y = geometry.pixel_center_grids()
+        expected_xy = torch.from_numpy(
+            np.stack([expected_x, expected_y], axis=-1)
+        ).to(actual_xy)
+
+        assert torch.allclose(actual_xy, expected_xy, atol=1e-6)
 
     def test_asymmetric_resolution(self, device):
         """Configurable bev_h != bev_w yields a non-square BEV grid."""

--- a/Platform/pipelines/overlay.py
+++ b/Platform/pipelines/overlay.py
@@ -19,12 +19,19 @@ from typing import Sequence
 import numpy as np
 
 
-OVERLAY_SCHEMA = "v2"
-OVERLAY_FORMAT_VERSION = 2
+OVERLAY_SCHEMA = "v3"
+OVERLAY_FORMAT_VERSION = 3
 OVERLAY_MAGIC = b"AOVL"
 UID_HASH_ALGORITHM = "sha256-le64-v1"
 FLAG_DETERMINISTIC_PLANNER = 1 << 0
-BEV_HEATMAP_NAMES = ("image", "navigation", "fused")
+BEV_HEATMAP_NAMES = (
+    "image",
+    "map",
+    "route_delta",
+    "navigation",
+    "fusion_delta",
+    "fused",
+)
 BEV_HEATMAP_SIZE = 32
 
 _HEADER = struct.Struct("<4sHHIHHHH")
@@ -33,6 +40,12 @@ _DIRECTORY_ENTRY = struct.Struct("<QI")
 _HORIZON = 64
 _DIMS = 2
 _LEGACY_FORMAT_VERSION = 1
+_V2_HEATMAP_NAMES = ("image", "navigation", "fused")
+_HEATMAP_NAMES_BY_VERSION = {
+    1: (),
+    2: _V2_HEATMAP_NAMES,
+    3: BEV_HEATMAP_NAMES,
+}
 
 
 @dataclass(frozen=True)
@@ -53,6 +66,7 @@ class DecodedOverlay:
     v0: np.ndarray
     bev_heatmaps: np.ndarray | None
     bev_heatmap_scales: np.ndarray | None
+    bev_heatmap_names: tuple[str, ...]
 
 
 def sample_uid_hash(sample_uid: str) -> int:
@@ -276,11 +290,10 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
     ) = _HEADER.unpack_from(raw)
     if magic != OVERLAY_MAGIC:
         raise ValueError("invalid overlay magic")
-    if version not in (_LEGACY_FORMAT_VERSION, OVERLAY_FORMAT_VERSION):
+    if version not in _HEATMAP_NAMES_BY_VERSION:
         raise ValueError(f"unsupported overlay version {version}")
-    expected_heatmap_count = (
-        0 if version == _LEGACY_FORMAT_VERSION else len(BEV_HEATMAP_NAMES)
-    )
+    heatmap_names = _HEATMAP_NAMES_BY_VERSION[version]
+    expected_heatmap_count = len(heatmap_names)
     if (
         horizon != _HORIZON
         or dims != _DIMS
@@ -298,11 +311,11 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
         + sample_count * seed_count * horizon * dims * 4
         + sample_count * 4
     )
-    if version == OVERLAY_FORMAT_VERSION:
+    if heatmap_names:
         expected_size += (
             sample_count * 4
             + sample_count
-            * len(BEV_HEATMAP_NAMES)
+            * len(heatmap_names)
             * BEV_HEATMAP_SIZE
             * BEV_HEATMAP_SIZE
         )
@@ -339,7 +352,7 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
     cursor += sample_count * 4
     heatmaps = None
     heatmap_scales = None
-    if version == OVERLAY_FORMAT_VERSION:
+    if heatmap_names:
         heatmap_scales = np.frombuffer(
             raw, dtype="<f4", count=sample_count, offset=cursor
         ).copy()
@@ -349,14 +362,14 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
             dtype=np.uint8,
             count=(
                 sample_count
-                * len(BEV_HEATMAP_NAMES)
+                * len(heatmap_names)
                 * BEV_HEATMAP_SIZE
                 * BEV_HEATMAP_SIZE
             ),
             offset=cursor,
         ).reshape(
             sample_count,
-            len(BEV_HEATMAP_NAMES),
+            len(heatmap_names),
             BEV_HEATMAP_SIZE,
             BEV_HEATMAP_SIZE,
         )
@@ -373,4 +386,5 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
         v0=speeds,
         bev_heatmaps=heatmaps,
         bev_heatmap_scales=heatmap_scales,
+        bev_heatmap_names=tuple(heatmap_names),
     )

--- a/Platform/pipelines/overlay.py
+++ b/Platform/pipelines/overlay.py
@@ -39,7 +39,6 @@ _SEED = struct.Struct("<q")
 _DIRECTORY_ENTRY = struct.Struct("<QI")
 _HORIZON = 64
 _DIMS = 2
-_LEGACY_FORMAT_VERSION = 1
 _V2_HEATMAP_NAMES = ("image", "navigation", "fused")
 _HEATMAP_NAMES_BY_VERSION = {
     1: (),
@@ -171,7 +170,7 @@ def encode_overlay(
     *,
     base_seeds: Sequence[int] = (0,),
     deterministic_planner: bool = False,
-    bev_heatmaps: np.ndarray | None = None,
+    bev_heatmaps: np.ndarray,
 ) -> bytes:
     """Encode and deterministically gzip one canonical shard overlay."""
     sample_uids = tuple(sample_uids)
@@ -196,16 +195,9 @@ def encode_overlay(
         controls, sample_count=sample_count, seed_count=seed_count
     )
     v0_f32 = _normalise_v0(v0, sample_count=sample_count)
-    heatmaps_u8 = None
-    heatmap_scales = None
-    format_version = _LEGACY_FORMAT_VERSION
-    heatmap_count = 0
-    if bev_heatmaps is not None:
-        heatmaps_u8, heatmap_scales = _quantise_bev_heatmaps(
-            bev_heatmaps, sample_count
-        )
-        format_version = OVERLAY_FORMAT_VERSION
-        heatmap_count = len(BEV_HEATMAP_NAMES)
+    heatmaps_u8, heatmap_scales = _quantise_bev_heatmaps(
+        bev_heatmaps, sample_count
+    )
 
     hashes = [sample_uid_hash(uid) for uid in sample_uids]
     if len(set(hashes)) != len(hashes):
@@ -216,13 +208,13 @@ def encode_overlay(
     raw = io.BytesIO()
     raw.write(_HEADER.pack(
         OVERLAY_MAGIC,
-        format_version,
+        OVERLAY_FORMAT_VERSION,
         flags,
         sample_count,
         seed_count,
         _HORIZON,
         _DIMS,
-        heatmap_count,
+        len(BEV_HEATMAP_NAMES),
     ))
     for seed in base_seeds:
         raw.write(_SEED.pack(seed))
@@ -230,9 +222,8 @@ def encode_overlay(
         raw.write(_DIRECTORY_ENTRY.pack(uid_hash, row))
     raw.write(controls_f32.tobytes(order="C"))
     raw.write(v0_f32.tobytes(order="C"))
-    if heatmaps_u8 is not None and heatmap_scales is not None:
-        raw.write(heatmap_scales.tobytes(order="C"))
-        raw.write(heatmaps_u8.tobytes(order="C"))
+    raw.write(heatmap_scales.tobytes(order="C"))
+    raw.write(heatmaps_u8.tobytes(order="C"))
 
     compressed = io.BytesIO()
     with gzip.GzipFile(
@@ -250,7 +241,7 @@ def write_overlay(
     *,
     base_seeds: Sequence[int] = (0,),
     deterministic_planner: bool = False,
-    bev_heatmaps: np.ndarray | None = None,
+    bev_heatmaps: np.ndarray,
 ) -> OverlayArtifact:
     """Atomically write one overlay and return its pointer metadata."""
     path = Path(path)

--- a/Platform/pipelines/overlay.py
+++ b/Platform/pipelines/overlay.py
@@ -19,17 +19,20 @@ from typing import Sequence
 import numpy as np
 
 
-OVERLAY_SCHEMA = "v1"
-OVERLAY_FORMAT_VERSION = 1
+OVERLAY_SCHEMA = "v2"
+OVERLAY_FORMAT_VERSION = 2
 OVERLAY_MAGIC = b"AOVL"
 UID_HASH_ALGORITHM = "sha256-le64-v1"
 FLAG_DETERMINISTIC_PLANNER = 1 << 0
+BEV_HEATMAP_NAMES = ("image", "navigation", "fused")
+BEV_HEATMAP_SIZE = 32
 
 _HEADER = struct.Struct("<4sHHIHHHH")
 _SEED = struct.Struct("<q")
 _DIRECTORY_ENTRY = struct.Struct("<QI")
 _HORIZON = 64
 _DIMS = 2
+_LEGACY_FORMAT_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -48,6 +51,8 @@ class DecodedOverlay:
     directory: tuple[tuple[int, int], ...]
     controls: np.ndarray
     v0: np.ndarray
+    bev_heatmaps: np.ndarray | None
+    bev_heatmap_scales: np.ndarray | None
 
 
 def sample_uid_hash(sample_uid: str) -> int:
@@ -110,6 +115,35 @@ def _normalise_v0(v0: np.ndarray, sample_count: int) -> np.ndarray:
     return np.ascontiguousarray(array, dtype="<f4")
 
 
+def _quantise_bev_heatmaps(
+    bev_heatmaps: np.ndarray,
+    sample_count: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    array = np.asarray(bev_heatmaps)
+    expected = (
+        sample_count,
+        len(BEV_HEATMAP_NAMES),
+        BEV_HEATMAP_SIZE,
+        BEV_HEATMAP_SIZE,
+    )
+    if array.shape != expected:
+        raise ValueError(
+            f"bev_heatmaps must have shape {expected}, got {array.shape}"
+        )
+    if not np.issubdtype(array.dtype, np.floating):
+        raise TypeError("bev_heatmaps must be floating point")
+    if not np.isfinite(array).all():
+        raise ValueError("bev_heatmaps contain NaN or infinity")
+    if np.any(array < 0):
+        raise ValueError("bev_heatmaps must be non-negative")
+
+    heatmaps = np.ascontiguousarray(array, dtype=np.float32)
+    scales = heatmaps.max(axis=(1, 2, 3)).astype("<f4", copy=False)
+    divisors = np.where(scales > 0, scales, 1.0).reshape(-1, 1, 1, 1)
+    quantised = np.rint(np.clip(heatmaps / divisors, 0.0, 1.0) * 255.0)
+    return np.ascontiguousarray(quantised, dtype=np.uint8), scales
+
+
 def encode_overlay(
     sample_uids: Sequence[str],
     controls: np.ndarray,
@@ -117,6 +151,7 @@ def encode_overlay(
     *,
     base_seeds: Sequence[int] = (0,),
     deterministic_planner: bool = False,
+    bev_heatmaps: np.ndarray | None = None,
 ) -> bytes:
     """Encode and deterministically gzip one canonical shard overlay."""
     sample_uids = tuple(sample_uids)
@@ -141,6 +176,16 @@ def encode_overlay(
         controls, sample_count=sample_count, seed_count=seed_count
     )
     v0_f32 = _normalise_v0(v0, sample_count=sample_count)
+    heatmaps_u8 = None
+    heatmap_scales = None
+    format_version = _LEGACY_FORMAT_VERSION
+    heatmap_count = 0
+    if bev_heatmaps is not None:
+        heatmaps_u8, heatmap_scales = _quantise_bev_heatmaps(
+            bev_heatmaps, sample_count
+        )
+        format_version = OVERLAY_FORMAT_VERSION
+        heatmap_count = len(BEV_HEATMAP_NAMES)
 
     hashes = [sample_uid_hash(uid) for uid in sample_uids]
     if len(set(hashes)) != len(hashes):
@@ -151,13 +196,13 @@ def encode_overlay(
     raw = io.BytesIO()
     raw.write(_HEADER.pack(
         OVERLAY_MAGIC,
-        OVERLAY_FORMAT_VERSION,
+        format_version,
         flags,
         sample_count,
         seed_count,
         _HORIZON,
         _DIMS,
-        0,
+        heatmap_count,
     ))
     for seed in base_seeds:
         raw.write(_SEED.pack(seed))
@@ -165,6 +210,9 @@ def encode_overlay(
         raw.write(_DIRECTORY_ENTRY.pack(uid_hash, row))
     raw.write(controls_f32.tobytes(order="C"))
     raw.write(v0_f32.tobytes(order="C"))
+    if heatmaps_u8 is not None and heatmap_scales is not None:
+        raw.write(heatmap_scales.tobytes(order="C"))
+        raw.write(heatmaps_u8.tobytes(order="C"))
 
     compressed = io.BytesIO()
     with gzip.GzipFile(
@@ -182,6 +230,7 @@ def write_overlay(
     *,
     base_seeds: Sequence[int] = (0,),
     deterministic_planner: bool = False,
+    bev_heatmaps: np.ndarray | None = None,
 ) -> OverlayArtifact:
     """Atomically write one overlay and return its pointer metadata."""
     path = Path(path)
@@ -191,6 +240,7 @@ def write_overlay(
         v0,
         base_seeds=base_seeds,
         deterministic_planner=deterministic_planner,
+        bev_heatmaps=bev_heatmaps,
     )
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
@@ -226,9 +276,16 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
     ) = _HEADER.unpack_from(raw)
     if magic != OVERLAY_MAGIC:
         raise ValueError("invalid overlay magic")
-    if version != OVERLAY_FORMAT_VERSION:
+    if version not in (_LEGACY_FORMAT_VERSION, OVERLAY_FORMAT_VERSION):
         raise ValueError(f"unsupported overlay version {version}")
-    if horizon != _HORIZON or dims != _DIMS or reserved != 0:
+    expected_heatmap_count = (
+        0 if version == _LEGACY_FORMAT_VERSION else len(BEV_HEATMAP_NAMES)
+    )
+    if (
+        horizon != _HORIZON
+        or dims != _DIMS
+        or reserved != expected_heatmap_count
+    ):
         raise ValueError("unsupported overlay dimensions or reserved bits")
     if sample_count == 0 or seed_count == 0:
         raise ValueError("overlay must contain samples and seeds")
@@ -241,6 +298,14 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
         + sample_count * seed_count * horizon * dims * 4
         + sample_count * 4
     )
+    if version == OVERLAY_FORMAT_VERSION:
+        expected_size += (
+            sample_count * 4
+            + sample_count
+            * len(BEV_HEATMAP_NAMES)
+            * BEV_HEATMAP_SIZE
+            * BEV_HEATMAP_SIZE
+        )
     if len(raw) != expected_size:
         raise ValueError(
             f"overlay size mismatch: expected {expected_size}, got {len(raw)}"
@@ -271,10 +336,41 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
     speeds = np.frombuffer(
         raw, dtype="<f4", count=sample_count, offset=cursor
     ).copy()
+    cursor += sample_count * 4
+    heatmaps = None
+    heatmap_scales = None
+    if version == OVERLAY_FORMAT_VERSION:
+        heatmap_scales = np.frombuffer(
+            raw, dtype="<f4", count=sample_count, offset=cursor
+        ).copy()
+        cursor += sample_count * 4
+        quantised = np.frombuffer(
+            raw,
+            dtype=np.uint8,
+            count=(
+                sample_count
+                * len(BEV_HEATMAP_NAMES)
+                * BEV_HEATMAP_SIZE
+                * BEV_HEATMAP_SIZE
+            ),
+            offset=cursor,
+        ).reshape(
+            sample_count,
+            len(BEV_HEATMAP_NAMES),
+            BEV_HEATMAP_SIZE,
+            BEV_HEATMAP_SIZE,
+        )
+        heatmaps = (
+            quantised.astype(np.float32)
+            * heatmap_scales.reshape(-1, 1, 1, 1)
+            / 255.0
+        )
     return DecodedOverlay(
         flags=flags,
         base_seeds=tuple(seeds),
         directory=tuple(directory),
         controls=controls,
         v0=speeds,
+        bev_heatmaps=heatmaps,
+        bev_heatmap_scales=heatmap_scales,
     )

--- a/Platform/pipelines/overlay.py
+++ b/Platform/pipelines/overlay.py
@@ -19,8 +19,8 @@ from typing import Sequence
 import numpy as np
 
 
-OVERLAY_SCHEMA = "v3"
-OVERLAY_FORMAT_VERSION = 3
+OVERLAY_SCHEMA = "v4"
+OVERLAY_FORMAT_VERSION = 4
 OVERLAY_MAGIC = b"AOVL"
 UID_HASH_ALGORITHM = "sha256-le64-v1"
 FLAG_DETERMINISTIC_PLANNER = 1 << 0
@@ -45,6 +45,7 @@ _HEATMAP_NAMES_BY_VERSION = {
     1: (),
     2: _V2_HEATMAP_NAMES,
     3: BEV_HEATMAP_NAMES,
+    4: BEV_HEATMAP_NAMES,
 }
 
 
@@ -152,8 +153,13 @@ def _quantise_bev_heatmaps(
         raise ValueError("bev_heatmaps must be non-negative")
 
     heatmaps = np.ascontiguousarray(array, dtype=np.float32)
-    scales = heatmaps.max(axis=(1, 2, 3)).astype("<f4", copy=False)
-    divisors = np.where(scales > 0, scales, 1.0).reshape(-1, 1, 1, 1)
+    scales = heatmaps.max(axis=(2, 3)).astype("<f4", copy=False)
+    divisors = np.where(scales > 0, scales, 1.0).reshape(
+        sample_count,
+        len(BEV_HEATMAP_NAMES),
+        1,
+        1,
+    )
     quantised = np.rint(np.clip(heatmaps / divisors, 0.0, 1.0) * 255.0)
     return np.ascontiguousarray(quantised, dtype=np.uint8), scales
 
@@ -312,8 +318,11 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
         + sample_count * 4
     )
     if heatmap_names:
+        scale_count = sample_count * (
+            len(heatmap_names) if version >= 4 else 1
+        )
         expected_size += (
-            sample_count * 4
+            scale_count * 4
             + sample_count
             * len(heatmap_names)
             * BEV_HEATMAP_SIZE
@@ -353,10 +362,16 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
     heatmaps = None
     heatmap_scales = None
     if heatmap_names:
+        scale_shape = (
+            (sample_count, len(heatmap_names))
+            if version >= 4
+            else (sample_count,)
+        )
+        scale_count = int(np.prod(scale_shape))
         heatmap_scales = np.frombuffer(
-            raw, dtype="<f4", count=sample_count, offset=cursor
-        ).copy()
-        cursor += sample_count * 4
+            raw, dtype="<f4", count=scale_count, offset=cursor
+        ).reshape(scale_shape).copy()
+        cursor += scale_count * 4
         quantised = np.frombuffer(
             raw,
             dtype=np.uint8,
@@ -373,11 +388,12 @@ def decode_overlay(payload: bytes) -> DecodedOverlay:
             BEV_HEATMAP_SIZE,
             BEV_HEATMAP_SIZE,
         )
-        heatmaps = (
-            quantised.astype(np.float32)
-            * heatmap_scales.reshape(-1, 1, 1, 1)
-            / 255.0
+        scale_view = (
+            heatmap_scales.reshape(sample_count, len(heatmap_names), 1, 1)
+            if version >= 4
+            else heatmap_scales.reshape(sample_count, 1, 1, 1)
         )
+        heatmaps = quantised.astype(np.float32) * scale_view / 255.0
     return DecodedOverlay(
         flags=flags,
         base_seeds=tuple(seeds),

--- a/Platform/pipelines/overlay_precompute.py
+++ b/Platform/pipelines/overlay_precompute.py
@@ -31,6 +31,35 @@ def _channel_rms(features: torch.Tensor) -> np.ndarray:
     return channel_rms.numpy()
 
 
+def _spatial_feature_deviation(
+    features: torch.Tensor,
+    *,
+    preserve_zero_cells: bool = False,
+) -> np.ndarray:
+    if preserve_zero_cells:
+        valid = torch.linalg.vector_norm(features, ord=2, dim=1) > 0
+    else:
+        valid = torch.ones(
+            features.shape[0],
+            features.shape[2],
+            features.shape[3],
+            dtype=torch.bool,
+            device=features.device,
+        )
+    weights = valid[:, None].to(features.dtype)
+    spatial_mean = (features * weights).sum(dim=(2, 3), keepdim=True)
+    spatial_mean = spatial_mean / weights.sum(
+        dim=(2, 3),
+        keepdim=True,
+    ).clamp(min=1.0)
+    deviation = torch.linalg.vector_norm(
+        features - spatial_mean,
+        ord=2,
+        dim=1,
+    ) / float(features.shape[1]) ** 0.5
+    return (deviation * valid).numpy()
+
+
 class _BEVActivationRecorder:
     def __init__(self, model: torch.nn.Module):
         try:
@@ -119,16 +148,21 @@ class _BEVActivationRecorder:
         ):
             raise RuntimeError("BEV diagnostic feature shapes differ")
         views = {
-            "image": _channel_rms(image_features),
-            "map": _channel_rms(map_features),
+            "image": _spatial_feature_deviation(
+                image_features,
+                preserve_zero_cells=True,
+            ),
+            "map": _spatial_feature_deviation(map_features),
             "route_delta": _channel_rms(
                 navigation_features - map_features
             ),
-            "navigation": _channel_rms(navigation_features),
+            "navigation": _spatial_feature_deviation(
+                navigation_features
+            ),
             "fusion_delta": _channel_rms(
                 fused_features - image_features
             ),
-            "fused": _channel_rms(fused_features),
+            "fused": _spatial_feature_deviation(fused_features),
         }
         heatmaps = np.stack(
             [views[name] for name in BEV_HEATMAP_NAMES],

--- a/Platform/pipelines/overlay_precompute.py
+++ b/Platform/pipelines/overlay_precompute.py
@@ -6,8 +6,86 @@ from typing import Any, Mapping, Sequence
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 
 from Platform.pipelines.inference import predict_control
+from Platform.pipelines.overlay import BEV_HEATMAP_NAMES, BEV_HEATMAP_SIZE
+
+
+class _BEVActivationRecorder:
+    def __init__(self, model: torch.nn.Module):
+        try:
+            reactive = model.Reactive_E2E
+            modules = (
+                reactive.FeatureFusion,
+                reactive.NavigationEncoder,
+                reactive.MapBEVFusion,
+            )
+        except AttributeError as exc:
+            raise ValueError(
+                "model does not expose the BEV diagnostic modules"
+            ) from exc
+        self._latest: dict[str, np.ndarray] = {}
+        self._enabled = False
+        self._handles = [
+            module.register_forward_hook(self._hook(name))
+            for name, module in zip(BEV_HEATMAP_NAMES, modules)
+        ]
+
+    def _hook(self, name: str):
+        def record(
+            _module: torch.nn.Module,
+            _inputs: tuple[Any, ...],
+            output: Any,
+        ) -> None:
+            if not self._enabled:
+                return
+            if not torch.is_tensor(output) or output.ndim != 4:
+                raise ValueError(
+                    f"{name} BEV output must be a [B,C,H,W] tensor"
+                )
+            channel_rms = torch.linalg.vector_norm(
+                output.detach(), ord=2, dim=1
+            ) / float(output.shape[1]) ** 0.5
+            downsampled = F.adaptive_avg_pool2d(
+                channel_rms[:, None].float(),
+                (BEV_HEATMAP_SIZE, BEV_HEATMAP_SIZE),
+            )[:, 0]
+            self._latest[name] = downsampled.cpu().numpy()
+
+        return record
+
+    def set_enabled(self, enabled: bool) -> None:
+        self._enabled = enabled
+        if enabled:
+            self._latest.clear()
+
+    def take(self, batch_size: int) -> np.ndarray:
+        missing = set(BEV_HEATMAP_NAMES) - set(self._latest)
+        if missing:
+            raise RuntimeError(
+                f"BEV diagnostic hooks did not run: {sorted(missing)}"
+            )
+        heatmaps = np.stack(
+            [self._latest[name] for name in BEV_HEATMAP_NAMES],
+            axis=1,
+        )
+        expected = (
+            batch_size,
+            len(BEV_HEATMAP_NAMES),
+            BEV_HEATMAP_SIZE,
+            BEV_HEATMAP_SIZE,
+        )
+        if heatmaps.shape != expected:
+            raise RuntimeError(
+                f"BEV diagnostic shape changed: {heatmaps.shape} != {expected}"
+            )
+        self._latest.clear()
+        return np.ascontiguousarray(heatmaps, dtype=np.float32)
+
+    def close(self) -> None:
+        for handle in self._handles:
+            handle.remove()
 
 
 def planner_is_deterministic(model: torch.nn.Module) -> bool:
@@ -48,6 +126,67 @@ def infer_loader_controls(
     Controls have shape ``[N,S,64,2]``. A deterministic Bezier planner is run
     once even if callers supply a seed fan because every draw would be identical.
     """
+    uids, controls, v0, seeds, _ = _infer_loader(
+        model,
+        loader,
+        model_artifact_id=model_artifact_id,
+        dataset_manifest_digest=dataset_manifest_digest,
+        base_seeds=base_seeds,
+        device=device,
+        training_policy=training_policy,
+        capture_bev_heatmaps=False,
+    )
+    return uids, controls, v0, seeds
+
+
+def infer_loader_overlay(
+    model: torch.nn.Module,
+    loader: Any,
+    *,
+    model_artifact_id: str,
+    dataset_manifest_digest: str,
+    base_seeds: Sequence[int] = (0,),
+    device: str | torch.device,
+    training_policy: Any = None,
+) -> tuple[
+    list[str],
+    np.ndarray,
+    np.ndarray,
+    tuple[int, ...],
+    np.ndarray,
+]:
+    """Infer controls and compact BEV activation maps for one shard."""
+    uids, controls, v0, seeds, heatmaps = _infer_loader(
+        model,
+        loader,
+        model_artifact_id=model_artifact_id,
+        dataset_manifest_digest=dataset_manifest_digest,
+        base_seeds=base_seeds,
+        device=device,
+        training_policy=training_policy,
+        capture_bev_heatmaps=True,
+    )
+    assert heatmaps is not None
+    return uids, controls, v0, seeds, heatmaps
+
+
+def _infer_loader(
+    model: torch.nn.Module,
+    loader: Any,
+    *,
+    model_artifact_id: str,
+    dataset_manifest_digest: str,
+    base_seeds: Sequence[int],
+    device: str | torch.device,
+    training_policy: Any,
+    capture_bev_heatmaps: bool,
+) -> tuple[
+    list[str],
+    np.ndarray,
+    np.ndarray,
+    tuple[int, ...],
+    np.ndarray | None,
+]:
     seeds = tuple(int(seed) for seed in base_seeds)
     if not seeds:
         raise ValueError("base_seeds must not be empty")
@@ -62,46 +201,63 @@ def infer_loader_controls(
     all_uids: list[str] = []
     control_batches: list[np.ndarray] = []
     speed_batches: list[np.ndarray] = []
-    for raw_batch in loader:
-        sample_uids = [str(uid) for uid in raw_batch["sample_uid"]]
-        batch = batch_to_device(raw_batch, device)
-        if training_policy is not None:
-            from training.dataset_policy import adapt_egomotion_history
+    heatmap_batches: list[np.ndarray] = []
+    recorder = _BEVActivationRecorder(model) if capture_bev_heatmaps else None
+    try:
+        for raw_batch in loader:
+            sample_uids = [str(uid) for uid in raw_batch["sample_uid"]]
+            batch = batch_to_device(raw_batch, device)
+            if training_policy is not None:
+                from training.dataset_policy import adapt_egomotion_history
 
-            batch["egomotion_history"] = adapt_egomotion_history(
-                batch["egomotion_history"],
-                training_policy,
+                batch["egomotion_history"] = adapt_egomotion_history(
+                    batch["egomotion_history"],
+                    training_policy,
+                )
+            per_seed = []
+            for seed_index, seed in enumerate(seeds):
+                if recorder is not None:
+                    recorder.set_enabled(seed_index == 0)
+                per_seed.append(
+                    predict_control(
+                        model,
+                        batch,
+                        sample_uids=sample_uids,
+                        model_artifact_id=model_artifact_id,
+                        dataset_manifest_digest=dataset_manifest_digest,
+                        base_seed=seed,
+                        projection=projection,
+                        geometry_type=geometry_type,
+                    )
+                )
+            controls = np.stack(per_seed, axis=1)
+            history = raw_batch["egomotion_history"].reshape(
+                len(sample_uids), 64, 4
             )
-        per_seed = [
-            predict_control(
-                model,
-                batch,
-                sample_uids=sample_uids,
-                model_artifact_id=model_artifact_id,
-                dataset_manifest_digest=dataset_manifest_digest,
-                base_seed=seed,
-                projection=projection,
-                geometry_type=geometry_type,
-            )
-            for seed in seeds
-        ]
-        controls = np.stack(per_seed, axis=1)
-        history = raw_batch["egomotion_history"].reshape(
-            len(sample_uids), 64, 4
-        )
-        speeds = history[:, -1, 0].detach().cpu().numpy().astype(np.float32)
+            speeds = history[:, -1, 0].detach().cpu().numpy().astype(np.float32)
 
-        all_uids.extend(sample_uids)
-        control_batches.append(controls)
-        speed_batches.append(speeds)
+            all_uids.extend(sample_uids)
+            control_batches.append(controls)
+            speed_batches.append(speeds)
+            if recorder is not None:
+                heatmap_batches.append(recorder.take(len(sample_uids)))
+    finally:
+        if recorder is not None:
+            recorder.close()
 
     if not all_uids:
         raise ValueError("overlay loader yielded no samples")
     if len(set(all_uids)) != len(all_uids):
         raise ValueError("overlay loader yielded duplicate sample_uids")
+    heatmaps = (
+        np.concatenate(heatmap_batches, axis=0)
+        if heatmap_batches
+        else None
+    )
     return (
         all_uids,
         np.concatenate(control_batches, axis=0),
         np.concatenate(speed_batches, axis=0),
         seeds,
+        heatmaps,
     )

--- a/Platform/pipelines/overlay_precompute.py
+++ b/Platform/pipelines/overlay_precompute.py
@@ -12,6 +12,25 @@ from Platform.pipelines.inference import predict_control
 from Platform.pipelines.overlay import BEV_HEATMAP_NAMES, BEV_HEATMAP_SIZE
 
 
+_HOOK_HEATMAP_NAMES = ("image", "navigation", "fused")
+
+
+def _downsample_features(output: torch.Tensor, name: str) -> torch.Tensor:
+    if not torch.is_tensor(output) or output.ndim != 4:
+        raise ValueError(f"{name} BEV output must be a [B,C,H,W] tensor")
+    return F.adaptive_avg_pool2d(
+        output.detach().float(),
+        (BEV_HEATMAP_SIZE, BEV_HEATMAP_SIZE),
+    ).cpu()
+
+
+def _channel_rms(features: torch.Tensor) -> np.ndarray:
+    channel_rms = torch.linalg.vector_norm(
+        features, ord=2, dim=1
+    ) / float(features.shape[1]) ** 0.5
+    return channel_rms.numpy()
+
+
 class _BEVActivationRecorder:
     def __init__(self, model: torch.nn.Module):
         try:
@@ -25,11 +44,12 @@ class _BEVActivationRecorder:
             raise ValueError(
                 "model does not expose the BEV diagnostic modules"
             ) from exc
-        self._latest: dict[str, np.ndarray] = {}
+        self._reactive = reactive
+        self._latest: dict[str, torch.Tensor] = {}
         self._enabled = False
         self._handles = [
             module.register_forward_hook(self._hook(name))
-            for name, module in zip(BEV_HEATMAP_NAMES, modules)
+            for name, module in zip(_HOOK_HEATMAP_NAMES, modules)
         ]
 
     def _hook(self, name: str):
@@ -40,18 +60,7 @@ class _BEVActivationRecorder:
         ) -> None:
             if not self._enabled:
                 return
-            if not torch.is_tensor(output) or output.ndim != 4:
-                raise ValueError(
-                    f"{name} BEV output must be a [B,C,H,W] tensor"
-                )
-            channel_rms = torch.linalg.vector_norm(
-                output.detach(), ord=2, dim=1
-            ) / float(output.shape[1]) ** 0.5
-            downsampled = F.adaptive_avg_pool2d(
-                channel_rms[:, None].float(),
-                (BEV_HEATMAP_SIZE, BEV_HEATMAP_SIZE),
-            )[:, 0]
-            self._latest[name] = downsampled.cpu().numpy()
+            self._latest[name] = _downsample_features(output, name)
 
         return record
 
@@ -60,14 +69,69 @@ class _BEVActivationRecorder:
         if enabled:
             self._latest.clear()
 
-    def take(self, batch_size: int) -> np.ndarray:
-        missing = set(BEV_HEATMAP_NAMES) - set(self._latest)
+    def take(
+        self,
+        batch: Mapping[str, Any],
+        batch_size: int,
+    ) -> np.ndarray:
+        self.set_enabled(False)
+        missing = set(_HOOK_HEATMAP_NAMES) - set(self._latest)
         if missing:
             raise RuntimeError(
                 f"BEV diagnostic hooks did not run: {sorted(missing)}"
             )
+        map_context = batch["map_context"]
+        map_valid = batch.get("map_valid")
+        if map_valid is None:
+            map_valid = torch.ones(
+                batch_size,
+                dtype=torch.bool,
+                device=map_context.device,
+            )
+        gated_map = map_context * torch.as_tensor(
+            map_valid, device=map_context.device
+        ).reshape(batch_size, 1, 1, 1).to(map_context.dtype)
+        route_channels = int(self._reactive.route_channels)
+        map_only_input = torch.cat(
+            [
+                gated_map,
+                map_context.new_zeros(
+                    batch_size,
+                    route_channels,
+                    map_context.shape[-2],
+                    map_context.shape[-1],
+                ),
+            ],
+            dim=1,
+        )
+        with torch.no_grad():
+            map_features = _downsample_features(
+                self._reactive.NavigationEncoder(map_only_input),
+                "map-only",
+            )
+
+        image_features = self._latest["image"]
+        navigation_features = self._latest["navigation"]
+        fused_features = self._latest["fused"]
+        if (
+            map_features.shape != navigation_features.shape
+            or image_features.shape != fused_features.shape
+        ):
+            raise RuntimeError("BEV diagnostic feature shapes differ")
+        views = {
+            "image": _channel_rms(image_features),
+            "map": _channel_rms(map_features),
+            "route_delta": _channel_rms(
+                navigation_features - map_features
+            ),
+            "navigation": _channel_rms(navigation_features),
+            "fusion_delta": _channel_rms(
+                fused_features - image_features
+            ),
+            "fused": _channel_rms(fused_features),
+        }
         heatmaps = np.stack(
-            [self._latest[name] for name in BEV_HEATMAP_NAMES],
+            [views[name] for name in BEV_HEATMAP_NAMES],
             axis=1,
         )
         expected = (
@@ -240,7 +304,9 @@ def _infer_loader(
             control_batches.append(controls)
             speed_batches.append(speeds)
             if recorder is not None:
-                heatmap_batches.append(recorder.take(len(sample_uids)))
+                heatmap_batches.append(
+                    recorder.take(batch, len(sample_uids))
+                )
     finally:
         if recorder is not None:
             recorder.close()

--- a/Platform/pipelines/overlay_tasks.py
+++ b/Platform/pipelines/overlay_tasks.py
@@ -522,6 +522,26 @@ def _publish_overlay_pointer(
             ) from exc
 
 
+def _validate_overlay_upgrade_coverage(
+    gate: Mapping[str, Any],
+    *,
+    n_shards: int,
+    n_samples: int,
+) -> None:
+    if "previous_overlay_schema" not in gate:
+        return
+    if (
+        gate["previous_n_shards"] != n_shards
+        or gate["previous_n_samples"] != n_samples
+    ):
+        raise RuntimeError(
+            "overlay schema upgrade changed dataset coverage: "
+            f"{n_shards} shards / {n_samples} samples != "
+            f"{gate['previous_n_shards']} shards / "
+            f"{gate['previous_n_samples']} samples"
+        )
+
+
 def _publish_overlay_set_ready(table, item: Mapping[str, Any]) -> None:
     from botocore.exceptions import ClientError
 
@@ -1850,16 +1870,11 @@ def finalize_overlay_set(
         raise ValueError("overlay partitions used inconsistent seed sets")
     seeds = list(next(iter(actual_seed_sets)))
     n_samples = sum(entry["sample_count"] for entry in entries)
-    if "previous_overlay_schema" in gate and (
-        gate["previous_n_shards"] != len(entries)
-        or gate["previous_n_samples"] != n_samples
-    ):
-        raise RuntimeError(
-            "overlay schema upgrade changed dataset coverage: "
-            f"{len(entries)} shards / {n_samples} samples != "
-            f"{gate['previous_n_shards']} shards / "
-            f"{gate['previous_n_samples']} samples"
-        )
+    _validate_overlay_upgrade_coverage(
+        gate,
+        n_shards=len(entries),
+        n_samples=n_samples,
+    )
     output_sha256 = hashlib.sha256(
         json.dumps(
             [(entry["shard"], entry["sha256"]) for entry in entries],

--- a/Platform/pipelines/overlay_tasks.py
+++ b/Platform/pipelines/overlay_tasks.py
@@ -1175,11 +1175,13 @@ def precompute_overlay_partition(
     from data_parsing.pre_extracted import make_pre_extracted_loader
     from Platform.pipelines.inference import load_policy
     from Platform.pipelines.overlay import (
+        BEV_HEATMAP_NAMES,
+        BEV_HEATMAP_SIZE,
         overlay_s3_key,
         write_overlay,
     )
     from Platform.pipelines.overlay_precompute import (
-        infer_loader_controls,
+        infer_loader_overlay,
         planner_is_deterministic,
     )
     from Platform.pipelines.overlay_store import (
@@ -1311,6 +1313,8 @@ def precompute_overlay_partition(
                 )
                 object_identity = {
                     "base-seeds": ",".join(map(str, actual_seeds)),
+                    "bev-heatmap-names": ",".join(BEV_HEATMAP_NAMES),
+                    "bev-heatmap-size": str(BEV_HEATMAP_SIZE),
                     "cache-identity": cache_identity,
                     "dataset-manifest-digest": dataset_manifest_digest,
                     "model-artifact-id": model_artifact_id,
@@ -1359,7 +1363,8 @@ def precompute_overlay_partition(
                                 controls,
                                 v0,
                                 actual_seeds_tuple,
-                            ) = infer_loader_controls(
+                                bev_heatmaps,
+                            ) = infer_loader_overlay(
                                 model,
                                 loader,
                                 model_artifact_id=model_artifact_id,
@@ -1396,6 +1401,7 @@ def precompute_overlay_partition(
                         v0,
                         base_seeds=actual_seeds,
                         deterministic_planner=deterministic_planner,
+                        bev_heatmaps=bev_heatmaps,
                     )
                     artifact_sha = artifact.sha256
                     sample_count = artifact.sample_count

--- a/Platform/pipelines/overlay_tasks.py
+++ b/Platform/pipelines/overlay_tasks.py
@@ -290,6 +290,219 @@ def _put_dynamo_immutable(
     return existing
 
 
+def _overlay_schema_version(value: Any) -> int:
+    match = re.fullmatch(r"v([1-9][0-9]*)", str(value))
+    if match is None:
+        raise ValueError(f"invalid overlay schema {value!r}")
+    return int(match.group(1))
+
+
+def _is_overlay_set_upgrade(
+    existing: Mapping[str, Any],
+    item: Mapping[str, Any],
+) -> bool:
+    identity_fields = (
+        "pk",
+        "sk",
+        "dataset_manifest_sha256",
+        "artifacts_bucket",
+        "seeds",
+    )
+    return (
+        existing.get("status") == "ready"
+        and all(existing.get(field) == item.get(field) for field in identity_fields)
+        and _overlay_schema_version(existing.get("overlay_schema"))
+        < _overlay_schema_version(item.get("overlay_schema"))
+    )
+
+
+def _prepare_overlay_set_item(
+    table,
+    item: Mapping[str, Any],
+) -> dict[str, Any]:
+    from botocore.exceptions import ClientError
+
+    try:
+        table.put_item(
+            Item=dict(item),
+            ConditionExpression=(
+                "attribute_not_exists(pk) AND attribute_not_exists(sk)"
+            ),
+        )
+        return dict(item)
+    except ClientError as exc:
+        if not _is_conditional_check_failed(exc):
+            raise
+
+    existing = _get_dynamo_item(table, item)
+    identity_fields = (
+        "pk",
+        "sk",
+        "dataset_manifest_sha256",
+        "request_identity",
+        "artifacts_bucket",
+        "overlay_schema",
+        "seeds",
+    )
+    mismatches = [
+        field
+        for field in identity_fields
+        if existing.get(field) != item.get(field)
+    ]
+    if not mismatches:
+        return existing
+    if _is_overlay_set_upgrade(existing, item):
+        staged = dict(item)
+        staged["previous_overlay_schema"] = existing["overlay_schema"]
+        staged["previous_request_identity"] = existing["request_identity"]
+        return staged
+    raise RuntimeError(
+        "immutable DynamoDB item exists with a different identity "
+        f"({', '.join(sorted(mismatches))}): "
+        f"{item['pk']} / {item['sk']}"
+    )
+
+
+def _stage_overlay_set_upgrade(
+    table,
+    item: Mapping[str, Any],
+    gate: Mapping[str, str],
+) -> None:
+    from botocore.exceptions import ClientError
+
+    previous_schema = gate.get("previous_overlay_schema")
+    previous_request = gate.get("previous_request_identity")
+    if not previous_schema or not previous_request:
+        return
+    try:
+        table.put_item(
+            Item=dict(item),
+            ConditionExpression=(
+                "#status = :ready "
+                "AND overlay_schema = :previous_schema "
+                "AND request_identity = :previous_request "
+                "AND dataset_manifest_sha256 = :dataset_manifest "
+                "AND artifacts_bucket = :artifacts_bucket"
+            ),
+            ExpressionAttributeNames={"#status": "status"},
+            ExpressionAttributeValues={
+                ":ready": "ready",
+                ":previous_schema": previous_schema,
+                ":previous_request": previous_request,
+                ":dataset_manifest": item["dataset_manifest_sha256"],
+                ":artifacts_bucket": item["artifacts_bucket"],
+            },
+        )
+        return
+    except ClientError as exc:
+        if not _is_conditional_check_failed(exc):
+            raise
+
+    existing = _get_dynamo_item(table, item)
+    fields = (
+        "status",
+        "request_identity",
+        "dataset_manifest_sha256",
+        "artifacts_bucket",
+        "overlay_schema",
+        "seeds",
+        "created_at",
+    )
+    mismatches = [
+        field
+        for field in fields
+        if existing.get(field) != item.get(field)
+    ]
+    if mismatches:
+        raise RuntimeError(
+            "overlay-set upgrade staging differs in "
+            f"{', '.join(sorted(mismatches))}: {item['pk']}"
+        )
+
+
+def _publish_overlay_pointer(
+    table,
+    item: Mapping[str, Any],
+) -> None:
+    from botocore.exceptions import ClientError
+
+    identity_fields = (
+        "pk",
+        "sk",
+        "s3_key",
+        "sha256",
+        "byte_size",
+        "sample_count",
+        "overlay_schema",
+        "dataset_manifest_sha256",
+        "cache_identity",
+        "status",
+    )
+    try:
+        table.put_item(
+            Item=dict(item),
+            ConditionExpression=(
+                "attribute_not_exists(pk) AND attribute_not_exists(sk)"
+            ),
+        )
+        return
+    except ClientError as exc:
+        if not _is_conditional_check_failed(exc):
+            raise
+
+    existing = _get_dynamo_item(table, item)
+    mismatches = [
+        field
+        for field in identity_fields
+        if existing.get(field) != item.get(field)
+    ]
+    if not mismatches:
+        return
+    same_dataset = (
+        existing.get("dataset_manifest_sha256")
+        == item.get("dataset_manifest_sha256")
+    )
+    previous_schema = existing.get("overlay_schema")
+    if (
+        existing.get("status") != "ready"
+        or not same_dataset
+        or _overlay_schema_version(previous_schema)
+        >= _overlay_schema_version(item.get("overlay_schema"))
+    ):
+        raise RuntimeError(
+            "overlay pointer exists with a different identity "
+            f"({', '.join(sorted(mismatches))}): "
+            f"{item['pk']} / {item['sk']}"
+        )
+    try:
+        table.put_item(
+            Item=dict(item),
+            ConditionExpression=(
+                "#status = :ready "
+                "AND overlay_schema = :previous_schema "
+                "AND dataset_manifest_sha256 = :dataset_manifest"
+            ),
+            ExpressionAttributeNames={"#status": "status"},
+            ExpressionAttributeValues={
+                ":ready": "ready",
+                ":previous_schema": previous_schema,
+                ":dataset_manifest": item["dataset_manifest_sha256"],
+            },
+        )
+    except ClientError as exc:
+        if not _is_conditional_check_failed(exc):
+            raise
+        current = _get_dynamo_item(table, item)
+        if any(
+            current.get(field) != item.get(field)
+            for field in identity_fields
+        ):
+            raise RuntimeError(
+                "concurrent overlay pointer upgrade has a different identity: "
+                f"{item['pk']} / {item['sk']}"
+            ) from exc
+
+
 def _publish_overlay_set_ready(table, item: Mapping[str, Any]) -> None:
     from botocore.exceptions import ClientError
 
@@ -342,18 +555,20 @@ def _publish_overlay_set_ready(table, item: Mapping[str, Any]) -> None:
 
 
 def _gate_token(item: Mapping[str, Any], model_artifact_id: str) -> str:
+    gate = {
+        "artifacts_bucket": item["artifacts_bucket"],
+        "created_at": item["created_at"],
+        "dataset_manifest_sha256": item["dataset_manifest_sha256"],
+        "model_artifact_id": model_artifact_id,
+        "overlay_schema": item["overlay_schema"],
+        "request_identity": item["request_identity"],
+        "status": item["status"],
+    }
+    for name in ("previous_overlay_schema", "previous_request_identity"):
+        if item.get(name):
+            gate[name] = item[name]
     return json.dumps(
-        {
-            "artifacts_bucket": item["artifacts_bucket"],
-            "created_at": item["created_at"],
-            "dataset_manifest_sha256": item[
-                "dataset_manifest_sha256"
-            ],
-            "model_artifact_id": model_artifact_id,
-            "overlay_schema": item["overlay_schema"],
-            "request_identity": item["request_identity"],
-            "status": item["status"],
-        },
+        gate,
         sort_keys=True,
         separators=(",", ":"),
     )
@@ -380,6 +595,12 @@ def _parse_gate(value: str) -> dict[str, str]:
         raise ValueError("overlay-set gate token is incomplete")
     if gate["status"] not in {"building", "ready"}:
         raise ValueError("overlay-set gate is not writable")
+    optional = ("previous_overlay_schema", "previous_request_identity")
+    if any(name in gate for name in optional) and any(
+        not isinstance(gate.get(name), str) or not gate[name]
+        for name in optional
+    ):
+        raise ValueError("overlay-set upgrade gate is incomplete")
     return gate
 
 
@@ -1114,19 +1335,7 @@ def prepare_overlay_set(
         artifacts_bucket=artifacts_bucket,
         created_at=created_at,
     )
-    existing = _put_dynamo_immutable(
-        table,
-        set_item,
-        identity_fields=(
-            "pk",
-            "sk",
-            "dataset_manifest_sha256",
-            "request_identity",
-            "artifacts_bucket",
-            "overlay_schema",
-            "seeds",
-        ),
-    )
+    existing = _prepare_overlay_set_item(table, set_item)
     if existing.get("status") not in {"building", "ready"}:
         raise RuntimeError(
             f"overlay set cannot resume from status {existing.get('status')!r}"
@@ -1186,7 +1395,6 @@ def precompute_overlay_partition(
     )
     from Platform.pipelines.overlay_store import (
         overlay_cache_identity,
-        overlay_pointer_item,
         overlay_request_identity,
     )
 
@@ -1281,7 +1489,6 @@ def precompute_overlay_partition(
     )
 
     s3 = boto3.client("s3", region_name=aws_region)
-    table = boto3.resource("dynamodb", region_name=aws_region).Table(dynamo_table)
     output_dir = Path(tempfile.mkdtemp(prefix="overlay-partition-"))
     entries = []
     seen_shards = set()
@@ -1422,37 +1629,6 @@ def precompute_overlay_partition(
                     )
 
                 created_at = gate["created_at"]
-                pointer = overlay_pointer_item(
-                    dataset=dataset,
-                    version=dataset_version,
-                    shard=shard_name,
-                    model_artifact_id=model_artifact_id,
-                    s3_key=key,
-                    sha256=artifact_sha,
-                    byte_size=byte_size,
-                    sample_count=sample_count,
-                    overlay_schema=OVERLAY_SCHEMA,
-                    dataset_manifest_digest=dataset_manifest_digest,
-                    cache_identity=cache_identity,
-                    created_at=created_at,
-                    model_metadata=metadata,
-                )
-                _put_dynamo_immutable(
-                    table,
-                    pointer,
-                    identity_fields=(
-                        "pk",
-                        "sk",
-                        "s3_key",
-                        "sha256",
-                        "byte_size",
-                        "sample_count",
-                        "overlay_schema",
-                        "dataset_manifest_sha256",
-                        "cache_identity",
-                        "status",
-                    ),
-                )
                 entries.append({
                     "shard": shard_name,
                     "s3_key": key,
@@ -1522,7 +1698,10 @@ def finalize_overlay_set(
 
     import boto3
 
-    from Platform.pipelines.overlay_store import overlay_set_item
+    from Platform.pipelines.overlay_store import (
+        overlay_pointer_item,
+        overlay_set_item,
+    )
 
     metadata = json.loads(Path(model_metadata.download()).read_text())
     gate = _parse_gate(prepare_gate)
@@ -1660,7 +1839,8 @@ def finalize_overlay_set(
         "shards": entries,
     }
     manifest_key = (
-        f"overlays_manifest/schema=v1/model={model_artifact_id}/"
+        f"overlays_manifest/schema=v1/overlay={OVERLAY_SCHEMA}/"
+        f"model={model_artifact_id}/"
         f"dataset={dataset}/version={dataset_version}/manifest.json"
     )
     s3 = boto3.client("s3", region_name=aws_region)
@@ -1686,6 +1866,36 @@ def finalize_overlay_set(
     )
 
     table = boto3.resource("dynamodb", region_name=aws_region).Table(dynamo_table)
+    building_item = overlay_set_item(
+        model_artifact_id,
+        dataset,
+        dataset_version,
+        status="building",
+        seeds=seeds,
+        overlay_schema=OVERLAY_SCHEMA,
+        dataset_manifest_digest=dataset_manifest_digest,
+        request_identity=environment["request_identity"],
+        artifacts_bucket=artifacts_bucket,
+        created_at=created_at,
+    )
+    _stage_overlay_set_upgrade(table, building_item, gate)
+    for entry in entries:
+        pointer = overlay_pointer_item(
+            dataset=dataset,
+            version=dataset_version,
+            shard=entry["shard"],
+            model_artifact_id=model_artifact_id,
+            s3_key=entry["s3_key"],
+            sha256=entry["sha256"],
+            byte_size=entry["byte_size"],
+            sample_count=entry["sample_count"],
+            overlay_schema=OVERLAY_SCHEMA,
+            dataset_manifest_digest=dataset_manifest_digest,
+            cache_identity=environment["cache_identity"],
+            created_at=created_at,
+            model_metadata=metadata,
+        )
+        _publish_overlay_pointer(table, pointer)
     ready_item = overlay_set_item(
         model_artifact_id,
         dataset,

--- a/Platform/pipelines/overlay_tasks.py
+++ b/Platform/pipelines/overlay_tasks.py
@@ -306,10 +306,12 @@ def _is_overlay_set_upgrade(
         "sk",
         "dataset_manifest_sha256",
         "artifacts_bucket",
-        "seeds",
     )
+    request_identity = existing.get("request_identity")
     return (
         existing.get("status") == "ready"
+        and isinstance(request_identity, str)
+        and _SHA256_RE.fullmatch(request_identity) is not None
         and all(existing.get(field) == item.get(field) for field in identity_fields)
         and _overlay_schema_version(existing.get("overlay_schema"))
         < _overlay_schema_version(item.get("overlay_schema"))
@@ -355,6 +357,10 @@ def _prepare_overlay_set_item(
         staged = dict(item)
         staged["previous_overlay_schema"] = existing["overlay_schema"]
         staged["previous_request_identity"] = existing["request_identity"]
+        staged["previous_created_at"] = existing["created_at"]
+        staged["previous_seeds"] = existing["seeds"]
+        staged["previous_n_shards"] = existing["n_shards"]
+        staged["previous_n_samples"] = existing["n_samples"]
         return staged
     raise RuntimeError(
         "immutable DynamoDB item exists with a different identity "
@@ -366,7 +372,7 @@ def _prepare_overlay_set_item(
 def _stage_overlay_set_upgrade(
     table,
     item: Mapping[str, Any],
-    gate: Mapping[str, str],
+    gate: Mapping[str, Any],
 ) -> None:
     from botocore.exceptions import ClientError
 
@@ -374,6 +380,10 @@ def _stage_overlay_set_upgrade(
     previous_request = gate.get("previous_request_identity")
     if not previous_schema or not previous_request:
         return
+    previous_seeds = gate["previous_seeds"]
+    previous_created_at = gate["previous_created_at"]
+    previous_n_shards = gate["previous_n_shards"]
+    previous_n_samples = gate["previous_n_samples"]
     try:
         table.put_item(
             Item=dict(item),
@@ -382,7 +392,11 @@ def _stage_overlay_set_upgrade(
                 "AND overlay_schema = :previous_schema "
                 "AND request_identity = :previous_request "
                 "AND dataset_manifest_sha256 = :dataset_manifest "
-                "AND artifacts_bucket = :artifacts_bucket"
+                "AND artifacts_bucket = :artifacts_bucket "
+                "AND seeds = :previous_seeds "
+                "AND created_at = :previous_created_at "
+                "AND n_shards = :previous_n_shards "
+                "AND n_samples = :previous_n_samples"
             ),
             ExpressionAttributeNames={"#status": "status"},
             ExpressionAttributeValues={
@@ -391,6 +405,10 @@ def _stage_overlay_set_upgrade(
                 ":previous_request": previous_request,
                 ":dataset_manifest": item["dataset_manifest_sha256"],
                 ":artifacts_bucket": item["artifacts_bucket"],
+                ":previous_seeds": previous_seeds,
+                ":previous_created_at": previous_created_at,
+                ":previous_n_shards": previous_n_shards,
+                ":previous_n_samples": previous_n_samples,
             },
         )
         return
@@ -565,7 +583,14 @@ def _gate_token(item: Mapping[str, Any], model_artifact_id: str) -> str:
         "request_identity": item["request_identity"],
         "status": item["status"],
     }
-    for name in ("previous_overlay_schema", "previous_request_identity"):
+    for name in (
+        "previous_overlay_schema",
+        "previous_request_identity",
+        "previous_created_at",
+        "previous_seeds",
+        "previous_n_shards",
+        "previous_n_samples",
+    ):
         if item.get(name):
             gate[name] = item[name]
     return json.dumps(
@@ -575,7 +600,7 @@ def _gate_token(item: Mapping[str, Any], model_artifact_id: str) -> str:
     )
 
 
-def _parse_gate(value: str) -> dict[str, str]:
+def _parse_gate(value: str) -> dict[str, Any]:
     try:
         gate = json.loads(value)
     except (TypeError, json.JSONDecodeError) as exc:
@@ -596,12 +621,41 @@ def _parse_gate(value: str) -> dict[str, str]:
         raise ValueError("overlay-set gate token is incomplete")
     if gate["status"] not in {"building", "ready"}:
         raise ValueError("overlay-set gate is not writable")
-    optional = ("previous_overlay_schema", "previous_request_identity")
-    if any(name in gate for name in optional) and any(
-        not isinstance(gate.get(name), str) or not gate[name]
-        for name in optional
-    ):
+    upgrade_fields = {
+        "previous_overlay_schema",
+        "previous_request_identity",
+        "previous_created_at",
+        "previous_seeds",
+        "previous_n_shards",
+        "previous_n_samples",
+    }
+    present_upgrade_fields = upgrade_fields.intersection(gate)
+    if present_upgrade_fields and present_upgrade_fields != upgrade_fields:
         raise ValueError("overlay-set upgrade gate is incomplete")
+    if present_upgrade_fields:
+        string_fields = (
+            "previous_overlay_schema",
+            "previous_request_identity",
+            "previous_created_at",
+        )
+        if any(
+            not isinstance(gate.get(name), str) or not gate[name]
+            for name in string_fields
+        ):
+            raise ValueError("overlay-set upgrade gate is incomplete")
+        if (
+            not isinstance(gate.get("previous_seeds"), list)
+            or not gate["previous_seeds"]
+            or not all(
+                isinstance(seed, int) and seed >= 0
+                for seed in gate["previous_seeds"]
+            )
+            or not isinstance(gate.get("previous_n_shards"), int)
+            or gate["previous_n_shards"] < 1
+            or not isinstance(gate.get("previous_n_samples"), int)
+            or gate["previous_n_samples"] < 1
+        ):
+            raise ValueError("overlay-set upgrade gate is incomplete")
     return gate
 
 
@@ -1229,6 +1283,7 @@ def resolve_overlay_model(
     requests=Resources(cpu="1", mem="2Gi"),
     limits=Resources(cpu="1", mem="2Gi"),
     environment=OVERLAY_TASK_ENV,
+    retries=3,
 )
 def prepare_overlay_set(
     resolved_metadata: FlyteFile,
@@ -1794,6 +1849,17 @@ def finalize_overlay_set(
     if len(actual_seed_sets) != 1:
         raise ValueError("overlay partitions used inconsistent seed sets")
     seeds = list(next(iter(actual_seed_sets)))
+    n_samples = sum(entry["sample_count"] for entry in entries)
+    if "previous_overlay_schema" in gate and (
+        gate["previous_n_shards"] != len(entries)
+        or gate["previous_n_samples"] != n_samples
+    ):
+        raise RuntimeError(
+            "overlay schema upgrade changed dataset coverage: "
+            f"{len(entries)} shards / {n_samples} samples != "
+            f"{gate['previous_n_shards']} shards / "
+            f"{gate['previous_n_samples']} samples"
+        )
     output_sha256 = hashlib.sha256(
         json.dumps(
             [(entry["shard"], entry["sha256"]) for entry in entries],
@@ -1815,7 +1881,7 @@ def finalize_overlay_set(
         "request_identity": environment["request_identity"],
         "cache_identity": environment["cache_identity"],
         "n_shards": len(entries),
-        "n_samples": sum(entry["sample_count"] for entry in entries),
+        "n_samples": n_samples,
         "seeds": seeds,
         "sampler": environment["sampler"],
         "num_inference_steps": environment["num_inference_steps"],

--- a/Platform/pipelines/overlay_tasks.py
+++ b/Platform/pipelines/overlay_tasks.py
@@ -1305,7 +1305,6 @@ def resolve_overlay_model(
     requests=Resources(cpu="1", mem="2Gi"),
     limits=Resources(cpu="1", mem="2Gi"),
     environment=OVERLAY_TASK_ENV,
-    retries=3,
 )
 def prepare_overlay_set(
     resolved_metadata: FlyteFile,
@@ -1757,6 +1756,7 @@ def precompute_overlay_partition(
     requests=Resources(cpu="1", mem="2Gi"),
     limits=Resources(cpu="1", mem="2Gi"),
     environment=OVERLAY_TASK_ENV,
+    retries=3,
 )
 def finalize_overlay_set(
     model_metadata: FlyteFile,

--- a/Platform/pipelines/overlay_tasks.py
+++ b/Platform/pipelines/overlay_tasks.py
@@ -400,7 +400,6 @@ def _stage_overlay_set_upgrade(
 
     existing = _get_dynamo_item(table, item)
     fields = (
-        "status",
         "request_identity",
         "dataset_manifest_sha256",
         "artifacts_bucket",
@@ -413,6 +412,8 @@ def _stage_overlay_set_upgrade(
         for field in fields
         if existing.get(field) != item.get(field)
     ]
+    if existing.get("status") not in {"building", "ready"}:
+        mismatches.append("status")
     if mismatches:
         raise RuntimeError(
             "overlay-set upgrade staging differs in "

--- a/Platform/pipelines/overlay_tasks.py
+++ b/Platform/pipelines/overlay_tasks.py
@@ -358,9 +358,11 @@ def _prepare_overlay_set_item(
         staged["previous_overlay_schema"] = existing["overlay_schema"]
         staged["previous_request_identity"] = existing["request_identity"]
         staged["previous_created_at"] = existing["created_at"]
-        staged["previous_seeds"] = existing["seeds"]
-        staged["previous_n_shards"] = existing["n_shards"]
-        staged["previous_n_samples"] = existing["n_samples"]
+        staged["previous_seeds"] = [
+            int(seed) for seed in existing["seeds"]
+        ]
+        staged["previous_n_shards"] = int(existing["n_shards"])
+        staged["previous_n_samples"] = int(existing["n_samples"])
         return staged
     raise RuntimeError(
         "immutable DynamoDB item exists with a different identity "

--- a/Tools/DataModelConsole/api/internal/handler/datasets.go
+++ b/Tools/DataModelConsole/api/internal/handler/datasets.go
@@ -27,6 +27,16 @@ type datasetsService interface {
 	StreamTarMemberRange(context.Context, string, string, string, int64, int64) (io.Reader, io.Closer, int64, error)
 }
 
+type navigationMapService interface {
+	SampleNavigationMap(
+		context.Context,
+		string,
+		string,
+		string,
+		string,
+	) ([]byte, string, string, error)
+}
+
 // DatasetsHandler serves the S3-backed dataset browsing endpoints.
 type DatasetsHandler struct {
 	s3                   datasetsService
@@ -326,6 +336,86 @@ func (h *DatasetsHandler) GetImage(w http.ResponseWriter, r *http.Request) {
 	if _, err := io.Copy(w, reader); err != nil {
 		// Headers already sent; just log (client likely disconnected).
 		slog.Warn("copy image body", "member", member, "error", err)
+	}
+}
+
+// GetNavigationMap handles a rendered semantic map for one indexed sample.
+func (h *DatasetsHandler) GetNavigationMap(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	name := chi.URLParam(r, "name")
+	shard := chi.URLParam(r, "shard")
+	key := chi.URLParam(r, "key")
+	if !h.s3.ValidDataset(name) {
+		writeError(
+			w, http.StatusNotFound, model.CodeNotFound, "unknown dataset: "+name,
+		)
+		return
+	}
+	if !validShardName(shard) ||
+		key == "" ||
+		strings.ContainsAny(key, "/\\") ||
+		strings.Contains(key, "..") {
+		writeError(
+			w,
+			http.StatusBadRequest,
+			model.CodeInvalidParam,
+			"invalid shard/key",
+		)
+		return
+	}
+	version, ok := requestedVersion(r)
+	if !ok {
+		writeError(
+			w, http.StatusBadRequest, model.CodeInvalidParam, "invalid version",
+		)
+		return
+	}
+	mapService, ok := h.s3.(navigationMapService)
+	if !ok {
+		writeError(
+			w,
+			http.StatusServiceUnavailable,
+			model.CodeUnavailable,
+			"navigation map service unavailable",
+		)
+		return
+	}
+	body, contentType, _, err := mapService.SampleNavigationMap(
+		r.Context(), name, version, shard, key,
+	)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			writeError(
+				w,
+				http.StatusNotFound,
+				model.CodeNotFound,
+				"navigation map not found: "+key,
+			)
+			return
+		}
+		slog.Error(
+			"render navigation map",
+			"dataset", name,
+			"shard", shard,
+			"key", key,
+			"error", err,
+		)
+		writeError(
+			w,
+			http.StatusBadGateway,
+			model.CodeS3Error,
+			"failed to render navigation map",
+		)
+		return
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+	setShardRangeCacheControl(w, version)
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		slog.Warn("write navigation map", "key", key, "error", err)
 	}
 }
 

--- a/Tools/DataModelConsole/api/internal/handler/datasets_test.go
+++ b/Tools/DataModelConsole/api/internal/handler/datasets_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -27,8 +28,13 @@ type fakeDatasetsService struct {
 	index       *model.ShardIndex
 	indexErr    error
 	body        []byte
+	mapBody     []byte
+	mapType     string
+	mapVersion  string
+	mapErr      error
 	buildCalls  []rangeCall
 	streamCalls []rangeCall
+	mapCalls    []rangeCall
 }
 
 func (*fakeDatasetsService) ListDatasets(context.Context) []model.Dataset {
@@ -81,6 +87,18 @@ func (f *fakeDatasetsService) StreamTarMemberRange(
 	})
 	reader := io.NopCloser(bytes.NewReader(f.body))
 	return reader, reader, int64(len(f.body)), nil
+}
+
+func (f *fakeDatasetsService) SampleNavigationMap(
+	_ context.Context,
+	dataset, version, shard, key string,
+) ([]byte, string, string, error) {
+	f.mapCalls = append(f.mapCalls, rangeCall{
+		dataset: dataset,
+		version: version,
+		shard:   shard,
+	})
+	return f.mapBody, f.mapType, f.mapVersion, f.mapErr
 }
 
 func newRangeService() *fakeDatasetsService {
@@ -138,6 +156,58 @@ func TestValidShardName(t *testing.T) {
 				t.Errorf("validShardName(%q) = %v, want %v", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetNavigationMapReturnsRenderedImage(t *testing.T) {
+	fake := newRangeService()
+	fake.mapBody = []byte("\x89PNG\r\n\x1a\nbody")
+	fake.mapType = "image/png"
+	fake.mapVersion = "v2.1"
+	handler := &DatasetsHandler{s3: fake}
+	request := requestWithDatasetRoute(
+		"/api/v1/datasets/l2d/shards/train-000000.tar/samples/sample/navigation-map?version=v2.1",
+		"name", "l2d",
+		"shard", "train-000000.tar",
+		"key", "sample",
+	)
+	response := httptest.NewRecorder()
+
+	handler.GetNavigationMap(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if response.Header().Get("Content-Type") != "image/png" {
+		t.Fatalf("content type = %q", response.Header().Get("Content-Type"))
+	}
+	if !strings.Contains(response.Header().Get("Cache-Control"), "max-age=3600") {
+		t.Fatalf("cache control = %q", response.Header().Get("Cache-Control"))
+	}
+	if !bytes.Equal(response.Body.Bytes(), fake.mapBody) {
+		t.Fatal("navigation map response differs from service body")
+	}
+	if len(fake.mapCalls) != 1 || fake.mapCalls[0].version != "v2.1" {
+		t.Fatalf("navigation map calls = %+v", fake.mapCalls)
+	}
+}
+
+func TestGetNavigationMapMapsMissingSampleToNotFound(t *testing.T) {
+	fake := newRangeService()
+	fake.mapErr = service.ErrNotFound
+	handler := &DatasetsHandler{s3: fake}
+	request := requestWithDatasetRoute(
+		"/api/v1/datasets/l2d/shards/train-000000.tar/samples/missing/navigation-map",
+		"name", "l2d",
+		"shard", "train-000000.tar",
+		"key", "missing",
+	)
+	response := httptest.NewRecorder()
+
+	handler.GetNavigationMap(response, request)
+
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
 	}
 }
 

--- a/Tools/DataModelConsole/api/internal/service/s3.go
+++ b/Tools/DataModelConsole/api/internal/service/s3.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -12,6 +13,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"image"
+	"image/color"
+	"image/png"
 	"io"
 	"log/slog"
 	"math"
@@ -56,6 +60,14 @@ const MaxRangeBytes = 32 << 20 // 32 MiB
 // roughly 0.5 MiB per 1000 samples and seed; 16 MiB leaves ample fan-out room
 // while preventing a corrupt pointer from exhausting the API pod.
 const MaxOverlayBytes = 16 << 20
+
+const (
+	navigationRasterSize      = 256
+	navigationMapChannels     = 14
+	navigationRouteChannels   = 2
+	maxNavigationArrayBytes   = 8 << 20
+	navigationArrayMemberName = "array.npy"
+)
 
 // maxConcurrentFullTarScans bounds full-shard streams across index, listing,
 // detail, and legacy member reads. A package-global semaphore makes the limit
@@ -1242,6 +1254,252 @@ func (s *S3Service) BuildShardIndex(ctx context.Context, dataset, version, shard
 		}()
 		return idx, err
 	}
+}
+
+// SampleNavigationMap returns a browser-ready navigation raster for one sample.
+// Legacy shards expose map.jpg directly; navigation-v3 shards are decoded from
+// their bounded NPZ members and rendered into a semantic PNG.
+func (s *S3Service) SampleNavigationMap(
+	ctx context.Context,
+	dataset, version, shard, sampleKey string,
+) ([]byte, string, string, error) {
+	index, err := s.BuildShardIndex(ctx, dataset, version, shard)
+	if err != nil {
+		return nil, "", "", err
+	}
+	var sample *model.IndexSample
+	for idx := range index.Samples {
+		if index.Samples[idx].Key == sampleKey {
+			sample = &index.Samples[idx]
+			break
+		}
+	}
+	if sample == nil {
+		return nil, "", index.Version, ErrNotFound
+	}
+	if member, ok := sample.Members["map.jpg"]; ok {
+		body, err := s.readShardMember(
+			ctx, dataset, index.Version, shard, member,
+		)
+		if err != nil {
+			return nil, "", index.Version, err
+		}
+		if len(body) < 4 ||
+			body[0] != 0xff || body[1] != 0xd8 ||
+			body[len(body)-2] != 0xff || body[len(body)-1] != 0xd9 {
+			return nil, "", index.Version, fmt.Errorf("legacy map is not JPEG")
+		}
+		return body, "image/jpeg", index.Version, nil
+	}
+
+	mapMember, hasMap := sample.Members["map_semantic.npz"]
+	routeMember, hasRoute := sample.Members["route_mask.npz"]
+	if !hasMap || !hasRoute {
+		return nil, "", index.Version, ErrNotFound
+	}
+	mapPayload, err := s.readShardMember(
+		ctx, dataset, index.Version, shard, mapMember,
+	)
+	if err != nil {
+		return nil, "", index.Version, err
+	}
+	routePayload, err := s.readShardMember(
+		ctx, dataset, index.Version, shard, routeMember,
+	)
+	if err != nil {
+		return nil, "", index.Version, err
+	}
+	mapBytes, err := decodeNavigationNPZ(
+		mapPayload,
+		"<f4",
+		[3]int{
+			navigationMapChannels,
+			navigationRasterSize,
+			navigationRasterSize,
+		},
+	)
+	if err != nil {
+		return nil, "", index.Version, fmt.Errorf(
+			"decode semantic navigation raster: %w", err,
+		)
+	}
+	routeBytes, err := decodeNavigationNPZ(
+		routePayload,
+		"|u1",
+		[3]int{
+			navigationRouteChannels,
+			navigationRasterSize,
+			navigationRasterSize,
+		},
+	)
+	if err != nil {
+		return nil, "", index.Version, fmt.Errorf(
+			"decode route navigation raster: %w", err,
+		)
+	}
+	body, err := renderNavigationPNG(mapBytes, routeBytes)
+	if err != nil {
+		return nil, "", index.Version, err
+	}
+	return body, "image/png", index.Version, nil
+}
+
+func (s *S3Service) readShardMember(
+	ctx context.Context,
+	dataset, version, shard string,
+	member model.MemberRange,
+) ([]byte, error) {
+	reader, closer, size, err := s.StreamTarMemberRange(
+		ctx, dataset, version, shard, member.Offset, member.Size,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer closer.Close()
+	body, err := io.ReadAll(io.LimitReader(reader, size+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) != size {
+		return nil, fmt.Errorf(
+			"shard member size mismatch: expected %d, got %d", size, len(body),
+		)
+	}
+	return body, nil
+}
+
+func decodeNavigationNPZ(
+	payload []byte,
+	descr string,
+	shape [3]int,
+) ([]byte, error) {
+	archive, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		return nil, fmt.Errorf("open NPZ: %w", err)
+	}
+	if len(archive.File) != 1 || archive.File[0].Name != navigationArrayMemberName {
+		return nil, fmt.Errorf("NPZ must contain only %s", navigationArrayMemberName)
+	}
+	entry := archive.File[0]
+	if entry.UncompressedSize64 > maxNavigationArrayBytes {
+		return nil, fmt.Errorf("NPY exceeds uncompressed size limit")
+	}
+	stream, err := entry.Open()
+	if err != nil {
+		return nil, fmt.Errorf("open NPY: %w", err)
+	}
+	defer stream.Close()
+	npy, err := io.ReadAll(io.LimitReader(stream, maxNavigationArrayBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read NPY: %w", err)
+	}
+	if len(npy) > maxNavigationArrayBytes {
+		return nil, fmt.Errorf("NPY exceeds uncompressed size limit")
+	}
+	if len(npy) < 10 || string(npy[:6]) != "\x93NUMPY" {
+		return nil, fmt.Errorf("invalid NPY magic")
+	}
+	headerStart := 10
+	headerLength := 0
+	switch npy[6] {
+	case 1:
+		headerLength = int(binary.LittleEndian.Uint16(npy[8:10]))
+	case 2, 3:
+		if len(npy) < 12 {
+			return nil, fmt.Errorf("truncated NPY v%d header", npy[6])
+		}
+		headerStart = 12
+		headerLength = int(binary.LittleEndian.Uint32(npy[8:12]))
+	default:
+		return nil, fmt.Errorf("unsupported NPY version %d", npy[6])
+	}
+	if headerLength <= 0 || headerStart+headerLength > len(npy) {
+		return nil, fmt.Errorf("invalid NPY header length")
+	}
+	header := string(npy[headerStart : headerStart+headerLength])
+	expectedShape := fmt.Sprintf("(%d, %d, %d)", shape[0], shape[1], shape[2])
+	if !strings.Contains(header, fmt.Sprintf("'descr': '%s'", descr)) ||
+		!strings.Contains(header, "'fortran_order': False") ||
+		!strings.Contains(header, fmt.Sprintf("'shape': %s", expectedShape)) {
+		return nil, fmt.Errorf("NPY dtype, order, or shape differs from contract")
+	}
+	itemSize := 1
+	if descr == "<f4" {
+		itemSize = 4
+	}
+	expectedDataSize := shape[0] * shape[1] * shape[2] * itemSize
+	data := npy[headerStart+headerLength:]
+	if len(data) != expectedDataSize {
+		return nil, fmt.Errorf(
+			"NPY data size mismatch: expected %d, got %d",
+			expectedDataSize, len(data),
+		)
+	}
+	return data, nil
+}
+
+func renderNavigationPNG(mapBytes, routeBytes []byte) ([]byte, error) {
+	pixels := navigationRasterSize * navigationRasterSize
+	if len(mapBytes) != navigationMapChannels*pixels*4 ||
+		len(routeBytes) != navigationRouteChannels*pixels {
+		return nil, fmt.Errorf("navigation raster byte size differs from contract")
+	}
+	layer := func(channel, pixel int) float32 {
+		offset := (channel*pixels + pixel) * 4
+		return math.Float32frombits(binary.LittleEndian.Uint32(
+			mapBytes[offset : offset+4],
+		))
+	}
+	route := func(channel, pixel int) bool {
+		return routeBytes[channel*pixels+pixel] != 0
+	}
+	canvas := image.NewRGBA(image.Rect(
+		0, 0, navigationRasterSize, navigationRasterSize,
+	))
+	for pixel := 0; pixel < pixels; pixel++ {
+		value := color.RGBA{R: 11, G: 15, B: 20, A: 255}
+		switch {
+		case layer(13, pixel) > 0.5:
+			value = color.RGBA{R: 126, G: 76, B: 132, A: 255}
+		case layer(4, pixel) > 0.5:
+			value = color.RGBA{R: 180, G: 187, B: 191, A: 255}
+		case layer(3, pixel) > 0.5:
+			value = color.RGBA{R: 65, G: 72, B: 88, A: 255}
+		case layer(0, pixel) > 0.5:
+			value = color.RGBA{R: 52, G: 65, B: 74, A: 255}
+		case layer(10, pixel) > 0.5:
+			value = color.RGBA{R: 27, G: 33, B: 40, A: 255}
+		}
+		switch {
+		case layer(6, pixel) > 0.5:
+			value = color.RGBA{R: 238, G: 181, B: 55, A: 255}
+		case layer(5, pixel) > 0.5:
+			value = color.RGBA{R: 229, G: 87, B: 72, A: 255}
+		case layer(1, pixel) > 0.5:
+			value = color.RGBA{R: 218, G: 222, B: 225, A: 255}
+		case layer(2, pixel) > 0.5:
+			value = color.RGBA{R: 126, G: 163, B: 184, A: 255}
+		}
+		if route(0, pixel) {
+			value = color.RGBA{
+				R: uint8((int(value.R) + 25*2) / 3),
+				G: uint8((int(value.G) + 174*2) / 3),
+				B: uint8((int(value.B) + 151*2) / 3),
+				A: 255,
+			}
+		}
+		if route(1, pixel) {
+			value = color.RGBA{R: 239, G: 77, B: 65, A: 255}
+		}
+		x := pixel % navigationRasterSize
+		y := pixel / navigationRasterSize
+		canvas.SetRGBA(x, y, value)
+	}
+	var output bytes.Buffer
+	if err := png.Encode(&output, canvas); err != nil {
+		return nil, fmt.Errorf("encode navigation PNG: %w", err)
+	}
+	return output.Bytes(), nil
 }
 
 func acquireFullTarScan(ctx context.Context) (func(), error) {

--- a/Tools/DataModelConsole/api/internal/service/s3_test.go
+++ b/Tools/DataModelConsole/api/internal/service/s3_test.go
@@ -2,10 +2,13 @@ package service
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"image/png"
 	"io"
 	"math"
 	"strings"
@@ -14,6 +17,99 @@ import (
 
 	"github.com/autowarefoundation/auto_e2e/tools/datamodelconsole/api/internal/model"
 )
+
+func navigationNPZFixture(
+	t *testing.T,
+	descr string,
+	shape [3]int,
+	data []byte,
+) []byte {
+	t.Helper()
+	header := fmt.Sprintf(
+		"{'descr': '%s', 'fortran_order': False, 'shape': (%d, %d, %d), }\n",
+		descr, shape[0], shape[1], shape[2],
+	)
+	var npy bytes.Buffer
+	npy.WriteString("\x93NUMPY")
+	npy.Write([]byte{1, 0})
+	if err := binary.Write(&npy, binary.LittleEndian, uint16(len(header))); err != nil {
+		t.Fatalf("write NPY header length: %v", err)
+	}
+	npy.WriteString(header)
+	npy.Write(data)
+
+	var output bytes.Buffer
+	archive := zip.NewWriter(&output)
+	member, err := archive.Create(navigationArrayMemberName)
+	if err != nil {
+		t.Fatalf("create NPZ member: %v", err)
+	}
+	if _, err := member.Write(npy.Bytes()); err != nil {
+		t.Fatalf("write NPZ member: %v", err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatalf("close NPZ: %v", err)
+	}
+	return output.Bytes()
+}
+
+func TestDecodeNavigationNPZValidatesArrayContract(t *testing.T) {
+	shape := [3]int{2, navigationRasterSize, navigationRasterSize}
+	data := make([]byte, shape[0]*shape[1]*shape[2])
+	data[17] = 1
+	payload := navigationNPZFixture(t, "|u1", shape, data)
+
+	decoded, err := decodeNavigationNPZ(payload, "|u1", shape)
+	if err != nil {
+		t.Fatalf("decode navigation NPZ: %v", err)
+	}
+	if !bytes.Equal(decoded, data) {
+		t.Fatal("decoded navigation array differs from source")
+	}
+	if _, err := decodeNavigationNPZ(
+		payload,
+		"|u1",
+		[3]int{3, navigationRasterSize, navigationRasterSize},
+	); err == nil || !strings.Contains(err.Error(), "contract") {
+		t.Fatalf("shape mismatch error = %v", err)
+	}
+}
+
+func TestRenderNavigationPNGUsesSemanticAndRouteLayers(t *testing.T) {
+	pixels := navigationRasterSize * navigationRasterSize
+	mapBytes := make([]byte, navigationMapChannels*pixels*4)
+	routeBytes := make([]byte, navigationRouteChannels*pixels)
+	binary.LittleEndian.PutUint32(
+		mapBytes[0:4],
+		math.Float32bits(1),
+	)
+	routeBytes[0] = 1
+	routeBytes[pixels+(pixels-1)] = 1
+
+	body, err := renderNavigationPNG(mapBytes, routeBytes)
+	if err != nil {
+		t.Fatalf("render navigation PNG: %v", err)
+	}
+	image, err := png.Decode(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("decode rendered PNG: %v", err)
+	}
+	if image.Bounds().Dx() != navigationRasterSize ||
+		image.Bounds().Dy() != navigationRasterSize {
+		t.Fatalf("rendered PNG bounds = %v", image.Bounds())
+	}
+	red, green, blue, _ := image.At(0, 0).RGBA()
+	if green <= red || green <= blue {
+		t.Fatalf("route corridor pixel is not green-dominant: %d %d %d", red, green, blue)
+	}
+	red, green, blue, _ = image.At(
+		navigationRasterSize-1,
+		navigationRasterSize-1,
+	).RGBA()
+	if red <= green || red <= blue {
+		t.Fatalf("destination pixel is not red-dominant: %d %d %d", red, green, blue)
+	}
+}
 
 func TestSampleKeyOf(t *testing.T) {
 	tests := []struct {

--- a/Tools/DataModelConsole/api/main.go
+++ b/Tools/DataModelConsole/api/main.go
@@ -172,6 +172,10 @@ func main() {
 			r.Use(middleware.Throttle(64))
 			r.Use(middleware.Timeout(30 * time.Second))
 			r.Get("/datasets/{name}/shards/{shard}/samples/{key}/image/{cam}", datasetsH.GetImage)
+			r.Get(
+				"/datasets/{name}/shards/{shard}/samples/{key}/navigation-map",
+				datasetsH.GetNavigationMap,
+			)
 			// Windowed multi-member range read: the player fetches one
 			// contiguous span covering a whole window of frames and slices the
 			// JPEGs client-side, so it belongs with the image reads (bounded S3

--- a/Tools/DataModelConsole/web/e2e/models-navigation.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/models-navigation.spec.ts
@@ -207,7 +207,7 @@ const experiments = [
     tags: {},
     metrics: {},
   },
-];
+] as const;
 
 async function mockExperiments(page: Page) {
   await page.route("**/api/v1/experiments", (route) =>

--- a/Tools/DataModelConsole/web/e2e/player.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/player.spec.ts
@@ -60,6 +60,28 @@ test("player renders real camera pixels, advances, and focuses", async ({ page }
   await expect(
     page.locator('[aria-label^="Episode player"]'),
   ).toBeVisible({ timeout: 30_000 });
+  const playbackControls = page.getByRole("region", {
+    name: "Playback controls",
+  });
+  await expect(
+    playbackControls.getByRole("slider", { name: "Timeline" }),
+  ).toBeVisible();
+  await expect(
+    playbackControls.getByRole("button", { name: "Play", exact: true }),
+  ).toBeVisible();
+  const playbackPrecedesCameras = await page
+    .locator('[aria-label^="Episode player"]')
+    .evaluate((player) => {
+      const controls = player.querySelector('[aria-label="Playback controls"]');
+      const camera = player.querySelector('button[aria-label$=" camera"]');
+      return Boolean(
+        controls &&
+        camera &&
+        controls.compareDocumentPosition(camera) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+    });
+  expect(playbackPrecedesCameras).toBe(true);
   // Every camera frame canvas must have non-blank pixels (real frame, not
   // black). The aria-hidden trajectory layer is intentionally transparent
   // until a model is selected, so it is not a frame-pixel assertion target.

--- a/Tools/DataModelConsole/web/e2e/rig-layout.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/rig-layout.spec.ts
@@ -8,9 +8,9 @@ import {
   rigCam,
 } from "../src/lib/rig";
 
-// The camera members packed in a KITScenes shard (cam_0..cam_6), and the set
-// the console displays after hiding the redundant ring-front (cam_1).
-const KIT_PACKED = [
+// KITScenes v2.2 uses seven slots. Canonical v3.0 removed ring-front and
+// compacted the six retained views into cam_0..cam_5.
+const KIT_SEVEN_PACKED = [
   "cam_0",
   "cam_1",
   "cam_2",
@@ -19,11 +19,17 @@ const KIT_PACKED = [
   "cam_5",
   "cam_6",
 ];
-const kitDisplayed = KIT_PACKED.filter((c) => !isHiddenCam("kitscenes", c));
+const KIT_SIX_PACKED = ["cam_0", "cam_1", "cam_2", "cam_3", "cam_4", "cam_5"];
+const sevenDisplayed = KIT_SEVEN_PACKED.filter(
+  (cam) => !isHiddenCam("kitscenes", cam, KIT_SEVEN_PACKED.length),
+);
+const sixDisplayed = KIT_SIX_PACKED.filter(
+  (cam) => !isHiddenCam("kitscenes", cam, KIT_SIX_PACKED.length),
+);
 
-test("KITScenes hides only the redundant ring-front (cam_1)", () => {
-  expect(isHiddenCam("kitscenes", "cam_1")).toBe(true);
-  expect(kitDisplayed).toEqual([
+test("KITScenes hides ring-front only when the shard has seven slots", () => {
+  expect(isHiddenCam("kitscenes", "cam_1", KIT_SEVEN_PACKED.length)).toBe(true);
+  expect(sevenDisplayed).toEqual([
     "cam_0",
     "cam_2",
     "cam_3",
@@ -31,39 +37,47 @@ test("KITScenes hides only the redundant ring-front (cam_1)", () => {
     "cam_5",
     "cam_6",
   ]);
+  expect(isHiddenCam("kitscenes", "cam_1", KIT_SIX_PACKED.length)).toBe(false);
+  expect(sixDisplayed).toEqual(KIT_SIX_PACKED);
   // Other datasets hide nothing.
   expect(isHiddenCam("nvidia_av", "cam_1")).toBe(false);
   expect(isHiddenCam("l2d", "cam_1")).toBe(false);
 });
 
-test("KITScenes displayed cameras form a filled 3x2 grid (no gaps, no ego cell)", () => {
-  const { rows, cols } = gridDimensions("kitscenes", kitDisplayed);
-  expect({ rows, cols }).toEqual({ rows: 2, cols: 3 });
+for (const [name, displayed, packedCount] of [
+  ["seven-slot", sevenDisplayed, KIT_SEVEN_PACKED.length],
+  ["compact six-slot", sixDisplayed, KIT_SIX_PACKED.length],
+] as const) {
+  test(`KITScenes ${name} cameras form a filled 3x2 grid`, () => {
+    const { rows, cols } = gridDimensions(
+      "kitscenes",
+      [...displayed],
+      packedCount,
+    );
+    expect({ rows, cols }).toEqual({ rows: 2, cols: 3 });
 
-  // Every one of the 6 cells is claimed exactly once by a displayed camera.
-  const cells = kitDisplayed.map((cam, i) => {
-    const c = rigCam("kitscenes", cam, i);
-    return `${c.row}:${c.col}`;
+    const cells = displayed.map((cam, i) => {
+      const c = rigCam("kitscenes", cam, i, packedCount);
+      return `${c.row}:${c.col}`;
+    });
+    expect(new Set(cells).size).toBe(6);
+    expect([...cells].sort()).toEqual([
+      "1:1",
+      "1:2",
+      "1:3",
+      "2:1",
+      "2:2",
+      "2:3",
+    ]);
+
+    const egoCell = `${Math.ceil(rows / 2)}:${Math.ceil(cols / 2)}`;
+    expect(cells).toContain(egoCell);
   });
-  expect(new Set(cells).size).toBe(6);
-  expect([...cells].sort()).toEqual([
-    "1:1",
-    "1:2",
-    "1:3",
-    "2:1",
-    "2:2",
-    "2:3",
-  ]);
+}
 
-  // The centre cell the ego tile would occupy — ceil(rows/2)=1, ceil(cols/2)=2 —
-  // is claimed by front-center, so the mosaic's egoInFreeCell check drops the
-  // ego tile (the car icon).
-  const egoCell = `${Math.ceil(rows / 2)}:${Math.ceil(cols / 2)}`;
-  expect(cells).toContain(egoCell);
-});
-
-test("forward cameras are on the top row, rear on the bottom, left-to-right", () => {
-  const at = (cam: string) => rigCam("kitscenes", cam, 0);
+test("seven-slot cameras keep the v2.2 positions", () => {
+  const at = (cam: string) =>
+    rigCam("kitscenes", cam, 0, KIT_SEVEN_PACKED.length);
   expect(at("cam_2")).toMatchObject({ label: "front-left", row: 1, col: 1 });
   expect(at("cam_0")).toMatchObject({ label: "front-center", row: 1, col: 2 });
   expect(at("cam_3")).toMatchObject({ label: "front-right", row: 1, col: 3 });
@@ -72,8 +86,30 @@ test("forward cameras are on the top row, rear on the bottom, left-to-right", ()
   expect(at("cam_6")).toMatchObject({ label: "rear-right", row: 2, col: 3 });
 });
 
+test("compact six-slot cameras use the canonical v3.0 positions", () => {
+  const at = (cam: string) =>
+    rigCam("kitscenes", cam, 0, KIT_SIX_PACKED.length);
+  expect(at("cam_1")).toMatchObject({ label: "front-left", row: 1, col: 1 });
+  expect(at("cam_0")).toMatchObject({ label: "front-center", row: 1, col: 2 });
+  expect(at("cam_2")).toMatchObject({ label: "front-right", row: 1, col: 3 });
+  expect(at("cam_4")).toMatchObject({ label: "rear-left", row: 2, col: 1 });
+  expect(at("cam_3")).toMatchObject({ label: "rear", row: 2, col: 2 });
+  expect(at("cam_5")).toMatchObject({ label: "rear-right", row: 2, col: 3 });
+  expect(camLabel("kitscenes", "cam_1", KIT_SIX_PACKED.length)).toBe(
+    "front-left",
+  );
+});
+
 test("NVIDIA and L2D rigs are unchanged (still 3x3, ego cell free)", () => {
-  const nvidia = ["cam_0", "cam_1", "cam_2", "cam_3", "cam_4", "cam_5", "cam_6"];
+  const nvidia = [
+    "cam_0",
+    "cam_1",
+    "cam_2",
+    "cam_3",
+    "cam_4",
+    "cam_5",
+    "cam_6",
+  ];
   expect(gridDimensions("nvidia_av", nvidia)).toEqual({ rows: 3, cols: 3 });
   // NVIDIA centre (2,2) is the ego cell and no camera claims it.
   const nvidiaCells = nvidia.map((cam, i) => {

--- a/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
@@ -460,6 +460,23 @@ test("trajectory overlays and geographic views honor production contracts", asyn
     name: "BEV activation heatmap",
   });
   await expect(heatmap).toContainText("per-encoder contrast");
+  const diagnosticsFollowReasoning = await page
+    .locator('[aria-label^="Episode player"]')
+    .evaluate((player) => {
+      const reasoningTitle = Array.from(player.querySelectorAll("p")).find(
+        (element) => element.textContent?.trim() === "Reasoning label",
+      );
+      const diagnostics = player.querySelector(
+        '[aria-label="BEV activation heatmap"]',
+      );
+      return Boolean(
+        reasoningTitle &&
+          diagnostics &&
+          reasoningTitle.compareDocumentPosition(diagnostics) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+    });
+  expect(diagnosticsFollowReasoning).toBe(true);
   await expect(heatmap.getByText("spatial deviation")).toHaveCount(4);
   await expect(heatmap.getByText("delta RMS")).toHaveCount(2);
   const heatmapCanvases = heatmap.locator("canvas");

--- a/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
@@ -448,6 +448,32 @@ test("trajectory overlays and geographic views honor production contracts", asyn
     "/scenes/kitscenes/train-000000.tar/0?version=v2.1",
     { waitUntil: "networkidle" },
   );
+  const playbackControls = page.getByRole("region", {
+    name: "Playback controls",
+  });
+  await expect(
+    playbackControls.getByRole("slider", { name: "Timeline" }),
+  ).toBeVisible();
+  await expect(
+    playbackControls.getByRole("button", { name: "Play", exact: true }),
+  ).toBeVisible();
+  const playbackPrecedesCameras = await page
+    .locator('[aria-label^="Episode player"]')
+    .evaluate((player) => {
+      const controls = player.querySelector(
+        '[aria-label="Playback controls"]',
+      );
+      const camera = player.querySelector(
+        'button[aria-label$=" camera"]',
+      );
+      return Boolean(
+        controls &&
+          camera &&
+          controls.compareDocumentPosition(camera) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+    });
+  expect(playbackPrecedesCameras).toBe(true);
   await expect(page.locator("#trajectory-model")).toHaveValue(MODEL_ID);
   await expect(page.getByText("3 seeds | median")).toBeVisible();
   await expect(page.getByText("episode/clip hold-out")).toBeVisible();

--- a/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
@@ -174,6 +174,23 @@ test("legacy overlays use one shared heatmap scale per sample", () => {
   }
 });
 
+test("v4 overlays use one heatmap scale per encoder", () => {
+  const body = overlayBody(4);
+  const buffer = body.buffer.slice(
+    body.byteOffset,
+    body.byteOffset + body.byteLength,
+  ) as ArrayBuffer;
+  const overlay = parseOverlay(buffer);
+
+  expect(overlay.bevHeatmapScales?.length).toBe(
+    SAMPLE_UIDS.length * 6,
+  );
+  expect(bevHeatmapForRow(overlay, 0, "image")?.scale).toBe(1);
+  expect(bevHeatmapForRow(overlay, 0, "fused")?.scale).toBe(6);
+  expect(bevHeatmapForRow(overlay, 1, "image")?.scale).toBe(2);
+  expect(bevHeatmapForRow(overlay, 1, "fused")?.scale).toBe(12);
+});
+
 function episodePath(): Buffer {
   const body = Buffer.alloc(80 * 32);
   for (let index = 0; index < 80; index++) {

--- a/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
@@ -50,8 +50,8 @@ function overlayBody(): Buffer {
   const seedsBytes = seedCount * 8;
   const directoryBytes = sampleCount * 12;
   const controlsBytes = sampleCount * seedCount * horizon * 2 * 4;
-  const heatmapScalesBytes = sampleCount * 4;
   const heatmapCount = 6;
+  const heatmapScalesBytes = sampleCount * heatmapCount * 4;
   const heatmapBytes = sampleCount * heatmapCount * 32 * 32;
   const body = Buffer.alloc(
     headerBytes +
@@ -63,7 +63,7 @@ function overlayBody(): Buffer {
       heatmapBytes,
   );
   body.write("AOVL", 0, "ascii");
-  body.writeUInt16LE(3, 4);
+  body.writeUInt16LE(4, 4);
   body.writeUInt16LE(0, 6);
   body.writeUInt32LE(sampleCount, 8);
   body.writeUInt16LE(seedCount, 12);
@@ -105,8 +105,11 @@ function overlayBody(): Buffer {
   const scalesOffset = speedsOffset + sampleCount * 4;
   const heatmapsOffset = scalesOffset + heatmapScalesBytes;
   for (let row = 0; row < sampleCount; row++) {
-    body.writeFloatLE(2 + row, scalesOffset + row * 4);
     for (let branch = 0; branch < heatmapCount; branch++) {
+      body.writeFloatLE(
+        (row + 1) * (branch + 1),
+        scalesOffset + (row * heatmapCount + branch) * 4,
+      );
       for (let pixel = 0; pixel < 32 * 32; pixel++) {
         const x = pixel % 32;
         const y = Math.floor(pixel / 32);
@@ -313,7 +316,7 @@ test("trajectory overlays and geographic views honor production contracts", asyn
             eval_ade: 1.25,
             eval_fde: 2.5,
             val_fraction: 0.3,
-            overlay_schema: "v3",
+            overlay_schema: "v4",
             sample_count: 3,
           },
         ],
@@ -398,7 +401,9 @@ test("trajectory overlays and geographic views honor production contracts", asyn
   const heatmap = page.getByRole("region", {
     name: "BEV activation heatmap",
   });
-  await expect(heatmap).toContainText("shared 2.00");
+  await expect(heatmap).toContainText("per-encoder contrast");
+  await expect(heatmap.getByText("spatial deviation")).toHaveCount(4);
+  await expect(heatmap.getByText("delta RMS")).toHaveCount(2);
   const heatmapCanvases = heatmap.locator("canvas");
   await expect(heatmapCanvases).toHaveCount(6);
   const heatmapSnapshots = await heatmapCanvases.evaluateAll((canvases) =>

--- a/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
@@ -51,7 +51,8 @@ function overlayBody(): Buffer {
   const directoryBytes = sampleCount * 12;
   const controlsBytes = sampleCount * seedCount * horizon * 2 * 4;
   const heatmapScalesBytes = sampleCount * 4;
-  const heatmapBytes = sampleCount * 3 * 32 * 32;
+  const heatmapCount = 6;
+  const heatmapBytes = sampleCount * heatmapCount * 32 * 32;
   const body = Buffer.alloc(
     headerBytes +
       seedsBytes +
@@ -62,13 +63,13 @@ function overlayBody(): Buffer {
       heatmapBytes,
   );
   body.write("AOVL", 0, "ascii");
-  body.writeUInt16LE(2, 4);
+  body.writeUInt16LE(3, 4);
   body.writeUInt16LE(0, 6);
   body.writeUInt32LE(sampleCount, 8);
   body.writeUInt16LE(seedCount, 12);
   body.writeUInt16LE(horizon, 14);
   body.writeUInt16LE(2, 16);
-  body.writeUInt16LE(3, 18);
+  body.writeUInt16LE(heatmapCount, 18);
 
   [0, 1, 2].forEach((seed, index) => {
     body.writeBigInt64LE(BigInt(seed), headerBytes + index * 8);
@@ -105,18 +106,23 @@ function overlayBody(): Buffer {
   const heatmapsOffset = scalesOffset + heatmapScalesBytes;
   for (let row = 0; row < sampleCount; row++) {
     body.writeFloatLE(2 + row, scalesOffset + row * 4);
-    for (let branch = 0; branch < 3; branch++) {
+    for (let branch = 0; branch < heatmapCount; branch++) {
       for (let pixel = 0; pixel < 32 * 32; pixel++) {
         const x = pixel % 32;
         const y = Math.floor(pixel / 32);
-        const value =
-          branch === 0
-            ? x * 8
-            : branch === 1
-              ? y * 8
-              : (x + y) * 4;
+        const patterns = [
+          x * 8,
+          y * 8,
+          (x + y) * 4,
+          (31 - x) * 8,
+          (31 - y) * 8,
+          Math.abs(x - y) * 8,
+        ];
+        const value = patterns[branch];
         const offset =
-          heatmapsOffset + (row * 3 + branch) * 32 * 32 + pixel;
+          heatmapsOffset +
+          (row * heatmapCount + branch) * 32 * 32 +
+          pixel;
         body.writeUInt8(Math.min(255, value), offset);
       }
     }
@@ -301,13 +307,13 @@ test("trajectory overlays and geographic views honor production contracts", asyn
           {
             model_artifact_id: MODEL_ID,
             registered_model_name: "auto-e2e-driving-policy",
-            model_version: 30,
+            model_version: 45,
             run_id: "run-30",
             model_name: "ConvNeXt-T",
             eval_ade: 1.25,
             eval_fde: 2.5,
             val_fraction: 0.3,
-            overlay_schema: "v2",
+            overlay_schema: "v3",
             sample_count: 3,
           },
         ],
@@ -392,13 +398,19 @@ test("trajectory overlays and geographic views honor production contracts", asyn
   const heatmap = page.getByRole("region", {
     name: "BEV activation heatmap",
   });
-  await expect(heatmap).toContainText("max RMS 2.00");
+  await expect(heatmap).toContainText("shared 2.00");
+  await expect(heatmap.getByRole("tab")).toHaveCount(6);
   const heatmapCanvas = heatmap.locator("canvas");
   const heatmapSnapshot = () =>
     heatmapCanvas.evaluate((canvas) =>
       (canvas as HTMLCanvasElement).toDataURL(),
     );
   const fusedHeatmap = await heatmapSnapshot();
+  await heatmap.getByRole("tab", { name: "Map only" }).click();
+  await expect.poll(heatmapSnapshot).not.toBe(fusedHeatmap);
+  const mapHeatmap = await heatmapSnapshot();
+  await heatmap.getByRole("tab", { name: "Route delta" }).click();
+  await expect.poll(heatmapSnapshot).not.toBe(mapHeatmap);
   await heatmap.getByRole("tab", { name: "Camera" }).click();
   await expect.poll(heatmapSnapshot).not.toBe(fusedHeatmap);
   await heatmap.getByRole("tab", { name: "Fused" }).click();

--- a/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
@@ -2,6 +2,11 @@ import { createHash } from "node:crypto";
 
 import { expect, test } from "@playwright/test";
 
+import {
+  bevHeatmapForRow,
+  parseOverlay,
+} from "../src/lib/overlay";
+
 const MODEL_ID = "a".repeat(64);
 const SAMPLE_UIDS = [
   "kitscenes-v1-scene-0042-f000064",
@@ -42,7 +47,7 @@ function uidHash(uid: string): bigint {
   return createHash("sha256").update(uid).digest().readBigUInt64LE(0);
 }
 
-function overlayBody(): Buffer {
+function overlayBody(formatVersion: 2 | 3 | 4 = 4): Buffer {
   const sampleCount = SAMPLE_UIDS.length;
   const seedCount = 3;
   const horizon = 64;
@@ -50,8 +55,10 @@ function overlayBody(): Buffer {
   const seedsBytes = seedCount * 8;
   const directoryBytes = sampleCount * 12;
   const controlsBytes = sampleCount * seedCount * horizon * 2 * 4;
-  const heatmapCount = 6;
-  const heatmapScalesBytes = sampleCount * heatmapCount * 4;
+  const heatmapCount = formatVersion === 2 ? 3 : 6;
+  const heatmapScaleCount =
+    sampleCount * (formatVersion === 4 ? heatmapCount : 1);
+  const heatmapScalesBytes = heatmapScaleCount * 4;
   const heatmapBytes = sampleCount * heatmapCount * 32 * 32;
   const body = Buffer.alloc(
     headerBytes +
@@ -63,7 +70,7 @@ function overlayBody(): Buffer {
       heatmapBytes,
   );
   body.write("AOVL", 0, "ascii");
-  body.writeUInt16LE(4, 4);
+  body.writeUInt16LE(formatVersion, 4);
   body.writeUInt16LE(0, 6);
   body.writeUInt32LE(sampleCount, 8);
   body.writeUInt16LE(seedCount, 12);
@@ -105,11 +112,16 @@ function overlayBody(): Buffer {
   const scalesOffset = speedsOffset + sampleCount * 4;
   const heatmapsOffset = scalesOffset + heatmapScalesBytes;
   for (let row = 0; row < sampleCount; row++) {
+    if (formatVersion < 4) {
+      body.writeFloatLE((row + 1) * 10, scalesOffset + row * 4);
+    }
     for (let branch = 0; branch < heatmapCount; branch++) {
-      body.writeFloatLE(
-        (row + 1) * (branch + 1),
-        scalesOffset + (row * heatmapCount + branch) * 4,
-      );
+      if (formatVersion === 4) {
+        body.writeFloatLE(
+          (row + 1) * (branch + 1),
+          scalesOffset + (row * heatmapCount + branch) * 4,
+        );
+      }
       for (let pixel = 0; pixel < 32 * 32; pixel++) {
         const x = pixel % 32;
         const y = Math.floor(pixel / 32);
@@ -132,6 +144,35 @@ function overlayBody(): Buffer {
   }
   return body;
 }
+
+test("legacy overlays use one shared heatmap scale per sample", () => {
+  for (const version of [2, 3] as const) {
+    const body = overlayBody(version);
+    const buffer = body.buffer.slice(
+      body.byteOffset,
+      body.byteOffset + body.byteLength,
+    ) as ArrayBuffer;
+    const overlay = parseOverlay(buffer);
+    const expectedNames =
+      version === 2
+        ? ["image", "navigation", "fused"]
+        : [
+            "image",
+            "map",
+            "route_delta",
+            "navigation",
+            "fusion_delta",
+            "fused",
+          ];
+
+    expect(overlay.bevHeatmapNames).toEqual(expectedNames);
+    expect(overlay.bevHeatmapScales?.length).toBe(SAMPLE_UIDS.length);
+    for (const name of overlay.bevHeatmapNames) {
+      expect(bevHeatmapForRow(overlay, 0, name)?.scale).toBe(10);
+      expect(bevHeatmapForRow(overlay, 1, name)?.scale).toBe(20);
+    }
+  }
+});
 
 function episodePath(): Buffer {
   const body = Buffer.alloc(80 * 32);

--- a/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
@@ -50,17 +50,25 @@ function overlayBody(): Buffer {
   const seedsBytes = seedCount * 8;
   const directoryBytes = sampleCount * 12;
   const controlsBytes = sampleCount * seedCount * horizon * 2 * 4;
+  const heatmapScalesBytes = sampleCount * 4;
+  const heatmapBytes = sampleCount * 3 * 32 * 32;
   const body = Buffer.alloc(
-    headerBytes + seedsBytes + directoryBytes + controlsBytes + sampleCount * 4,
+    headerBytes +
+      seedsBytes +
+      directoryBytes +
+      controlsBytes +
+      sampleCount * 4 +
+      heatmapScalesBytes +
+      heatmapBytes,
   );
   body.write("AOVL", 0, "ascii");
-  body.writeUInt16LE(1, 4);
+  body.writeUInt16LE(2, 4);
   body.writeUInt16LE(0, 6);
   body.writeUInt32LE(sampleCount, 8);
   body.writeUInt16LE(seedCount, 12);
   body.writeUInt16LE(horizon, 14);
   body.writeUInt16LE(2, 16);
-  body.writeUInt16LE(0, 18);
+  body.writeUInt16LE(3, 18);
 
   [0, 1, 2].forEach((seed, index) => {
     body.writeBigInt64LE(BigInt(seed), headerBytes + index * 8);
@@ -92,6 +100,26 @@ function overlayBody(): Buffer {
   const speedsOffset = controlsOffset + controlsBytes;
   for (let row = 0; row < sampleCount; row++) {
     body.writeFloatLE(8 + row, speedsOffset + row * 4);
+  }
+  const scalesOffset = speedsOffset + sampleCount * 4;
+  const heatmapsOffset = scalesOffset + heatmapScalesBytes;
+  for (let row = 0; row < sampleCount; row++) {
+    body.writeFloatLE(2 + row, scalesOffset + row * 4);
+    for (let branch = 0; branch < 3; branch++) {
+      for (let pixel = 0; pixel < 32 * 32; pixel++) {
+        const x = pixel % 32;
+        const y = Math.floor(pixel / 32);
+        const value =
+          branch === 0
+            ? x * 8
+            : branch === 1
+              ? y * 8
+              : (x + y) * 4;
+        const offset =
+          heatmapsOffset + (row * 3 + branch) * 32 * 32 + pixel;
+        body.writeUInt8(Math.min(255, value), offset);
+      }
+    }
   }
   return body;
 }
@@ -241,6 +269,14 @@ test("trajectory overlays and geographic views honor production contracts", asyn
           members: {
             "cam_0.jpg": { offset: index * 10_000 + 512, size: 200 },
             "cam_1.jpg": { offset: index * 10_000 + 2048, size: 200 },
+            "map_semantic.npz": {
+              offset: index * 10_000 + 3072,
+              size: 200,
+            },
+            "route_mask.npz": {
+              offset: index * 10_000 + 4096,
+              size: 200,
+            },
           },
           ego_now: [8 + index, 0.05, 0, 0],
           ego_history: egoHistory(8 + index),
@@ -271,7 +307,7 @@ test("trajectory overlays and geographic views honor production contracts", asyn
             eval_ade: 1.25,
             eval_fde: 2.5,
             val_fraction: 0.3,
-            overlay_schema: "v1",
+            overlay_schema: "v2",
             sample_count: 3,
           },
         ],
@@ -331,6 +367,13 @@ test("trajectory overlays and geographic views honor production contracts", asyn
         body: PIXEL,
       });
     }
+    if (path.endsWith("/navigation-map")) {
+      return route.fulfill({
+        status: 200,
+        contentType: "image/png",
+        body: PIXEL,
+      });
+    }
     return route.fulfill({ status: 404, body: "not mocked" });
   });
 
@@ -342,6 +385,23 @@ test("trajectory overlays and geographic views honor production contracts", asyn
   await expect(page.getByText("3 seeds | median")).toBeVisible();
   await expect(page.getByText("episode/clip hold-out")).toBeVisible();
   await expect(page.getByText("Scene map")).toBeVisible();
+  const navigationMap = page.getByRole("region", {
+    name: "Rendered navigation map",
+  });
+  await expect(navigationMap.getByRole("img")).toBeVisible();
+  const heatmap = page.getByRole("region", {
+    name: "BEV activation heatmap",
+  });
+  await expect(heatmap).toContainText("max RMS 2.00");
+  const heatmapCanvas = heatmap.locator("canvas");
+  const heatmapSnapshot = () =>
+    heatmapCanvas.evaluate((canvas) =>
+      (canvas as HTMLCanvasElement).toDataURL(),
+    );
+  const fusedHeatmap = await heatmapSnapshot();
+  await heatmap.getByRole("tab", { name: "Camera" }).click();
+  await expect.poll(heatmapSnapshot).not.toBe(fusedHeatmap);
+  await heatmap.getByRole("tab", { name: "Fused" }).click();
   expect(rigRequestPath).toBe(
     "/api/v1/datasets/kitscenes/shards/train-000000.tar/rig-projection",
   );
@@ -454,6 +514,8 @@ test("trajectory overlays and geographic views honor production contracts", asyn
 
   await page.setViewportSize({ width: 390, height: 844 });
   await expect(page.getByText("Scene map")).toBeVisible();
+  await expect(navigationMap.getByRole("img")).toBeVisible();
+  await expect(heatmapCanvas).toBeVisible();
   const overflow = await page.evaluate(
     () => document.documentElement.scrollWidth - window.innerWidth,
   );

--- a/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
+++ b/Tools/DataModelConsole/web/e2e/trajectory-overlay.spec.ts
@@ -399,21 +399,12 @@ test("trajectory overlays and geographic views honor production contracts", asyn
     name: "BEV activation heatmap",
   });
   await expect(heatmap).toContainText("shared 2.00");
-  await expect(heatmap.getByRole("tab")).toHaveCount(6);
-  const heatmapCanvas = heatmap.locator("canvas");
-  const heatmapSnapshot = () =>
-    heatmapCanvas.evaluate((canvas) =>
-      (canvas as HTMLCanvasElement).toDataURL(),
-    );
-  const fusedHeatmap = await heatmapSnapshot();
-  await heatmap.getByRole("tab", { name: "Map only" }).click();
-  await expect.poll(heatmapSnapshot).not.toBe(fusedHeatmap);
-  const mapHeatmap = await heatmapSnapshot();
-  await heatmap.getByRole("tab", { name: "Route delta" }).click();
-  await expect.poll(heatmapSnapshot).not.toBe(mapHeatmap);
-  await heatmap.getByRole("tab", { name: "Camera" }).click();
-  await expect.poll(heatmapSnapshot).not.toBe(fusedHeatmap);
-  await heatmap.getByRole("tab", { name: "Fused" }).click();
+  const heatmapCanvases = heatmap.locator("canvas");
+  await expect(heatmapCanvases).toHaveCount(6);
+  const heatmapSnapshots = await heatmapCanvases.evaluateAll((canvases) =>
+    canvases.map((canvas) => (canvas as HTMLCanvasElement).toDataURL()),
+  );
+  expect(new Set(heatmapSnapshots).size).toBe(6);
   expect(rigRequestPath).toBe(
     "/api/v1/datasets/kitscenes/shards/train-000000.tar/rig-projection",
   );
@@ -527,7 +518,7 @@ test("trajectory overlays and geographic views honor production contracts", asyn
   await page.setViewportSize({ width: 390, height: 844 });
   await expect(page.getByText("Scene map")).toBeVisible();
   await expect(navigationMap.getByRole("img")).toBeVisible();
-  await expect(heatmapCanvas).toBeVisible();
+  await expect(heatmapCanvases.first()).toBeVisible();
   const overflow = await page.evaluate(
     () => document.documentElement.scrollWidth - window.innerWidth,
   );

--- a/Tools/DataModelConsole/web/src/components/player/bev-activation-heatmap.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/bev-activation-heatmap.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  BEV_HEATMAP_NAMES,
+  BEV_HEATMAP_SIZE,
+  bevHeatmapForRow,
+  type BEVHeatmapName,
+  type OverlayArtifact,
+} from "@/lib/overlay";
+
+const LABELS: Record<BEVHeatmapName, string> = {
+  image: "Camera",
+  navigation: "Navigation",
+  fused: "Fused",
+};
+
+const COLOR_STOPS = [
+  [12, 15, 22],
+  [35, 83, 132],
+  [22, 151, 143],
+  [236, 196, 70],
+  [220, 62, 48],
+] as const;
+
+function heatColor(value: number): [number, number, number] {
+  const position = (value / 255) * (COLOR_STOPS.length - 1);
+  const lower = Math.min(Math.floor(position), COLOR_STOPS.length - 2);
+  const fraction = position - lower;
+  const start = COLOR_STOPS[lower];
+  const end = COLOR_STOPS[lower + 1];
+  return [
+    Math.round(start[0] + (end[0] - start[0]) * fraction),
+    Math.round(start[1] + (end[1] - start[1]) * fraction),
+    Math.round(start[2] + (end[2] - start[2]) * fraction),
+  ];
+}
+
+export function BEVActivationHeatmap({
+  overlay,
+  row,
+}: {
+  overlay: OverlayArtifact | null;
+  row: number | undefined;
+}) {
+  const [mode, setMode] = useState<BEVHeatmapName>("fused");
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const heatmap =
+    overlay && row !== undefined
+      ? bevHeatmapForRow(overlay, row, mode)
+      : null;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !heatmap) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    const image = context.createImageData(
+      BEV_HEATMAP_SIZE,
+      BEV_HEATMAP_SIZE,
+    );
+    for (let index = 0; index < heatmap.values.length; index++) {
+      const [red, green, blue] = heatColor(heatmap.values[index]);
+      const offset = index * 4;
+      image.data[offset] = red;
+      image.data[offset + 1] = green;
+      image.data[offset + 2] = blue;
+      image.data[offset + 3] = 255;
+    }
+    context.putImageData(image, 0, 0);
+  }, [heatmap]);
+
+  return (
+    <section
+      className="rounded-md border border-slate-800 bg-slate-950 p-2"
+      aria-label="BEV activation heatmap"
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h3 className="text-xs font-medium text-slate-200">BEV activations</h3>
+        <span className="font-mono text-[10px] text-slate-500">
+          {heatmap ? `max RMS ${heatmap.scale.toPrecision(3)}` : "unavailable"}
+        </span>
+      </div>
+      <div
+        role="tablist"
+        aria-label="BEV activation branch"
+        className="mb-2 grid grid-cols-3 rounded border border-slate-800 bg-slate-900 p-0.5"
+      >
+        {BEV_HEATMAP_NAMES.map((name) => (
+          <button
+            key={name}
+            type="button"
+            role="tab"
+            aria-selected={mode === name}
+            onClick={() => setMode(name)}
+            className={
+              mode === name
+                ? "h-6 rounded-sm bg-slate-700 px-1 text-[10px] text-white"
+                : "h-6 rounded-sm px-1 text-[10px] text-slate-400 hover:text-slate-200"
+            }
+          >
+            {LABELS[name]}
+          </button>
+        ))}
+      </div>
+      {heatmap ? (
+        <div className="grid grid-cols-[14px_1fr] grid-rows-[1fr_14px]">
+          <span className="flex items-center text-[9px] text-slate-500 [writing-mode:vertical-rl]">
+            +X forward
+          </span>
+          <div className="relative aspect-square overflow-hidden border border-slate-800 bg-slate-950">
+            <canvas
+              ref={canvasRef}
+              width={BEV_HEATMAP_SIZE}
+              height={BEV_HEATMAP_SIZE}
+              className="size-full [image-rendering:pixelated]"
+            />
+            <span
+              className="absolute left-1/2 top-2/3 block size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-l border-t border-white"
+              aria-hidden="true"
+            />
+          </div>
+          <span />
+          <span className="text-center text-[9px] leading-[14px] text-slate-500">
+            +Y left
+          </span>
+        </div>
+      ) : (
+        <div className="flex aspect-square items-center justify-center border border-dashed border-slate-800 px-5 text-center text-xs text-slate-500">
+          This model overlay has no BEV diagnostics.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/Tools/DataModelConsole/web/src/components/player/bev-activation-heatmap.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/bev-activation-heatmap.tsx
@@ -19,6 +19,11 @@ const LABELS: Record<BEVHeatmapName, string> = {
   fused: "Fused",
 };
 
+const DELTA_HEATMAPS = new Set<BEVHeatmapName>([
+  "route_delta",
+  "fusion_delta",
+]);
+
 const COLOR_STOPS = [
   [12, 15, 22],
   [35, 83, 132],
@@ -60,14 +65,20 @@ function HeatmapTile({
         { sum: 0, peak: 0 },
       )
     : null;
-  const meanRMS =
+  const meanValue =
     statistics && heatmap
       ? (statistics.sum / heatmap.values.length / 255) * heatmap.scale
       : null;
-  const peakRMS =
+  const peakValue =
     statistics && heatmap
       ? (statistics.peak / 255) * heatmap.scale
       : null;
+  const metric =
+    overlay.formatVersion >= 4
+      ? DELTA_HEATMAPS.has(name)
+        ? "delta RMS"
+        : "spatial deviation"
+      : "channel RMS";
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -98,15 +109,20 @@ function HeatmapTile({
       aria-label={`${LABELS[name]} activation`}
     >
       <figcaption className="mb-2 flex min-h-8 items-start justify-between gap-2">
-        <span className="text-xs font-medium text-slate-200">
-          {LABELS[name]}
+        <span>
+          <span className="block text-xs font-medium text-slate-200">
+            {LABELS[name]}
+          </span>
+          <span className="block text-[9px] leading-3 text-slate-500">
+            {metric}
+          </span>
         </span>
         <span className="text-right font-mono text-[9px] leading-3 text-slate-500">
-          {meanRMS !== null && peakRMS !== null ? (
+          {meanValue !== null && peakValue !== null ? (
             <>
-              mean {meanRMS.toPrecision(3)}
+              mean {meanValue.toPrecision(3)}
               <br />
-              peak {peakRMS.toPrecision(3)}
+              peak {peakValue.toPrecision(3)}
             </>
           ) : (
             "unavailable"
@@ -150,7 +166,10 @@ export function BEVActivationHeatmap({
       ? overlay.bevHeatmapNames
       : BEV_HEATMAP_NAMES;
   const sharedScale =
-    overlay && row !== undefined && overlay.bevHeatmapScales
+    overlay &&
+    overlay.formatVersion < 4 &&
+    row !== undefined &&
+    overlay.bevHeatmapScales
       ? overlay.bevHeatmapScales[row]
       : null;
 
@@ -161,7 +180,9 @@ export function BEVActivationHeatmap({
           Encoder diagnostics
         </h3>
         <span className="font-mono text-[10px] text-slate-500">
-          {sharedScale !== null
+          {overlay?.formatVersion && overlay.formatVersion >= 4
+            ? "per-encoder contrast"
+            : sharedScale !== null
             ? `shared ${sharedScale.toPrecision(3)} RMS`
             : "unavailable"}
         </span>

--- a/Tools/DataModelConsole/web/src/components/player/bev-activation-heatmap.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/bev-activation-heatmap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
 import {
   BEV_HEATMAP_NAMES,
@@ -40,23 +40,17 @@ function heatColor(value: number): [number, number, number] {
   ];
 }
 
-export function BEVActivationHeatmap({
+function HeatmapTile({
+  name,
   overlay,
   row,
 }: {
-  overlay: OverlayArtifact | null;
-  row: number | undefined;
+  name: BEVHeatmapName;
+  overlay: OverlayArtifact;
+  row: number;
 }) {
-  const [mode, setMode] = useState<BEVHeatmapName>("fused");
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const availableNames =
-    overlay && overlay.bevHeatmapNames.length > 0
-      ? overlay.bevHeatmapNames
-      : BEV_HEATMAP_NAMES;
-  const heatmap =
-    overlay && row !== undefined
-      ? bevHeatmapForRow(overlay, row, mode)
-      : null;
+  const heatmap = bevHeatmapForRow(overlay, row, name);
   const statistics = heatmap
     ? heatmap.values.reduce(
         (result, value) => ({
@@ -74,14 +68,6 @@ export function BEVActivationHeatmap({
     statistics && heatmap
       ? (statistics.peak / 255) * heatmap.scale
       : null;
-
-  useEffect(() => {
-    if (!availableNames.includes(mode)) {
-      setMode(
-        availableNames.includes("fused") ? "fused" : availableNames[0],
-      );
-    }
-  }, [availableNames, mode]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -107,74 +93,92 @@ export function BEVActivationHeatmap({
   }, [heatmap]);
 
   return (
-    <section
+    <figure
       className="rounded-md border border-slate-800 bg-slate-950 p-2"
-      aria-label="BEV activation heatmap"
+      aria-label={`${LABELS[name]} activation`}
     >
-      <div className="mb-2 flex items-start justify-between gap-2">
-        <h3 className="text-xs font-medium text-slate-200">
-          Encoder diagnostics
-        </h3>
-        <div className="text-right font-mono text-[9px] leading-3 text-slate-500">
-          {heatmap && meanRMS !== null && peakRMS !== null ? (
+      <figcaption className="mb-2 flex min-h-8 items-start justify-between gap-2">
+        <span className="text-xs font-medium text-slate-200">
+          {LABELS[name]}
+        </span>
+        <span className="text-right font-mono text-[9px] leading-3 text-slate-500">
+          {meanRMS !== null && peakRMS !== null ? (
             <>
-              <div>mean {meanRMS.toPrecision(3)} RMS</div>
-              <div>
-                peak {peakRMS.toPrecision(3)} / shared{" "}
-                {heatmap.scale.toPrecision(3)}
-              </div>
+              mean {meanRMS.toPrecision(3)}
+              <br />
+              peak {peakRMS.toPrecision(3)}
             </>
           ) : (
             "unavailable"
           )}
+        </span>
+      </figcaption>
+      <div className="grid grid-cols-[14px_1fr] grid-rows-[1fr_14px]">
+        <span className="flex items-center text-[9px] text-slate-500 [writing-mode:vertical-rl]">
+          +X forward
+        </span>
+        <div className="relative aspect-square overflow-hidden border border-slate-800 bg-slate-950">
+          <canvas
+            ref={canvasRef}
+            width={BEV_HEATMAP_SIZE}
+            height={BEV_HEATMAP_SIZE}
+            className="size-full [image-rendering:pixelated]"
+          />
+          <span
+            className="absolute left-1/2 top-2/3 block size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-l border-t border-white"
+            aria-hidden="true"
+          />
         </div>
+        <span />
+        <span className="text-center text-[9px] leading-[14px] text-slate-500">
+          +Y left
+        </span>
       </div>
-      <div
-        role="tablist"
-        aria-label="BEV encoder output"
-        className="mb-2 grid grid-cols-3 rounded border border-slate-800 bg-slate-900 p-0.5"
-      >
-        {availableNames.map((name) => (
-          <button
-            key={name}
-            type="button"
-            role="tab"
-            aria-selected={mode === name}
-            onClick={() => setMode(name)}
-            className={
-              mode === name
-                ? "h-7 rounded-sm bg-slate-700 px-1 text-[9px] text-white"
-                : "h-7 rounded-sm px-1 text-[9px] text-slate-400 hover:text-slate-200"
-            }
-          >
-            {LABELS[name]}
-          </button>
-        ))}
+    </figure>
+  );
+}
+
+export function BEVActivationHeatmap({
+  overlay,
+  row,
+}: {
+  overlay: OverlayArtifact | null;
+  row: number | undefined;
+}) {
+  const availableNames =
+    overlay && overlay.bevHeatmapNames.length > 0
+      ? overlay.bevHeatmapNames
+      : BEV_HEATMAP_NAMES;
+  const sharedScale =
+    overlay && row !== undefined && overlay.bevHeatmapScales
+      ? overlay.bevHeatmapScales[row]
+      : null;
+
+  return (
+    <section className="space-y-2" aria-label="BEV activation heatmap">
+      <div className="flex items-end justify-between gap-3">
+        <h3 className="text-sm font-medium text-slate-200">
+          Encoder diagnostics
+        </h3>
+        <span className="font-mono text-[10px] text-slate-500">
+          {sharedScale !== null
+            ? `shared ${sharedScale.toPrecision(3)} RMS`
+            : "unavailable"}
+        </span>
       </div>
-      {heatmap ? (
-        <div className="grid grid-cols-[14px_1fr] grid-rows-[1fr_14px]">
-          <span className="flex items-center text-[9px] text-slate-500 [writing-mode:vertical-rl]">
-            +X forward
-          </span>
-          <div className="relative aspect-square overflow-hidden border border-slate-800 bg-slate-950">
-            <canvas
-              ref={canvasRef}
-              width={BEV_HEATMAP_SIZE}
-              height={BEV_HEATMAP_SIZE}
-              className="size-full [image-rendering:pixelated]"
+      {overlay && row !== undefined && overlay.bevHeatmaps ? (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {availableNames.map((name) => (
+            <HeatmapTile
+              key={name}
+              name={name}
+              overlay={overlay}
+              row={row}
             />
-            <span
-              className="absolute left-1/2 top-2/3 block size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-l border-t border-white"
-              aria-hidden="true"
-            />
-          </div>
-          <span />
-          <span className="text-center text-[9px] leading-[14px] text-slate-500">
-            +Y left
-          </span>
+          ))}
         </div>
       ) : (
-        <div className="flex aspect-square items-center justify-center border border-dashed border-slate-800 px-5 text-center text-xs text-slate-500">
+        <div className="flex min-h-32 items-center justify-center rounded-md border border-dashed border-slate-800 px-5 text-center text-xs text-slate-500">
           No encoder diagnostics for this model.
         </div>
       )}

--- a/Tools/DataModelConsole/web/src/components/player/bev-activation-heatmap.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/bev-activation-heatmap.tsx
@@ -12,7 +12,10 @@ import {
 
 const LABELS: Record<BEVHeatmapName, string> = {
   image: "Camera",
+  map: "Map only",
+  route_delta: "Route delta",
   navigation: "Navigation",
+  fusion_delta: "Fusion delta",
   fused: "Fused",
 };
 
@@ -46,16 +49,47 @@ export function BEVActivationHeatmap({
 }) {
   const [mode, setMode] = useState<BEVHeatmapName>("fused");
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const availableNames =
+    overlay && overlay.bevHeatmapNames.length > 0
+      ? overlay.bevHeatmapNames
+      : BEV_HEATMAP_NAMES;
   const heatmap =
     overlay && row !== undefined
       ? bevHeatmapForRow(overlay, row, mode)
       : null;
+  const statistics = heatmap
+    ? heatmap.values.reduce(
+        (result, value) => ({
+          sum: result.sum + value,
+          peak: Math.max(result.peak, value),
+        }),
+        { sum: 0, peak: 0 },
+      )
+    : null;
+  const meanRMS =
+    statistics && heatmap
+      ? (statistics.sum / heatmap.values.length / 255) * heatmap.scale
+      : null;
+  const peakRMS =
+    statistics && heatmap
+      ? (statistics.peak / 255) * heatmap.scale
+      : null;
+
+  useEffect(() => {
+    if (!availableNames.includes(mode)) {
+      setMode(
+        availableNames.includes("fused") ? "fused" : availableNames[0],
+      );
+    }
+  }, [availableNames, mode]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas || !heatmap) return;
+    if (!canvas) return;
     const context = canvas.getContext("2d");
     if (!context) return;
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    if (!heatmap) return;
 
     const image = context.createImageData(
       BEV_HEATMAP_SIZE,
@@ -77,18 +111,30 @@ export function BEVActivationHeatmap({
       className="rounded-md border border-slate-800 bg-slate-950 p-2"
       aria-label="BEV activation heatmap"
     >
-      <div className="mb-2 flex items-center justify-between gap-2">
-        <h3 className="text-xs font-medium text-slate-200">BEV activations</h3>
-        <span className="font-mono text-[10px] text-slate-500">
-          {heatmap ? `max RMS ${heatmap.scale.toPrecision(3)}` : "unavailable"}
-        </span>
+      <div className="mb-2 flex items-start justify-between gap-2">
+        <h3 className="text-xs font-medium text-slate-200">
+          Encoder diagnostics
+        </h3>
+        <div className="text-right font-mono text-[9px] leading-3 text-slate-500">
+          {heatmap && meanRMS !== null && peakRMS !== null ? (
+            <>
+              <div>mean {meanRMS.toPrecision(3)} RMS</div>
+              <div>
+                peak {peakRMS.toPrecision(3)} / shared{" "}
+                {heatmap.scale.toPrecision(3)}
+              </div>
+            </>
+          ) : (
+            "unavailable"
+          )}
+        </div>
       </div>
       <div
         role="tablist"
-        aria-label="BEV activation branch"
+        aria-label="BEV encoder output"
         className="mb-2 grid grid-cols-3 rounded border border-slate-800 bg-slate-900 p-0.5"
       >
-        {BEV_HEATMAP_NAMES.map((name) => (
+        {availableNames.map((name) => (
           <button
             key={name}
             type="button"
@@ -97,8 +143,8 @@ export function BEVActivationHeatmap({
             onClick={() => setMode(name)}
             className={
               mode === name
-                ? "h-6 rounded-sm bg-slate-700 px-1 text-[10px] text-white"
-                : "h-6 rounded-sm px-1 text-[10px] text-slate-400 hover:text-slate-200"
+                ? "h-7 rounded-sm bg-slate-700 px-1 text-[9px] text-white"
+                : "h-7 rounded-sm px-1 text-[9px] text-slate-400 hover:text-slate-200"
             }
           >
             {LABELS[name]}
@@ -129,7 +175,7 @@ export function BEVActivationHeatmap({
         </div>
       ) : (
         <div className="flex aspect-square items-center justify-center border border-dashed border-slate-800 px-5 text-center text-xs text-slate-500">
-          This model overlay has no BEV diagnostics.
+          No encoder diagnostics for this model.
         </div>
       )}
     </section>

--- a/Tools/DataModelConsole/web/src/components/player/camera-mosaic.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/camera-mosaic.tsx
@@ -18,7 +18,12 @@ import type {
   ScreenPoint,
   ScreenRibbon,
 } from "@/lib/projection";
-import { camLabel, displayAspectRatio, gridDimensions, rigCam } from "@/lib/rig";
+import {
+  camLabel,
+  displayAspectRatio,
+  gridDimensions,
+  rigCam,
+} from "@/lib/rig";
 import { cn } from "@/lib/utils";
 import type { IndexSample } from "@/types";
 
@@ -367,6 +372,7 @@ export function CameraMosaic({
   sample,
   frame,
   cams,
+  packedCameraCount,
   mode,
   focusCam,
   onSelectCam,
@@ -380,6 +386,7 @@ export function CameraMosaic({
   sample?: IndexSample;
   frame: number;
   cams: string[];
+  packedCameraCount?: number;
   mode: "grid" | "focus";
   focusCam: number; // index into cams
   onSelectCam: (idx: number) => void;
@@ -411,7 +418,7 @@ export function CameraMosaic({
             store={store}
             frame={frame}
             cam={focused}
-            label={camLabel(dataset, focused)}
+            label={camLabel(dataset, focused, packedCameraCount)}
             predictionPaths={predictionPaths?.[focused]}
             predictionRibbons={predictionRibbons?.[focused]}
             groundTruthRibbons={groundTruthRibbons?.[focused]}
@@ -441,7 +448,7 @@ export function CameraMosaic({
               store={store}
               frame={frame}
               cam={cam}
-              label={camLabel(dataset, cam)}
+              label={camLabel(dataset, cam, packedCameraCount)}
               ordinal={i + 1}
               predictionPaths={predictionPaths?.[cam]}
               predictionRibbons={predictionRibbons?.[cam]}
@@ -463,7 +470,7 @@ export function CameraMosaic({
   // Grid: bird's-eye layout. Each camera is placed in the CSS-grid cell that
   // matches where it points; the ego readout sits in the center. Cells with no
   // camera stay empty so the spatial arrangement reads clearly.
-  const { rows, cols } = gridDimensions(dataset, cams);
+  const { rows, cols } = gridDimensions(dataset, cams, packedCameraCount);
   const egoRow = Math.ceil(rows / 2);
   const egoCol = Math.ceil(cols / 2);
   // Detect a camera that would collide with the ego center cell; if one lands
@@ -471,7 +478,7 @@ export function CameraMosaic({
   // we only drop the ego tile into a cell no camera claims.
   const claimed = new Set(
     cams.map((cam, i) => {
-      const c = rigCam(dataset, cam, i);
+      const c = rigCam(dataset, cam, i, packedCameraCount);
       return `${c.row}:${c.col}`;
     }),
   );
@@ -491,7 +498,7 @@ export function CameraMosaic({
         }}
       >
         {cams.map((cam, i) => {
-          const c = rigCam(dataset, cam, i);
+          const c = rigCam(dataset, cam, i, packedCameraCount);
           return (
             <div key={cam} style={{ gridRow: c.row, gridColumn: c.col }}>
               <CanvasTile

--- a/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
@@ -30,6 +30,8 @@ import {
 } from "lucide-react";
 
 import { CameraMosaic } from "@/components/player/camera-mosaic";
+import { BEVActivationHeatmap } from "@/components/player/bev-activation-heatmap";
+import { NavigationMap } from "@/components/player/navigation-map";
 import {
   OverlaySelectionBar,
   type OverlayLoadStatus,
@@ -440,23 +442,25 @@ export function EpisodePlayer({
   // discrete status drives the panel (never hangs on 404/5xx, never shows a
   // stale card for a frame that is still loading).
   const sample = index.samples[frame];
+  const overlayRow = sample
+    ? overlayRows.get(sample.sample_uid)
+    : undefined;
   const curvatureSign = trajectoryCurvatureSign(dataset);
   const predictionTrajectories = useMemo(() => {
     if (!overlay || !sample) return [];
-    const row = overlayRows.get(sample.sample_uid);
-    if (row === undefined) return [];
+    if (overlayRow === undefined) return [];
     const paths = new Array<TrajectoryPoint[]>(overlay.seedCount);
     for (let seed = 0; seed < overlay.seedCount; seed++) {
       paths[seed] = integrateInterleavedControl(
-        overlay.v0[row],
-        controlsForRow(overlay, row, seed),
+        overlay.v0[overlayRow],
+        controlsForRow(overlay, overlayRow, seed),
         0.1,
         predictionMode,
         curvatureSign,
       );
     }
     return paths;
-  }, [overlay, overlayRows, sample, predictionMode, curvatureSign]);
+  }, [overlay, overlayRow, sample, predictionMode, curvatureSign]);
   const medianPrediction = useMemo(
     () => medianTrajectory(predictionTrajectories),
     [predictionTrajectories],
@@ -686,6 +690,13 @@ export function EpisodePlayer({
             medianPrediction={medianPrediction}
             curvatureSign={curvatureSign}
           />
+          <NavigationMap
+            dataset={dataset}
+            shard={shard}
+            version={version}
+            sample={sample}
+          />
+          <BEVActivationHeatmap overlay={overlay} row={overlayRow} />
           <div className="rounded-md border border-slate-800 bg-slate-900/60 p-2 font-mono text-[10px] leading-relaxed text-slate-400">
             <p>
               ep {sample?.episode_id || "-"} ·{" "}

--- a/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
@@ -184,15 +184,19 @@ export function EpisodePlayer({
     return () => s.destroy();
   }, [index, dataset, shard, version]);
 
-  const cams = useMemo(() => {
+  const packedCams = useMemo(() => {
     const first = index.samples[0];
     if (!first) return [];
     return Object.keys(first.members)
       .filter((m) => m.match(/^cam_\d+\.jpg$/))
       .map((m) => m.replace(/\.jpg$/, ""))
-      .filter((cam) => !isHiddenCam(dataset, cam))
       .sort();
-  }, [index, dataset]);
+  }, [index]);
+  const cams = useMemo(
+    () =>
+      packedCams.filter((cam) => !isHiddenCam(dataset, cam, packedCams.length)),
+    [dataset, packedCams],
+  );
 
   const [overlayModels, setOverlayModels] = useState<OverlayModel[]>([]);
   const [selectedModelID, setSelectedModelID] = useState(
@@ -671,6 +675,7 @@ export function EpisodePlayer({
           sample={sample}
           frame={frame}
           cams={cams}
+          packedCameraCount={packedCams.length}
           mode={mode}
           focusCam={focusCam}
           onSelectCam={focusCamera}

--- a/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
@@ -766,8 +766,6 @@ export function EpisodePlayer({
         </div>
       </div>
 
-      <BEVActivationHeatmap overlay={overlay} row={overlayRow} />
-
       <SceneMap
         dataset={dataset}
         version={version}
@@ -981,6 +979,8 @@ export function EpisodePlayer({
           </p>
         )}
       </div>
+
+      <BEVActivationHeatmap overlay={overlay} row={overlayRow} />
     </div>
   );
 }

--- a/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
@@ -12,13 +12,7 @@
 //   f            toggle focus/grid
 //   Esc          back to grid
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Gauge,
   Keyboard,
@@ -60,10 +54,7 @@ import {
   trajectoryCurvatureSign,
   yawRateFrom,
 } from "@/lib/ego";
-import type {
-  TrajectoryDisplayMode,
-  TrajectoryPoint,
-} from "@/lib/ego";
+import type { TrajectoryDisplayMode, TrajectoryPoint } from "@/lib/ego";
 import {
   controlsForRow,
   parseOverlay,
@@ -74,11 +65,7 @@ import {
   projectTrajectoriesToCameras,
   projectTrajectoryRibbonToCameras,
 } from "@/lib/projection";
-import type {
-  OverlayModel,
-  RigProjectionDocument,
-  ShardIndex,
-} from "@/types";
+import type { OverlayModel, RigProjectionDocument, ShardIndex } from "@/types";
 
 const SPEED_STEPS = [0.1, 0.25, 0.5, 1, 2, 4, 8, 16];
 const SPACE_OWNING_ELEMENTS = [
@@ -202,10 +189,9 @@ export function EpisodePlayer({
   const [selectedModelID, setSelectedModelID] = useState(
     initialState?.model ?? "",
   );
-  const [predictionMode, setPredictionMode] =
-    useState<TrajectoryDisplayMode>(
-      initialState?.predictionMode ?? "raw",
-    );
+  const [predictionMode, setPredictionMode] = useState<TrajectoryDisplayMode>(
+    initialState?.predictionMode ?? "raw",
+  );
   const [overlayStatus, setOverlayStatus] =
     useState<OverlayLoadStatus>("loading-models");
   const [overlay, setOverlay] = useState<OverlayArtifact | null>(null);
@@ -367,7 +353,8 @@ export function EpisodePlayer({
   ]);
 
   const visibleCams = useMemo(
-    () => (mode === "focus" ? [cams[focusCam] ?? cams[0]].filter(Boolean) : cams),
+    () =>
+      mode === "focus" ? [cams[focusCam] ?? cams[0]].filter(Boolean) : cams,
     [mode, cams, focusCam],
   );
   visibleCamsRef.current = visibleCams;
@@ -446,9 +433,7 @@ export function EpisodePlayer({
   // discrete status drives the panel (never hangs on 404/5xx, never shows a
   // stale card for a frame that is still loading).
   const sample = index.samples[frame];
-  const overlayRow = sample
-    ? overlayRows.get(sample.sample_uid)
-    : undefined;
+  const overlayRow = sample ? overlayRows.get(sample.sample_uid) : undefined;
   const curvatureSign = trajectoryCurvatureSign(dataset);
   const predictionTrajectories = useMemo(() => {
     if (!overlay || !sample) return [];
@@ -641,11 +626,7 @@ export function EpisodePlayer({
 
   if (!store || cams.length === 0) {
     return (
-      <p
-        role="status"
-        aria-live="polite"
-        className="text-sm text-slate-500"
-      >
+      <p role="status" aria-live="polite" className="text-sm text-slate-500">
         Empty shard index — nothing to play.
       </p>
     );
@@ -668,6 +649,159 @@ export function EpisodePlayer({
         baseSeeds={overlay?.baseSeeds ?? []}
         splitBucket={sample?.split_bucket}
       />
+      <section className="space-y-3" aria-label="Playback controls">
+        <TimelineScrubber
+          samples={index.samples}
+          fps={index.fps || 10}
+          frame={frame}
+          onSeek={setFrame}
+          onScrubStart={pause}
+        />
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() => setFrame(0)}
+            aria-label="Back to start"
+            title="Back to start"
+          >
+            <Rewind className="size-3.5" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() => step(-1)}
+            aria-label="Step back one frame"
+            title="Step back one frame (← or ,)"
+          >
+            <StepBack className="size-3.5" />
+          </Button>
+          <Button
+            size="icon-sm"
+            onClick={toggle}
+            aria-label={playing ? "Pause" : "Play"}
+            title="Play/Pause (Space)"
+          >
+            {playing ? (
+              <Pause className="size-3.5" />
+            ) : (
+              <Play className="size-3.5" />
+            )}
+          </Button>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() => step(1)}
+            aria-label="Step forward one frame"
+            title="Step forward one frame (→ or .)"
+          >
+            <StepForward className="size-3.5" />
+          </Button>
+          <span className="mx-1 h-4 w-px bg-slate-800" />
+          <Gauge className="size-3.5 text-slate-500" />
+          {/* Always-visible readout: usePlayback clamps but accepts off-preset
+              speeds (e.g. ?speed=3), which would otherwise light no chip. */}
+          <span className="font-mono text-[10px] text-slate-400">{speed}x</span>
+          {SPEED_STEPS.map((s) => (
+            <button
+              key={s}
+              onClick={() => setSpeed(s)}
+              title={`Set speed ${s}x ([ / ] to change)`}
+              className={`rounded px-1.5 py-0.5 font-mono text-[10px] transition-colors ${
+                Math.abs(speed - s) < 1e-9
+                  ? "bg-blue-600 text-white"
+                  : "bg-slate-900 text-slate-400 hover:text-slate-200"
+              }`}
+            >
+              {s}x
+            </button>
+          ))}
+          {/* Group the buffering chip and Shortcuts button under one ml-auto so
+              the chip toggling does not reflow (shift) the Shortcuts button. */}
+          <div className="ml-auto flex items-center gap-2">
+            {buffering && (
+              <span
+                role="status"
+                aria-live="polite"
+                className="flex items-center gap-1 rounded bg-amber-950/60 px-2 py-0.5 font-mono text-[10px] text-amber-400"
+                title="Fetching frames ahead of the playhead"
+              >
+                <span className="size-1.5 animate-pulse rounded-full bg-amber-400" />
+                buffering
+              </span>
+            )}
+            <button
+              onClick={() => {
+                setShowHelp((v) => !v);
+                dismissHint();
+              }}
+              title="Keyboard shortcuts (?)"
+              aria-label="Keyboard shortcuts"
+              className="flex items-center gap-1 rounded bg-slate-900 px-2 py-1 font-mono text-[11px] text-slate-400 transition-colors hover:text-slate-200"
+            >
+              <Keyboard className="size-3.5" />
+              Shortcuts (?)
+            </button>
+          </div>
+        </div>
+
+        {showHint && (
+          <div className="flex items-center justify-between rounded-md border border-slate-800 bg-slate-900/60 px-3 py-1.5 text-[11px] text-slate-400">
+            <span>
+              Press <kbd className="rounded bg-slate-800 px-1">?</kbd> for
+              keyboard shortcuts.
+            </span>
+            <button
+              onClick={dismissHint}
+              className="font-mono text-slate-500 hover:text-slate-300"
+              aria-label="Dismiss hint"
+            >
+              dismiss
+            </button>
+          </div>
+        )}
+
+        {showHelp && (
+          <div className="rounded-lg border border-slate-700 bg-slate-950/80 p-4">
+            <div className="mb-2 flex items-center justify-between">
+              <p className="text-[10px] uppercase tracking-wider text-slate-500">
+                Keyboard shortcuts
+              </p>
+              <button
+                onClick={() => setShowHelp(false)}
+                className="font-mono text-[10px] text-slate-500 hover:text-slate-300"
+              >
+                close (esc)
+              </button>
+            </div>
+            <dl className="grid grid-cols-2 gap-x-6 gap-y-1 font-mono text-[11px] text-slate-400 sm:grid-cols-3">
+              {[
+                ["Space", "play / pause"],
+                ["← / ,", "step back one frame"],
+                ["→ / .", "step forward one frame"],
+                ["[ / -", "slower"],
+                ["] / +", "faster"],
+                [
+                  cams.length > 1 ? `1 - ${Math.min(9, cams.length)}` : "1",
+                  "focus camera n",
+                ],
+                ["f", "toggle focus / grid"],
+                ["Esc", "back to grid"],
+                ["?", "toggle this help"],
+              ].map(([k, desc]) => (
+                <div key={k} className="flex items-baseline gap-2">
+                  <kbd className="rounded bg-slate-800 px-1.5 py-0.5 text-slate-200">
+                    {k}
+                  </kbd>
+                  <span>{desc}</span>
+                </div>
+              ))}
+            </dl>
+          </div>
+        )}
+      </section>
+
       <div className="grid gap-4 xl:grid-cols-[1fr_300px]">
         <CameraMosaic
           store={store}
@@ -679,7 +813,9 @@ export function EpisodePlayer({
           mode={mode}
           focusCam={focusCam}
           onSelectCam={focusCamera}
-          onToggleFocus={() => setMode((m) => (m === "grid" ? "focus" : "grid"))}
+          onToggleFocus={() =>
+            setMode((m) => (m === "grid" ? "focus" : "grid"))
+          }
           predictionPaths={cameraPredictionPaths}
           predictionRibbons={cameraPredictionRibbons}
           groundTruthRibbons={cameraGroundTruthRibbons}
@@ -751,12 +887,18 @@ export function EpisodePlayer({
                   Math.abs(yawRateFrom(v, kappa)) >= MAX_YAW_RATE - 1e-9;
                 if (bevClamped) {
                   return (
-                    <span className="text-amber-600"> · non-physical (clamped in BEV)</span>
+                    <span className="text-amber-600">
+                      {" "}
+                      · non-physical (clamped in BEV)
+                    </span>
                   );
                 }
                 if (Math.abs(yaw) > MAX_YAW_RATE) {
                   return (
-                    <span className="text-amber-600"> · yaw_rate non-physical</span>
+                    <span className="text-amber-600">
+                      {" "}
+                      · yaw_rate non-physical
+                    </span>
                   );
                 }
                 return null;
@@ -774,157 +916,6 @@ export function EpisodePlayer({
         medianPrediction={medianPrediction}
         curvatureSign={curvatureSign}
       />
-
-      <TimelineScrubber
-        samples={index.samples}
-        fps={index.fps || 10}
-        frame={frame}
-        onSeek={setFrame}
-        onScrubStart={pause}
-      />
-
-      <div className="flex flex-wrap items-center gap-2">
-        <Button
-          variant="outline"
-          size="icon-sm"
-          onClick={() => setFrame(0)}
-          aria-label="Back to start"
-          title="Back to start"
-        >
-          <Rewind className="size-3.5" />
-        </Button>
-        <Button
-          variant="outline"
-          size="icon-sm"
-          onClick={() => step(-1)}
-          aria-label="Step back one frame"
-          title="Step back one frame (← or ,)"
-        >
-          <StepBack className="size-3.5" />
-        </Button>
-        <Button
-          size="icon-sm"
-          onClick={toggle}
-          aria-label={playing ? "Pause" : "Play"}
-          title="Play/Pause (Space)"
-        >
-          {playing ? (
-            <Pause className="size-3.5" />
-          ) : (
-            <Play className="size-3.5" />
-          )}
-        </Button>
-        <Button
-          variant="outline"
-          size="icon-sm"
-          onClick={() => step(1)}
-          aria-label="Step forward one frame"
-          title="Step forward one frame (→ or .)"
-        >
-          <StepForward className="size-3.5" />
-        </Button>
-        <span className="mx-1 h-4 w-px bg-slate-800" />
-        <Gauge className="size-3.5 text-slate-500" />
-        {/* Always-visible readout: usePlayback clamps but accepts off-preset
-            speeds (e.g. ?speed=3), which would otherwise light no chip. */}
-        <span className="font-mono text-[10px] text-slate-400">{speed}x</span>
-        {SPEED_STEPS.map((s) => (
-          <button
-            key={s}
-            onClick={() => setSpeed(s)}
-            title={`Set speed ${s}x ([ / ] to change)`}
-            className={`rounded px-1.5 py-0.5 font-mono text-[10px] transition-colors ${
-              Math.abs(speed - s) < 1e-9
-                ? "bg-blue-600 text-white"
-                : "bg-slate-900 text-slate-400 hover:text-slate-200"
-            }`}
-          >
-            {s}x
-          </button>
-        ))}
-        {/* Group the buffering chip and Shortcuts button under one ml-auto so
-            the chip toggling does not reflow (shift) the Shortcuts button. */}
-        <div className="ml-auto flex items-center gap-2">
-          {buffering && (
-            <span
-              role="status"
-              aria-live="polite"
-              className="flex items-center gap-1 rounded bg-amber-950/60 px-2 py-0.5 font-mono text-[10px] text-amber-400"
-              title="Fetching frames ahead of the playhead"
-            >
-              <span className="size-1.5 animate-pulse rounded-full bg-amber-400" />
-              buffering
-            </span>
-          )}
-          <button
-            onClick={() => {
-              setShowHelp((v) => !v);
-              dismissHint();
-            }}
-            title="Keyboard shortcuts (?)"
-            aria-label="Keyboard shortcuts"
-            className="flex items-center gap-1 rounded bg-slate-900 px-2 py-1 font-mono text-[11px] text-slate-400 transition-colors hover:text-slate-200"
-          >
-            <Keyboard className="size-3.5" />
-            Shortcuts (?)
-          </button>
-        </div>
-      </div>
-
-      {showHint && (
-        <div className="flex items-center justify-between rounded-md border border-slate-800 bg-slate-900/60 px-3 py-1.5 text-[11px] text-slate-400">
-          <span>
-            Press <kbd className="rounded bg-slate-800 px-1">?</kbd> for keyboard
-            shortcuts.
-          </span>
-          <button
-            onClick={dismissHint}
-            className="font-mono text-slate-500 hover:text-slate-300"
-            aria-label="Dismiss hint"
-          >
-            dismiss
-          </button>
-        </div>
-      )}
-
-      {showHelp && (
-        <div className="rounded-lg border border-slate-700 bg-slate-950/80 p-4">
-          <div className="mb-2 flex items-center justify-between">
-            <p className="text-[10px] uppercase tracking-wider text-slate-500">
-              Keyboard shortcuts
-            </p>
-            <button
-              onClick={() => setShowHelp(false)}
-              className="font-mono text-[10px] text-slate-500 hover:text-slate-300"
-            >
-              close (esc)
-            </button>
-          </div>
-          <dl className="grid grid-cols-2 gap-x-6 gap-y-1 font-mono text-[11px] text-slate-400 sm:grid-cols-3">
-            {[
-              ["Space", "play / pause"],
-              ["← / ,", "step back one frame"],
-              ["→ / .", "step forward one frame"],
-              ["[ / -", "slower"],
-              ["] / +", "faster"],
-              [
-                cams.length > 1 ? `1 - ${Math.min(9, cams.length)}` : "1",
-                "focus camera n",
-              ],
-              ["f", "toggle focus / grid"],
-              ["Esc", "back to grid"],
-              ["?", "toggle this help"],
-            ].map(([k, desc]) => (
-              <div key={k} className="flex items-baseline gap-2">
-                <kbd className="rounded bg-slate-800 px-1.5 py-0.5 text-slate-200">
-                  {k}
-                </kbd>
-                <span>{desc}</span>
-              </div>
-            ))}
-          </dl>
-        </div>
-      )}
 
       <div className="rounded-lg border border-slate-800 bg-slate-950/50 p-4">
         <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
@@ -973,9 +964,11 @@ export function EpisodePlayer({
             className="text-sm text-slate-500"
           >
             No reasoning label at or before this frame
-            {promptVersion ? " for the selected teacher and prompt version" : ""}. Amber
-            ticks on the timeline mark frames labelled in any run, so a ticked
-            frame may still be unlabelled in this one.
+            {promptVersion
+              ? " for the selected teacher and prompt version"
+              : ""}
+            . Amber ticks on the timeline mark frames labelled in any run, so a
+            ticked frame may still be unlabelled in this one.
           </p>
         )}
       </div>

--- a/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/episode-player.tsx
@@ -696,7 +696,6 @@ export function EpisodePlayer({
             version={version}
             sample={sample}
           />
-          <BEVActivationHeatmap overlay={overlay} row={overlayRow} />
           <div className="rounded-md border border-slate-800 bg-slate-900/60 p-2 font-mono text-[10px] leading-relaxed text-slate-400">
             <p>
               ep {sample?.episode_id || "-"} ·{" "}
@@ -761,6 +760,8 @@ export function EpisodePlayer({
           </div>
         </div>
       </div>
+
+      <BEVActivationHeatmap overlay={overlay} row={overlayRow} />
 
       <SceneMap
         dataset={dataset}

--- a/Tools/DataModelConsole/web/src/components/player/navigation-map.tsx
+++ b/Tools/DataModelConsole/web/src/components/player/navigation-map.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { getSampleNavigationMapURL } from "@/lib/api";
+import type { IndexSample } from "@/types";
+
+export function NavigationMap({
+  dataset,
+  shard,
+  version,
+  sample,
+}: {
+  dataset: string;
+  shard: string;
+  version?: string;
+  sample: IndexSample | undefined;
+}) {
+  const hasMap = Boolean(
+    sample &&
+      (sample.members["map.jpg"] ||
+        (sample.members["map_semantic.npz"] &&
+          sample.members["route_mask.npz"])),
+  );
+  const source = useMemo(
+    () =>
+      sample && hasMap
+        ? getSampleNavigationMapURL(dataset, shard, sample.key, version)
+        : "",
+    [dataset, hasMap, sample, shard, version],
+  );
+  const [status, setStatus] = useState<"loading" | "ready" | "error">(
+    "loading",
+  );
+
+  useEffect(() => {
+    setStatus("loading");
+  }, [source]);
+
+  return (
+    <section
+      className="rounded-md border border-slate-800 bg-slate-950 p-2"
+      aria-label="Rendered navigation map"
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h3 className="text-xs font-medium text-slate-200">Navigation map</h3>
+        <div className="flex items-center gap-2 text-[9px] text-slate-500">
+          <span className="flex items-center gap-1">
+            <span className="size-2 bg-teal-500" aria-hidden="true" />
+            Route
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="size-2 bg-slate-300" aria-hidden="true" />
+            Lane
+          </span>
+        </div>
+      </div>
+      {source ? (
+        <div className="grid grid-cols-[14px_1fr] grid-rows-[1fr_14px]">
+          <span className="flex items-center text-[9px] text-slate-500 [writing-mode:vertical-rl]">
+            +X forward
+          </span>
+          <div className="relative aspect-square overflow-hidden border border-slate-800 bg-slate-950">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              key={source}
+              src={source}
+              alt="Ego-frame semantic navigation raster"
+              className="size-full object-contain [image-rendering:pixelated]"
+              onLoad={() => setStatus("ready")}
+              onError={() => setStatus("error")}
+            />
+            {status === "loading" && (
+              <div
+                role="status"
+                className="absolute inset-0 flex items-center justify-center bg-slate-950 text-xs text-slate-500"
+              >
+                Loading map...
+              </div>
+            )}
+            {status === "error" && (
+              <div
+                role="status"
+                className="absolute inset-0 flex items-center justify-center bg-slate-950 px-4 text-center text-xs text-rose-400"
+              >
+                Map render failed.
+              </div>
+            )}
+            {status === "ready" && (
+              <span
+                className="absolute left-1/2 top-2/3 block size-2 -translate-x-1/2 -translate-y-1/2 rotate-45 border-l border-t border-white"
+                aria-hidden="true"
+              />
+            )}
+          </div>
+          <span />
+          <span className="text-center text-[9px] leading-[14px] text-slate-500">
+            +Y left
+          </span>
+        </div>
+      ) : (
+        <div className="flex aspect-square items-center justify-center border border-dashed border-slate-800 px-5 text-center text-xs text-slate-500">
+          No navigation raster for this sample.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/Tools/DataModelConsole/web/src/lib/api.ts
+++ b/Tools/DataModelConsole/web/src/lib/api.ts
@@ -376,6 +376,20 @@ export async function getShardOverlay(
   return response.arrayBuffer();
 }
 
+export function getSampleNavigationMapURL(
+  dataset: string,
+  shard: string,
+  key: string,
+  version?: string,
+): string {
+  return (
+    `${BASE_URL}/api/v1/datasets/${encodeURIComponent(dataset)}` +
+    `/shards/${encodeURIComponent(shard)}` +
+    `/samples/${encodeURIComponent(key)}/navigation-map` +
+    versionParam(version, "?")
+  );
+}
+
 export function getShardRigProjection(
   dataset: string,
   shard: string,

--- a/Tools/DataModelConsole/web/src/lib/overlay.ts
+++ b/Tools/DataModelConsole/web/src/lib/overlay.ts
@@ -3,6 +3,9 @@ const HEADER_BYTES = 20;
 const DIRECTORY_ENTRY_BYTES = 12;
 const HORIZON = 64;
 const DIMS = 2;
+export const BEV_HEATMAP_NAMES = ["image", "navigation", "fused"] as const;
+export const BEV_HEATMAP_SIZE = 32;
+export type BEVHeatmapName = (typeof BEV_HEATMAP_NAMES)[number];
 
 export interface OverlayArtifact {
   formatVersion: number;
@@ -15,6 +18,8 @@ export interface OverlayArtifact {
   directory: Map<bigint, number>;
   controls: Float32Array;
   v0: Float32Array;
+  bevHeatmaps: Uint8Array | null;
+  bevHeatmapScales: Float32Array | null;
 }
 
 export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
@@ -34,7 +39,13 @@ export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
   const horizon = view.getUint16(14, true);
   const dims = view.getUint16(16, true);
   const reserved = view.getUint16(18, true);
-  if (formatVersion !== 1 || horizon !== HORIZON || dims !== DIMS || reserved !== 0) {
+  const heatmapCount = formatVersion === 2 ? BEV_HEATMAP_NAMES.length : 0;
+  if (
+    (formatVersion !== 1 && formatVersion !== 2) ||
+    horizon !== HORIZON ||
+    dims !== DIMS ||
+    reserved !== heatmapCount
+  ) {
     throw new Error("Unsupported overlay format");
   }
   if (sampleCount === 0 || seedCount === 0) {
@@ -47,7 +58,17 @@ export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
     directoryOffset + sampleCount * DIRECTORY_ENTRY_BYTES;
   const controlsLength = sampleCount * seedCount * horizon * dims;
   const speedsOffset = controlsOffset + controlsLength * 4;
-  const expectedBytes = speedsOffset + sampleCount * 4;
+  const heatmapScalesOffset = speedsOffset + sampleCount * 4;
+  const heatmapsOffset = heatmapScalesOffset + sampleCount * 4;
+  const heatmapsLength =
+    sampleCount *
+    heatmapCount *
+    BEV_HEATMAP_SIZE *
+    BEV_HEATMAP_SIZE;
+  const expectedBytes =
+    formatVersion === 2
+      ? heatmapsOffset + heatmapsLength
+      : heatmapScalesOffset;
   if (buffer.byteLength !== expectedBytes) {
     throw new Error(
       `Overlay size mismatch: expected ${expectedBytes}, got ${buffer.byteLength}`,
@@ -85,6 +106,14 @@ export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
     directory,
     controls: new Float32Array(buffer, controlsOffset, controlsLength),
     v0: new Float32Array(buffer, speedsOffset, sampleCount),
+    bevHeatmaps:
+      formatVersion === 2
+        ? new Uint8Array(buffer, heatmapsOffset, heatmapsLength)
+        : null,
+    bevHeatmapScales:
+      formatVersion === 2
+        ? new Float32Array(buffer, heatmapScalesOffset, sampleCount)
+        : null,
   };
 }
 
@@ -104,6 +133,30 @@ export function controlsForRow(
   const stride = overlay.horizon * overlay.dims;
   const begin = (row * overlay.seedCount + seedIndex) * stride;
   return overlay.controls.subarray(begin, begin + stride);
+}
+
+export function bevHeatmapForRow(
+  overlay: OverlayArtifact,
+  row: number,
+  name: BEVHeatmapName,
+): { values: Uint8Array; scale: number } | null {
+  if (
+    row < 0 ||
+    row >= overlay.sampleCount ||
+    overlay.bevHeatmaps === null ||
+    overlay.bevHeatmapScales === null
+  ) {
+    return null;
+  }
+  const heatmapIndex = BEV_HEATMAP_NAMES.indexOf(name);
+  if (heatmapIndex < 0) return null;
+  const pixels = BEV_HEATMAP_SIZE * BEV_HEATMAP_SIZE;
+  const begin =
+    (row * BEV_HEATMAP_NAMES.length + heatmapIndex) * pixels;
+  return {
+    values: overlay.bevHeatmaps.subarray(begin, begin + pixels),
+    scale: overlay.bevHeatmapScales[row],
+  };
 }
 
 export async function sampleUIDHash(sampleUID: string): Promise<bigint> {

--- a/Tools/DataModelConsole/web/src/lib/overlay.ts
+++ b/Tools/DataModelConsole/web/src/lib/overlay.ts
@@ -51,14 +51,15 @@ export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
   const bevHeatmapNames =
     formatVersion === 2
       ? LEGACY_BEV_HEATMAP_NAMES
-      : formatVersion === 3
+      : formatVersion === 3 || formatVersion === 4
         ? BEV_HEATMAP_NAMES
         : [];
   const heatmapCount = bevHeatmapNames.length;
   if (
     (formatVersion !== 1 &&
       formatVersion !== 2 &&
-      formatVersion !== 3) ||
+      formatVersion !== 3 &&
+      formatVersion !== 4) ||
     horizon !== HORIZON ||
     dims !== DIMS ||
     reserved !== heatmapCount
@@ -76,7 +77,11 @@ export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
   const controlsLength = sampleCount * seedCount * horizon * dims;
   const speedsOffset = controlsOffset + controlsLength * 4;
   const heatmapScalesOffset = speedsOffset + sampleCount * 4;
-  const heatmapsOffset = heatmapScalesOffset + sampleCount * 4;
+  const heatmapScaleCount =
+    heatmapCount > 0
+      ? sampleCount * (formatVersion >= 4 ? heatmapCount : 1)
+      : 0;
+  const heatmapsOffset = heatmapScalesOffset + heatmapScaleCount * 4;
   const heatmapsLength =
     sampleCount *
     heatmapCount *
@@ -129,7 +134,11 @@ export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
         : null,
     bevHeatmapScales:
       heatmapCount > 0
-        ? new Float32Array(buffer, heatmapScalesOffset, sampleCount)
+        ? new Float32Array(
+            buffer,
+            heatmapScalesOffset,
+            heatmapScaleCount,
+          )
         : null,
     bevHeatmapNames,
   };
@@ -173,7 +182,12 @@ export function bevHeatmapForRow(
     (row * overlay.bevHeatmapNames.length + heatmapIndex) * pixels;
   return {
     values: overlay.bevHeatmaps.subarray(begin, begin + pixels),
-    scale: overlay.bevHeatmapScales[row],
+    scale:
+      overlay.bevHeatmapScales[
+        overlay.formatVersion >= 4
+          ? row * overlay.bevHeatmapNames.length + heatmapIndex
+          : row
+      ],
   };
 }
 

--- a/Tools/DataModelConsole/web/src/lib/overlay.ts
+++ b/Tools/DataModelConsole/web/src/lib/overlay.ts
@@ -3,8 +3,16 @@ const HEADER_BYTES = 20;
 const DIRECTORY_ENTRY_BYTES = 12;
 const HORIZON = 64;
 const DIMS = 2;
-export const BEV_HEATMAP_NAMES = ["image", "navigation", "fused"] as const;
 export const BEV_HEATMAP_SIZE = 32;
+const LEGACY_BEV_HEATMAP_NAMES = ["image", "navigation", "fused"] as const;
+export const BEV_HEATMAP_NAMES = [
+  "image",
+  "map",
+  "route_delta",
+  "navigation",
+  "fusion_delta",
+  "fused",
+] as const;
 export type BEVHeatmapName = (typeof BEV_HEATMAP_NAMES)[number];
 
 export interface OverlayArtifact {
@@ -20,6 +28,7 @@ export interface OverlayArtifact {
   v0: Float32Array;
   bevHeatmaps: Uint8Array | null;
   bevHeatmapScales: Float32Array | null;
+  bevHeatmapNames: readonly BEVHeatmapName[];
 }
 
 export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
@@ -39,9 +48,17 @@ export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
   const horizon = view.getUint16(14, true);
   const dims = view.getUint16(16, true);
   const reserved = view.getUint16(18, true);
-  const heatmapCount = formatVersion === 2 ? BEV_HEATMAP_NAMES.length : 0;
+  const bevHeatmapNames =
+    formatVersion === 2
+      ? LEGACY_BEV_HEATMAP_NAMES
+      : formatVersion === 3
+        ? BEV_HEATMAP_NAMES
+        : [];
+  const heatmapCount = bevHeatmapNames.length;
   if (
-    (formatVersion !== 1 && formatVersion !== 2) ||
+    (formatVersion !== 1 &&
+      formatVersion !== 2 &&
+      formatVersion !== 3) ||
     horizon !== HORIZON ||
     dims !== DIMS ||
     reserved !== heatmapCount
@@ -66,7 +83,7 @@ export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
     BEV_HEATMAP_SIZE *
     BEV_HEATMAP_SIZE;
   const expectedBytes =
-    formatVersion === 2
+    heatmapCount > 0
       ? heatmapsOffset + heatmapsLength
       : heatmapScalesOffset;
   if (buffer.byteLength !== expectedBytes) {
@@ -107,13 +124,14 @@ export function parseOverlay(buffer: ArrayBuffer): OverlayArtifact {
     controls: new Float32Array(buffer, controlsOffset, controlsLength),
     v0: new Float32Array(buffer, speedsOffset, sampleCount),
     bevHeatmaps:
-      formatVersion === 2
+      heatmapCount > 0
         ? new Uint8Array(buffer, heatmapsOffset, heatmapsLength)
         : null,
     bevHeatmapScales:
-      formatVersion === 2
+      heatmapCount > 0
         ? new Float32Array(buffer, heatmapScalesOffset, sampleCount)
         : null,
+    bevHeatmapNames,
   };
 }
 
@@ -148,11 +166,11 @@ export function bevHeatmapForRow(
   ) {
     return null;
   }
-  const heatmapIndex = BEV_HEATMAP_NAMES.indexOf(name);
+  const heatmapIndex = overlay.bevHeatmapNames.indexOf(name);
   if (heatmapIndex < 0) return null;
   const pixels = BEV_HEATMAP_SIZE * BEV_HEATMAP_SIZE;
   const begin =
-    (row * BEV_HEATMAP_NAMES.length + heatmapIndex) * pixels;
+    (row * overlay.bevHeatmapNames.length + heatmapIndex) * pixels;
   return {
     values: overlay.bevHeatmaps.subarray(begin, begin + pixels),
     scale: overlay.bevHeatmapScales[row],

--- a/Tools/DataModelConsole/web/src/lib/rig.ts
+++ b/Tools/DataModelConsole/web/src/lib/rig.ts
@@ -12,9 +12,12 @@
 // L2D (l2d/camera.py): 6 surround cameras (map is packed separately)
 //   0 front_left, 1 left_forward, 2 right_forward,
 //   3 left_backward, 4 rear, 5 right_backward
-// KITScenes (kit_scenes/camera.py): 7 cameras
-//   0 base_front_center, 1 ring_front, 2 ring_front_left,
-//   3 ring_front_right, 4 ring_rear, 5 ring_rear_left, 6 ring_rear_right
+// KITScenes has two published slot contracts:
+//   7-view: 0 base_front_center, 1 ring_front, 2 ring_front_left,
+//           3 ring_front_right, 4 ring_rear, 5 ring_rear_left,
+//           6 ring_rear_right
+//   6-view: 0 base_front_center, 1 ring_front_left, 2 ring_front_right,
+//           3 ring_rear, 4 ring_rear_left, 5 ring_rear_right
 
 export interface RigCam {
   label: string;
@@ -60,7 +63,7 @@ const L2D_RIG: Record<string, RigCam> = {
 // filled there is no free centre cell, so the ego readout tile is omitted.
 //   (1,1) front-left    (1,2) front-center  (1,3) front-right
 //   (2,1) rear-left     (2,2) rear          (2,3) rear-right
-const KITSCENES_RIG: Record<string, RigCam> = {
+const KITSCENES_SEVEN_VIEW_RIG: Record<string, RigCam> = {
   cam_0: { label: "front-center", row: 1, col: 2 },
   cam_2: { label: "front-left", row: 1, col: 1 },
   cam_3: { label: "front-right", row: 1, col: 3 },
@@ -69,40 +72,66 @@ const KITSCENES_RIG: Record<string, RigCam> = {
   cam_6: { label: "rear-right", row: 2, col: 3 },
 };
 
+const KITSCENES_SIX_VIEW_RIG: Record<string, RigCam> = {
+  cam_0: { label: "front-center", row: 1, col: 2 },
+  cam_1: { label: "front-left", row: 1, col: 1 },
+  cam_2: { label: "front-right", row: 1, col: 3 },
+  cam_3: { label: "rear", row: 2, col: 2 },
+  cam_4: { label: "rear-left", row: 2, col: 1 },
+  cam_5: { label: "rear-right", row: 2, col: 3 },
+};
+
 const RIGS: Record<string, Record<string, RigCam>> = {
   nvidia_av: NVIDIA_RIG,
   l2d: L2D_RIG,
-  kitscenes: KITSCENES_RIG,
 };
 
-// Cameras that are packed in the shard but the console intentionally does not
-// display. KITScenes cam_1 (ring_front) duplicates cam_0 (base_front_center) —
-// same heading, essentially the same field of view — so it is the redundant
-// camera the model itself dropped (kit_scenes/camera.py, #146). Hiding it in the
-// viewer leaves the six distinct views for a clean 3x2 grid.
-const HIDDEN_CAMS: Record<string, Set<string>> = {
-  kitscenes: new Set(["cam_1"]),
-};
+function datasetRig(
+  dataset: string,
+  packedCameraCount?: number,
+): Record<string, RigCam> | undefined {
+  if (dataset === "kitscenes") {
+    return packedCameraCount === 6
+      ? KITSCENES_SIX_VIEW_RIG
+      : KITSCENES_SEVEN_VIEW_RIG;
+  }
+  return RIGS[dataset];
+}
 
 // isHiddenCam reports whether a shard camera member should be omitted from the
 // mosaic for a dataset. Filtering happens on the displayed camera list, so the
 // hidden camera never claims a grid cell, a focus slot, or a keyboard ordinal.
-export function isHiddenCam(dataset: string, cam: string): boolean {
-  return HIDDEN_CAMS[dataset]?.has(cam) ?? false;
+export function isHiddenCam(
+  dataset: string,
+  cam: string,
+  packedCameraCount?: number,
+): boolean {
+  // Seven-view shards contain the redundant ring-front in slot 1. Six-view
+  // shards already removed it and compacted front-left into slot 1.
+  return dataset === "kitscenes" && packedCameraCount !== 6 && cam === "cam_1";
 }
 
 // rigCam returns the rig position + grid cell for a "cam_N" identifier.
 // Falls back to a sequential cell + the raw id for unknown datasets/cameras.
-export function rigCam(dataset: string, cam: string, index: number): RigCam {
-  const mapped = RIGS[dataset]?.[cam];
+export function rigCam(
+  dataset: string,
+  cam: string,
+  index: number,
+  packedCameraCount?: number,
+): RigCam {
+  const mapped = datasetRig(dataset, packedCameraCount)?.[cam];
   if (mapped) return mapped;
   // Unknown rig: lay out sequentially in a 3-col grid.
   return { label: cam, row: Math.floor(index / 3) + 1, col: (index % 3) + 1 };
 }
 
 // camLabel returns just the rig position label (back-compat helper).
-export function camLabel(dataset: string, cam: string): string {
-  return RIGS[dataset]?.[cam]?.label ?? cam;
+export function camLabel(
+  dataset: string,
+  cam: string,
+  packedCameraCount?: number,
+): string {
+  return datasetRig(dataset, packedCameraCount)?.[cam]?.label ?? cam;
 }
 
 // displayAspectRatio is the width/height a camera tile should reserve for a
@@ -124,14 +153,18 @@ export function displayAspectRatio(dataset: string): number {
 // (KITScenes: forward + rear) must report rows=2, or the grid emits a phantom
 // empty third row AND the ego cell lands in row 2 (ceil(3/2)) on top of a
 // camera. `cams` should already be the DISPLAYED set (hidden cams filtered).
-export function gridDimensions(dataset: string, cams: string[]): {
+export function gridDimensions(
+  dataset: string,
+  cams: string[],
+  packedCameraCount?: number,
+): {
   rows: number;
   cols: number;
 } {
   let rows = 1;
   let cols = 1;
   cams.forEach((cam, i) => {
-    const c = rigCam(dataset, cam, i);
+    const c = rigCam(dataset, cam, i, packedCameraCount);
     rows = Math.max(rows, c.row);
     cols = Math.max(cols, c.col);
   });

--- a/Tools/trajectory_visualization/provenance.py
+++ b/Tools/trajectory_visualization/provenance.py
@@ -105,6 +105,8 @@ def validate_report_provenance(
         raise ValueError("overlay and dataset publication identities differ")
     if overlay_manifest.get("overlay_binary_schema") not in {
         "v1",
+        "v2",
+        "v3",
         OVERLAY_SCHEMA,
     }:
         raise ValueError("overlay manifest has an unsupported binary schema")

--- a/Tools/trajectory_visualization/provenance.py
+++ b/Tools/trajectory_visualization/provenance.py
@@ -103,7 +103,10 @@ def validate_report_provenance(
         or overlay_manifest.get("version") != version
     ):
         raise ValueError("overlay and dataset publication identities differ")
-    if overlay_manifest.get("overlay_binary_schema") != OVERLAY_SCHEMA:
+    if overlay_manifest.get("overlay_binary_schema") not in {
+        "v1",
+        OVERLAY_SCHEMA,
+    }:
         raise ValueError("overlay manifest has an unsupported binary schema")
 
     shard = Path(shard_path)


### PR DESCRIPTION
https://d2itskdqq39tx1.cloudfront.net/scenes/kitscenes/part-0e08829f6aac8fe3-train-000000.tar/23?version=v3.0&model=a9c532860af1a096004276d137d03b35c6e22df6de42563adf3aee5116a86c1b

## Summary

- Align camera and navigation BEV coordinates and add the rendered navigation map to the scene player.
- Add AOVL v4 encoder diagnostics for Camera, Map only, Route delta, Navigation, Fusion delta, and Fused features.
- Preserve per-sample, per-encoder quantization scales so smaller Camera and Fused signals remain visible alongside Map activations.
- Use spatial feature deviation for Camera, Map, Navigation, and Fused panels, while retaining channel RMS for Route and Fusion delta panels.
- Fix KITScenes v2.2 and v3.0 camera contracts, including the rear-right camera slot.
- Place playback controls above the camera views and Encoder diagnostics below Reasoning Labels.

## Overlay publication

- Stage v3-to-v4 overlay upgrades before switching the live pointer.
- Require complete shard and sample coverage before cutover.
- Support safe retries after an overlay set has already reached the ready state.

## Validation

- GitHub CI and DCO checks pass.
- EC2 production build, ESLint, and Playwright tests pass.
- Flyte execution `a4rrmtgrthppwq8x7llr` completed successfully and published AOVL v4 diagnostics for 404 shards and 42,667 samples.
- Production desktop and mobile checks confirmed playback, UI ordering, all six cameras including rear-right, and all six nonblank encoder heatmaps without browser or layout errors.

Closes #147


<img width="1274" height="852" alt="image" src="https://github.com/user-attachments/assets/b02a3432-a657-4301-9f09-effcac4a4c46" />

<img width="1244" height="779" alt="image" src="https://github.com/user-attachments/assets/17e155fe-8935-4951-b635-79b7dd669e74" />

