### PR TITLE
Add OpenStreetMap SD-map prior (SDTagNet) as a vector map branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@ __pycache__/
 *.py[cod]
 ._*
 benchmark_results.json
+# Downloaded SDTagNet NLP encoder checkpoint (default download dir)
+checkpoints/
+# Generated OSM SD-map artifacts: caches, raw Overpass fetches, tokenized
+# shards, built road graphs, and visualization output.
+cache/
+*.osm.gz
+osm_bbox_*.xml.gz
+graph_*.pkl
+osm_map_vis.png

--- a/Model/README.md
+++ b/Model/README.md
@@ -34,4 +34,20 @@ trajectory, ego_hidden, future_visual_features = model(
 **To learn the driving policy:**
 - Imitation Learning is used to penalize trajectory prediction as well as World Model Simulation based Reinforcement Learning
 
+## Map priors
+
+Two interchangeable map-branch flavours feed road-network priors into the BEV:
+
+- **`map_type="rasterized"`** (default): a rendered nav-map image is encoded to a
+  spatial map BEV and fused with the camera BEV (`map_fusion_mode="residual"` or
+  `"cross_attn"`). See [data_parsing/map_rendering](./data_parsing/map_rendering).
+- **`map_type="osm_vector"`**: OpenStreetMap SD-map elements are encoded as
+  **text-annotated vector tokens** (ported from
+  [SDTagNet](https://arxiv.org/abs/2506.08997)) and the camera BEV
+  cross-attends to them (`map_fusion_mode="osm_cross_attn"`). This keeps arbitrary
+  OSM semantics (lane counts, surface, turn restrictions, ...) without a fixed
+  class taxonomy. See [data_parsing/osm_sd_map](./data_parsing/osm_sd_map) for the
+  offline pipeline and [model_components/map_encoder/osm_vector](./model_components/map_encoder/osm_vector)
+  for the encoder. Both branches share one on-disk OSM cache.
+
 

--- a/Model/data_parsing/l2d/dataset.py
+++ b/Model/data_parsing/l2d/dataset.py
@@ -68,10 +68,17 @@ class L2DDataset(Dataset):
         episodes: list[int] | None = None,
         backbone_name: str = "swinv2_tiny_window8_256",
         local_files_only: bool = False,
+        osm_cache_dir: str | None = None,
     ) -> None:
         from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
 
         self.repo_id = repo_id
+        # When set, per-episode tokenised OSM shards (built offline via
+        # data_parsing.osm_sd_map.cache.build_episode_osm_cache) are merged into
+        # each sample as osm_map_* keys for the OSM vector encoder. When None,
+        # samples are unchanged (existing behaviour).
+        self.osm_cache_dir = osm_cache_dir
+        self._osm_shard_cache: tuple[int | None, dict | None] = (None, None)
 
         self.lerobot_dataset = LeRobotDataset(
             repo_id=repo_id,
@@ -162,7 +169,7 @@ class L2DDataset(Dataset):
 
         visual_history = torch.zeros(_VISUAL_HISTORY_DIM, dtype=torch.float32)
 
-        return L2DSample(
+        sample = L2DSample(
             visual_tiles=visual_tiles,
             egomotion_history=egomotion_history,
             visual_history=visual_history,
@@ -170,3 +177,41 @@ class L2DDataset(Dataset):
             episode_index=ep_idx,
             frame_index=local_frame_idx,
         )
+
+        if self.osm_cache_dir is not None:
+            osm_sample = self._load_osm_sample(ep_idx, local_frame_idx)
+            if osm_sample is not None:
+                # Merge osm_map_* keys; collate_osm_batch groups them per batch.
+                sample.update(osm_sample)
+
+        return sample
+
+    def _load_osm_sample(self, ep_idx: int, local_frame_idx: int):
+        """Load one frame's tokenised OSM data from the per-episode shard cache."""
+        from data_parsing.osm_sd_map.cache import load_episode_osm_cache
+
+        cached_ep, shard = self._osm_shard_cache
+        if cached_ep != ep_idx:
+            shard = load_episode_osm_cache(self.osm_cache_dir, ep_idx)
+            self._osm_shard_cache = (ep_idx, shard)
+        if shard is None:
+            return None
+        return shard.get(local_frame_idx)
+
+    def episode_ego_poses(self, ep_idx: int) -> list[tuple[int, float, float, float]]:
+        """Per-valid-frame ``(local_frame_idx, lat, lon, heading)`` for OSM caching.
+
+        Feed the result to ``osm_sd_map.cache.build_episode_osm_cache``. Uses
+        the vehicle state columns ``[1]=heading, [3]=lat, [4]=lon``.
+        """
+        episode_data_index = self.lerobot_dataset.episode_data_index
+        ep_start = episode_data_index["from"][ep_idx].item()
+
+        poses = []
+        for sample_ep_idx, global_frame_idx in self._samples:
+            if sample_ep_idx != ep_idx:
+                continue
+            local_frame_idx = global_frame_idx - ep_start
+            state = self.lerobot_dataset[global_frame_idx]["observation.state.vehicle"].numpy()
+            poses.append((local_frame_idx, float(state[3]), float(state[4]), float(state[1])))
+        return poses

--- a/Model/data_parsing/map_rendering/cache.py
+++ b/Model/data_parsing/map_rendering/cache.py
@@ -63,8 +63,9 @@ def render_and_cache_tiles(
         output_dir: where rendered PNG tiles are written (`{clip_id}.png`).
         radius_m: render radius around each clip's centroid.
         image_size: output `(W, H)`.
-        network_cache_dir: if given, fetched graphs are persisted here keyed by
-            centroid so neighbouring clips share a cached download.
+        network_cache_dir: if given, fetched graphs and the shared raw-OSM XML
+            are persisted here (keyed by the clip's trajectory bbox) so
+            neighbouring clips and the OSM vector branch reuse downloads.
         skip_existing: do not re-render clips whose PNG already exists.
 
     Returns:
@@ -91,8 +92,11 @@ def render_and_cache_tiles(
         ego_lon = float(lons[-1])
         ego_heading = _heading_from_trace(lats, lons, ego_lat)
 
+        # Fetch sized to the whole trajectory + the render radius, so the route
+        # and the ±radius draw window are always covered (a centroid radius can
+        # miss long clips).
         graph = _load_or_fetch_network(
-            ego_lat, ego_lon, radius_m, net_cache
+            list(lats), list(lons), radius_m, net_cache
         )
         if graph is None:
             logger.warning("clip %s: failed to obtain road network; skipping", clip_id)
@@ -146,35 +150,108 @@ def _heading_from_trace(
     return math.atan2(dx, dy)
 
 
-def _load_or_fetch_network(
-    center_lat: float,
-    center_lon: float,
-    radius_m: int,
+def _graph_from_shared_osm(
+    lats: Sequence[float],
+    lons: Sequence[float],
+    margin_m: int,
     cache_dir: Path | None,
 ) -> nx.MultiDiGraph | None:
-    """Return a cached graph if available, otherwise fetch and cache it.
+    """Build the road graph from the shared raw-OSM cache (trace bbox + margin).
 
-    Centroids are quantized to ~100 m so nearby clips reuse the same download.
+    The SD-map (OSM vector) branch and this rendered-tile branch share a single
+    on-disk artifact: the raw Overpass OSM XML (see
+    ``data_parsing.osm_sd_map.overpass``). Both fetch the bounding box of the
+    clip's trajectory expanded by their own margin (here the render radius); the
+    shared cache reuses any already-fetched XML that covers the request, so one
+    download serves both. Returns ``None`` (caller falls back to a direct fetch)
+    if the shared path is unavailable for any reason.
     """
-    if cache_dir is not None:
-        key = f"{round(center_lat, 3)}_{round(center_lon, 3)}_{radius_m}.pkl"
-        cache_path = cache_dir / key
+    try:
+        import os
+        import tempfile
+
+        import osmnx as ox
+
+        from ..osm_sd_map.overpass import load_or_fetch_osm_for_trace
+    except Exception as exc:  # noqa: BLE001 — optional path; never break rendering
+        logger.debug("shared OSM path unavailable (%s); using direct fetch", exc)
+        return None
+
+    xml = load_or_fetch_osm_for_trace(lats, lons, margin_m, cache_dir)
+    if xml is None:
+        return None
+
+    tmp = tempfile.NamedTemporaryFile("w", suffix=".osm", delete=False, encoding="utf-8")
+    try:
+        tmp.write(xml)
+        tmp.close()
+        return ox.graph_from_xml(tmp.name, bidirectional=False, simplify=True, retain_all=True)
+    except Exception as exc:  # noqa: BLE001 — osmnx version/parse differences
+        logger.warning("graph_from_xml failed (%s); using direct fetch", exc)
+        return None
+    finally:
+        os.unlink(tmp.name)
+
+
+def _trace_centroid_radius(
+    lats: Sequence[float], lons: Sequence[float], margin_m: int
+) -> tuple[float, float, int]:
+    """Centroid + a radius that covers the whole trace plus ``margin_m``."""
+    clat = sum(lats) / len(lats)
+    clon = sum(lons) / len(lons)
+    deg_to_m = EARTH_RADIUS_M * math.pi / 180.0
+    cos_lat = math.cos(math.radians(clat))
+    max_d = 0.0
+    for la, lo in zip(lats, lons):
+        dx = (lo - clon) * cos_lat * deg_to_m
+        dy = (la - clat) * deg_to_m
+        max_d = max(max_d, math.hypot(dx, dy))
+    return clat, clon, int(max_d + margin_m)
+
+
+def _graph_cache_path(
+    lats: Sequence[float], lons: Sequence[float], margin_m: int, cache_dir: Path
+) -> Path | None:
+    """Pickle path for the built graph, keyed by the trace bbox."""
+    try:
+        from ..osm_sd_map.overpass import bbox_from_points
+    except Exception:  # noqa: BLE001
+        return None
+    s, w, n, e = bbox_from_points(lats, lons, margin_m)
+    return cache_dir / f"graph_{s:.4f}_{w:.4f}_{n:.4f}_{e:.4f}.pkl"
+
+
+def _load_or_fetch_network(
+    lats: Sequence[float],
+    lons: Sequence[float],
+    margin_m: int,
+    cache_dir: Path | None,
+) -> nx.MultiDiGraph | None:
+    """Return a cached graph if available, otherwise build/fetch and cache it.
+
+    The fetch is sized to the trajectory bounding box plus ``margin_m`` (the
+    render radius), so long clips are fully covered (a fixed centroid radius can
+    miss them). The graph is built from the shared raw-OSM cache when possible
+    (reused by the OSM vector branch via bbox containment); otherwise it falls
+    back to a direct osmnx fetch sized to cover the trace. The built graph is
+    memoized as a pickle keyed by the trace bbox.
+    """
+    cache_path = _graph_cache_path(lats, lons, margin_m, cache_dir) if cache_dir is not None else None
+    if cache_path is not None:
         cached = load_cached_network(cache_path)
         if cached is not None:
             return cached
-    else:
-        cache_path = None
 
-    try:
-        graph = fetch_road_network(center_lat, center_lon, radius_m=radius_m)
-    except Exception as exc:  # noqa: BLE001 — network/Overpass failures
-        logger.warning(
-            "fetch_road_network(%.4f, %.4f) failed: %s",
-            center_lat,
-            center_lon,
-            exc,
-        )
-        return None
+    graph = _graph_from_shared_osm(lats, lons, margin_m, cache_dir)
+    if graph is None:
+        clat, clon, radius = _trace_centroid_radius(lats, lons, margin_m)
+        try:
+            graph = fetch_road_network(clat, clon, radius_m=radius)
+        except Exception as exc:  # noqa: BLE001 — network/Overpass failures
+            logger.warning(
+                "fetch_road_network(%.4f, %.4f) failed: %s", clat, clon, exc
+            )
+            return None
 
     if cache_path is not None:
         cache_network(graph, cache_path)

--- a/Model/data_parsing/osm_sd_map/README.md
+++ b/Model/data_parsing/osm_sd_map/README.md
@@ -1,0 +1,146 @@
+# SD-map (OpenStreetMap) vector pipeline
+
+Feeds OpenStreetMap standard-definition (SD) map priors to AutoE2E as a set of
+**text-annotated vector tokens**, ported from
+[SDTagNet](https://arxiv.org/abs/2506.08997) (NeurIPS 2025) and adapted from
+online HD-map construction to end-to-end driving. The model side lives in
+[`model_components/map_encoder/osm_vector`](../../model_components/map_encoder/osm_vector)
+(the encoder) and
+[`map_bev_fusion/osm_cross_attn_fusion.py`](../../model_components/map_encoder/map_bev_fusion/osm_cross_attn_fusion.py)
+(BEV ↔ token cross-attention).
+
+## How it differs from the rendered map tile
+
+The existing [`map_rendering`](../map_rendering) branch rasterises the road
+network into an RGB tile. This branch instead keeps OSM elements as **vectors**
+(nodes / ways / relations) and embeds their **tag strings** with a pretrained
+NLP encoder, so arbitrary semantics (lane counts, surface, turn restrictions,
+amenities, ...) flow into the model without a hand-picked class taxonomy. The
+two branches **share one on-disk OSM cache** (raw Overpass XML); see
+[`map_rendering/cache.py`](../map_rendering/cache.py).
+
+## One-time setup: NLP tag encoder
+
+```python
+from data_parsing.osm_sd_map import download_nlp_weights
+
+nlp_path = download_nlp_weights()   # -> <repo>/checkpoints/sdtagnet_nlp (gitignored)
+```
+
+`nlp_path` is passed both to the encoder (`nlp_model_path=`) and used internally
+for the matching tokenizer.
+
+## Offline preprocessing (per episode)
+
+Slow work — Overpass fetch, OSM parse, tokenisation — is done once and cached as
+one `.pt` shard per episode. Pair with `L2DDataset`:
+
+```python
+from transformers import AutoTokenizer
+from data_parsing.l2d import L2DDataset
+from data_parsing.osm_sd_map.cache import build_episode_osm_cache
+
+tokenizer = AutoTokenizer.from_pretrained(nlp_path)
+ds = L2DDataset(repo_id="yaak-ai/L2D", episodes=[0])
+pc_range = (-60.0, -30.0, -5.0, 60.0, 30.0, 3.0)
+
+for ep in [0]:
+    build_episode_osm_cache(
+        episode_id=ep,
+        frames=ds.episode_ego_poses(ep),       # (frame_idx, lat, lon, heading)
+        tokenizer=tokenizer,
+        pc_range=pc_range,
+        out_dir="cache/osm_tokens",
+        raw_osm_cache_dir="cache/osm_raw",     # shared with map_rendering
+    )
+```
+
+## Training time
+
+```python
+from torch.utils.data import DataLoader
+from data_parsing.l2d import L2DDataset
+from data_parsing.osm_sd_map import collate_osm_batch
+
+ds = L2DDataset(repo_id="yaak-ai/L2D", osm_cache_dir="cache/osm_tokens")
+loader = DataLoader(ds, batch_size=6, collate_fn=collate_osm_batch)  # ragged OSM
+```
+
+Build the model with the OSM branch and pass the collated batch as the map input
+(the encoder only reads the `osm_map_*` keys, so the whole batch dict is fine):
+
+```python
+from model_components.auto_e2e import AutoE2E
+
+model = AutoE2E(
+    map_type="osm_vector",
+    map_encoder_kwargs=dict(nlp_model_path=nlp_path, pc_range=pc_range),
+    map_fusion_mode="osm_cross_attn",
+)
+
+for batch in loader:
+    out = model(batch["visual_tiles"], batch, batch["visual_history"],
+                batch["egomotion_history"], mode="train",
+                trajectory_target=batch["trajectory_target"])
+```
+
+With the default encoder config the token dimension is
+`pts_dim·pos_num_feats + nlp_embed_dim + 2·orf_dim = 3·16 + 144 + 2·64 = 320`
+(matching SDTagNet's canonical `input_dim`).
+
+## Validate on a real OSM map
+
+One command fetches a real OSM area around a GPS point, runs the full pipeline
+(Overpass query → ego projection → patch crop → tokenise), renders a
+SDTagNet-style figure, and (optionally) runs the encoder forward on it:
+
+```bash
+cd Model
+python -m data_parsing.osm_sd_map.visualize \
+    --lat 48.9930 --lon 8.4037 --heading 0.0 \
+    --download-nlp --run-encoder --out osm_map_vis.png
+```
+
+The figure shows the ego (★, forward = +x), way polylines (highway = green,
+other = red), node points (blue), decoded tag text, and relation member links —
+exactly what the encoder consumes — so geometry, ego framing and tag decoding
+can be eyeballed for correctness. `--run-encoder` additionally prints the token
+tensor shape, valid/total token counts and a finiteness check, validating the
+encoder on real data. Pass `--osm-file area.osm` to use a local extract instead
+of hitting Overpass, and `--nlp-model-path PATH` to use already-downloaded NLP
+weights.
+
+`visualize_osm_map_data(sample, pc_range, out_path, tokenizer=...)` is also
+importable to render any cached per-frame sample.
+
+## Modules
+
+| File | Purpose |
+| --- | --- |
+| `overpass.py`     | Tested SDTagNet Overpass query + shared raw-OSM XML cache. |
+| `osm_parser.py`   | Parse OSM XML, project to ego frame, crop to a metric patch. |
+| `wgs84_to_local.py` | Generic WGS84 → ego (X=forward, Y=left) projection. |
+| `osm_tokenize.py` | Resample way geometry + tokenise tags → `osm_map_data`. |
+| `cache.py`        | Build / load per-episode tokenised shards. |
+| `nlp_download.py` | Fetch the SDTagNet NLP encoder from HuggingFace. |
+| `collate.py`      | DataLoader `collate_fn` for ragged `osm_map_data`. |
+| `visualize.py`    | SDTagNet-style SD-map figure + real-data validation CLI. |
+
+## Notes
+
+- **Fetch extent**: each episode does one Overpass fetch sized to the
+  **bounding box of its trajectory plus a margin**, which covers long episodes
+  (a fixed centroid radius silently misses frames whose patch falls outside it).
+  The margin defaults to the rendered-tile branch's render radius (~800 m,
+  `DEFAULT_FETCH_MARGIN_M`) so both branches request the same area and **share a
+  single raw-OSM download** (the vector branch crops to `pc_range` at
+  tokenisation regardless). For a **vector-only** setup with no rendered tiles,
+  pass `fetch_margin_m=patch_reach_m(pc_range)` to fetch only the ~70 m the patch
+  needs. The shared cache also reuses any already-fetched XML whose bbox
+  **contains** a request, so smaller fetches still hit a larger cached one.
+- **Coordinates**: ego frame X=forward, Y=left, Z=up (matches `pc_range`); OSM is
+  treated as 2D and gets a constant `z=0` when `pts_dim=3`.
+- **Heading**: `L2DDataset.episode_ego_poses` uses `vehicle[1]` as heading
+  (radians); confirm the convention against your data during validation.
+- **osmnx**: only the rendered-tile branch needs `osmnx` (to build a graph from
+  the shared XML); the vector branch does not.

--- a/Model/data_parsing/osm_sd_map/__init__.py
+++ b/Model/data_parsing/osm_sd_map/__init__.py
@@ -1,0 +1,47 @@
+"""SD-map (OpenStreetMap) data pipeline for the OSM vector map encoder.
+
+Offline preprocessing:
+  * ``overpass``      — fetch raw OSM XML (tested SDTagNet query) + shared cache.
+  * ``osm_parser``    — parse OSM XML, project to ego frame, crop to a patch.
+  * ``osm_tokenize``  — resample geometry + tokenise tags into ``osm_map_data``.
+  * ``cache``         — build/load per-episode tokenised shards.
+  * ``nlp_download``  — fetch the SDTagNet NLP tag encoder from HuggingFace.
+
+Training time:
+  * ``collate.collate_osm_batch`` — DataLoader collate for ragged OSM batches.
+
+The model-ready ``osm_map_data`` dict is consumed by
+``model_components.map_encoder.osm_vector.OSMVectorMapEncoder``.
+"""
+
+from .collate import collate_osm_batch
+from .nlp_download import download_nlp_weights
+from .osm_parser import OSMMapElements, parse
+from .osm_tokenize import extract_osm_map_data, tokenize_osm_elements
+from .overpass import (
+    bbox_from_points,
+    build_query,
+    fetch_raw_osm,
+    load_or_fetch_osm,
+    load_or_fetch_osm_bbox,
+    load_or_fetch_osm_for_trace,
+)
+from .wgs84_to_local import wgs84_to_ego_local
+
+# Note: `visualize` is intentionally NOT imported here. It is run as a module
+# (`python -m data_parsing.osm_sd_map.visualize`); importing it in the package
+# __init__ would double-import it under runpy and emit a RuntimeWarning. Import
+# it explicitly where needed: `from data_parsing.osm_sd_map.visualize import ...`.
+
+__all__ = [
+    "collate_osm_batch",
+    "download_nlp_weights",
+    "OSMMapElements",
+    "parse",
+    "extract_osm_map_data",
+    "tokenize_osm_elements",
+    "build_query",
+    "fetch_raw_osm",
+    "load_or_fetch_osm",
+    "wgs84_to_ego_local",
+]

--- a/Model/data_parsing/osm_sd_map/cache.py
+++ b/Model/data_parsing/osm_sd_map/cache.py
@@ -1,0 +1,124 @@
+"""Offline per-episode tokenised OSM cache.
+
+Mirrors ``map_rendering.cache`` philosophy: do the slow work (Overpass fetch,
+OSM parse, tokenisation) once, offline, and persist per-episode shards so the
+DataLoader only reads files. One ``.pt`` file per episode holds a
+``{frame_index: osm_map_data}`` mapping.
+
+The expensive ``osm_parser.parse`` runs once per episode (shared raw OSM cache);
+``build_node_way_lists`` + patch extraction + tokenisation run per frame because
+each frame has its own ego pose.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+
+import torch
+
+from .osm_parser import parse
+from .osm_tokenize import extract_osm_map_data
+from .overpass import load_or_fetch_osm_for_trace
+
+logger = logging.getLogger(__name__)
+
+# Default fetch margin = the rendered-tile branch's render radius
+# (map_rendering.gps_to_map.DEFAULT_RADIUS_M). Defaulting to it means the vector
+# and raster branches request the same-sized area around a clip, so their shared
+# raw-OSM cache collapses to a single download (the vector branch crops to
+# pc_range at tokenisation time regardless). For a vector-only setup with no
+# rendered tiles, pass `fetch_margin_m=patch_reach_m(pc_range)` to fetch the
+# minimal area instead. Keep in sync with map_rendering's DEFAULT_RADIUS_M.
+DEFAULT_FETCH_MARGIN_M = 800
+
+
+def patch_reach_m(pc_range, buffer_m=50.0):
+    """Max distance from an ego pose to a corner of its pc_range patch, + buffer.
+
+    The minimal per-side margin the SD-map fetch needs beyond the trajectory so
+    every frame's pc_range crop is covered. Use it as ``fetch_margin_m`` for a
+    vector-only setup; the default (``DEFAULT_FETCH_MARGIN_M``) is larger so the
+    fetch is shared with the rendered-tile branch.
+    """
+    max_x = max(abs(pc_range[0]), abs(pc_range[3]))
+    max_y = max(abs(pc_range[1]), abs(pc_range[4]))
+    return (max_x ** 2 + max_y ** 2) ** 0.5 + buffer_m
+
+
+def build_episode_osm_cache(
+    episode_id,
+    frames,
+    tokenizer,
+    pc_range,
+    out_dir,
+    raw_osm_cache_dir=None,
+    fetch_margin_m=None,
+    fixed_num=10,
+    pts_dim=3,
+    remove_not_relevant_keys=True,
+    skip_existing=True,
+):
+    """Build and persist the tokenised OSM cache for one episode.
+
+    Args:
+        episode_id: identifier; the shard is ``{out_dir}/{episode_id}.pt``.
+        frames: iterable of ``(frame_index, ego_lat, ego_lon, ego_heading)``.
+        tokenizer: HuggingFace tokenizer matching the NLP encoder.
+        pc_range: ego-metric crop ``(x_min,y_min,z_min,x_max,y_max,z_max)``.
+        out_dir: directory for per-episode shards.
+        raw_osm_cache_dir: shared raw-OSM XML cache (see ``overpass``); also used
+            by the rendered-tile branch (containment reuse).
+        fetch_margin_m: per-side margin beyond the trajectory bbox for the
+            Overpass fetch. Defaults to ``DEFAULT_FETCH_MARGIN_M`` (the raster
+            branch's render radius) so the fetch is shared with the rendered-tile
+            branch. Pass ``patch_reach_m(pc_range)`` for a minimal vector-only
+            fetch. Either way it's sized to the trajectory (covers long episodes;
+            no fixed centroid radius blind spot).
+
+    Returns:
+        Path to the written shard, or ``None`` if the OSM fetch failed.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    shard_path = out_dir / f"{episode_id}.pt"
+    if skip_existing and shard_path.exists():
+        return shard_path
+
+    frames = list(frames)
+    if not frames:
+        logger.warning("episode %s has no frames; skipping", episode_id)
+        return None
+
+    if fetch_margin_m is None:
+        fetch_margin_m = DEFAULT_FETCH_MARGIN_M
+
+    # One fetch per episode, sized to the trajectory bbox + patch margin.
+    lats = [f[1] for f in frames]
+    lons = [f[2] for f in frames]
+    xml = load_or_fetch_osm_for_trace(lats, lons, fetch_margin_m, raw_osm_cache_dir)
+    if xml is None:
+        logger.warning("episode %s: no OSM available; skipping", episode_id)
+        return None
+
+    osm_elements = parse(io.StringIO(xml))
+
+    shard = {}
+    for frame_index, ego_lat, ego_lon, ego_heading in frames:
+        shard[frame_index] = extract_osm_map_data(
+            osm_elements, ego_lat, ego_lon, ego_heading, tokenizer, pc_range,
+            fixed_num=fixed_num, pts_dim=pts_dim,
+            remove_not_relevant_keys=remove_not_relevant_keys,
+        )
+
+    torch.save(shard, shard_path)
+    return shard_path
+
+
+def load_episode_osm_cache(out_dir, episode_id):
+    """Load a per-episode shard ``{frame_index: osm_map_data}`` (or ``None``)."""
+    shard_path = Path(out_dir) / f"{episode_id}.pt"
+    if not shard_path.exists():
+        return None
+    return torch.load(shard_path, weights_only=False)

--- a/Model/data_parsing/osm_sd_map/collate.py
+++ b/Model/data_parsing/osm_sd_map/collate.py
@@ -1,0 +1,40 @@
+"""Custom ``collate_fn`` for batches carrying ragged ``osm_map_data``.
+
+``OSMVectorMapEncoder`` consumes per-key lists indexed by batch position (the
+number of OSM elements varies per sample, so the tensors cannot be stacked).
+Every key prefixed ``osm_map_`` is therefore grouped into a Python list over the
+batch; all other keys (images, egomotion, targets, ...) go through the default
+collate so existing behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+from torch.utils.data import default_collate
+
+_OSM_PREFIX = "osm_map_"
+
+
+def collate_osm_batch(batch):
+    """Collate samples that may contain ``osm_map_*`` ragged fields.
+
+    Args:
+        batch: list of per-sample dicts.
+
+    Returns:
+        dict where ``osm_map_*`` keys map to length-B lists and all other keys
+        are default-collated (stacked) tensors / values.
+    """
+    if not batch:
+        return {}
+
+    keys = batch[0].keys()
+    osm_keys = [k for k in keys if k.startswith(_OSM_PREFIX)]
+    other_keys = [k for k in keys if not k.startswith(_OSM_PREFIX)]
+
+    out = {}
+    if other_keys:
+        collated = default_collate([{k: s[k] for k in other_keys} for s in batch])
+        out.update(collated)
+    for k in osm_keys:
+        out[k] = [s[k] for s in batch]
+    return out

--- a/Model/data_parsing/osm_sd_map/nlp_download.py
+++ b/Model/data_parsing/osm_sd_map/nlp_download.py
@@ -1,0 +1,100 @@
+"""Download the SDTagNet NLP tag encoder from HuggingFace.
+
+The OSM vector encoder needs a SentenceTransformer that embeds OSM tag strings.
+The pretrained model is shipped as a tar.gz in the SDTagNet HuggingFace dataset
+repo, under ``nlp_encoder/``:
+
+  * ``bert-144-osm-tags-embed-from_scratch.tar.gz`` — the trained tag encoder
+    (this is what AutoE2E uses; extracts to ``bert-144-osm-tags-embed-from_scratch/
+    checkpoint-10628/``, the path referenced by SDTagNet's config),
+  * ``bert-144-l6-reset-custom-tokenizer.tar.gz`` — the untrained base (for
+    re-running the NLP pretraining only).
+
+This helper downloads the archive, extracts it, and returns the local path to
+the SentenceTransformer directory (the folder containing ``modules.json``),
+suitable for both ``SentenceTransformer(path)`` and
+``AutoTokenizer.from_pretrained(path)``.
+"""
+
+from __future__ import annotations
+
+import logging
+import tarfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# SDTagNet release on the HuggingFace Hub.
+DEFAULT_REPO_ID = "immel-f/SDTagNet"
+DEFAULT_REPO_TYPE = "dataset"
+# Trained tag encoder archive (verified path in the repo).
+DEFAULT_ARCHIVE = "nlp_encoder/bert-144-osm-tags-embed-from_scratch.tar.gz"
+
+# Fixed default download location, anchored to the repo root (auto_e2e/) rather
+# than the current working directory, so repeated runs from any directory reuse
+# one download. (.../osm_sd_map/nlp_download.py -> parents[3] == auto_e2e/)
+DEFAULT_TARGET_DIR = Path(__file__).resolve().parents[3] / "checkpoints" / "sdtagnet_nlp"
+
+# Files that mark the root of a SentenceTransformer model directory.
+_ST_MARKERS = ("modules.json", "config_sentence_transformers.json")
+
+
+def _find_model_dir(root: Path):
+    """Return the SentenceTransformer dir under ``root`` (contains modules.json)."""
+    markers = [p for m in _ST_MARKERS for p in root.rglob(m)]
+    if not markers:
+        return None
+    # Prefer a trainer "checkpoint-XXXX" dir if several models are present.
+    markers.sort(key=lambda p: (0 if "checkpoint" in p.parent.name else 1, len(str(p))))
+    return markers[0].parent
+
+
+def download_nlp_weights(
+    target_dir: str | Path = DEFAULT_TARGET_DIR,
+    repo_id: str = DEFAULT_REPO_ID,
+    repo_type: str = DEFAULT_REPO_TYPE,
+    archive: str = DEFAULT_ARCHIVE,
+    force: bool = False,
+) -> str:
+    """Download + extract the NLP tag encoder; return the model directory path.
+
+    Skips download/extraction if a SentenceTransformer is already present under
+    ``target_dir`` (unless ``force``).
+
+    Args:
+        target_dir: Local directory to download + extract into.
+        repo_id / repo_type: HuggingFace location.
+        archive: Path of the tar.gz within the repo (override to fetch the base
+            tokenizer archive instead of the trained model).
+        force: Re-download + re-extract even if a model is already present.
+    """
+    target = Path(target_dir)
+
+    if not force:
+        existing = _find_model_dir(target) if target.exists() else None
+        if existing is not None:
+            logger.info("NLP weights already present at %s; skipping download.", existing)
+            return str(existing)
+
+    from huggingface_hub import hf_hub_download
+
+    target.mkdir(parents=True, exist_ok=True)
+    archive_path = hf_hub_download(
+        repo_id=repo_id, repo_type=repo_type, filename=archive, local_dir=str(target),
+    )
+
+    # Extract (safe filter strips absolute/.. paths; Python 3.12 default).
+    with tarfile.open(archive_path, "r:gz") as tar:
+        try:
+            tar.extractall(target, filter="data")
+        except TypeError:  # filter kw added in 3.12; fall back for older pythons
+            tar.extractall(target)
+
+    model_dir = _find_model_dir(target)
+    if model_dir is None:
+        raise RuntimeError(
+            f"Extracted {archive} but found no SentenceTransformer model "
+            f"(no {' / '.join(_ST_MARKERS)}) under {target}."
+        )
+    logger.info("NLP weights ready at %s", model_dir)
+    return str(model_dir)

--- a/Model/data_parsing/osm_sd_map/osm_parser.py
+++ b/Model/data_parsing/osm_sd_map/osm_parser.py
@@ -1,0 +1,299 @@
+"""OpenStreetMap XML parser + ego-centric patch extraction.
+
+Ported from SDTagNet's ``tools/sdtagnet/osm_parser.py`` (numpy/shapely only —
+already free of mmdetection3d). The only change: the dataset-specific city
+coordinate conversions are replaced by the generic
+``wgs84_to_local.wgs84_to_ego_local`` projection, so nodes/ways are placed
+directly in the ego (X=forward, Y=left) frame and the patch is a metric box in
+that frame.
+
+Typical use (offline, per frame):
+
+    osm = parse(open("area.osm"))
+    osm.build_node_way_lists(ego_lat, ego_lon, ego_heading)
+    patch = shapely.geometry.box(x_min, y_min, x_max, y_max)   # pc_range
+    elements = osm.get_elements_in_patch(patch)
+
+``elements`` is the raw per-frame dict (lat/lon already in ego metres, tags as
+strings) consumed by ``osm_tokenize.tokenize_osm_elements``.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from xml.etree import cElementTree as ET
+
+import numpy as np
+
+from .wgs84_to_local import wgs84_to_ego_local
+
+def iterparse(fileobj):
+    context = iter(ET.iterparse(fileobj, events=("start", "end")))
+    _event, root = next(context)
+    return root, context
+
+
+@contextmanager
+def log_file_on_exception(xml):
+    try:
+        yield
+    except SyntaxError as ex:
+        import tempfile
+        _fd, filename = tempfile.mkstemp('.osm')
+        xml.seek(0)
+        with open(filename, 'w') as f:
+            f.write(xml.read())
+        print('SyntaxError in xml: %s, (stored dump %s)' % (ex, filename))
+
+
+@dataclass
+class Node:
+    id: int
+    lat_lon: np.ndarray
+    tags: dict
+
+
+@dataclass
+class Way:
+    id: int
+    node_lat_lon: np.ndarray
+    node_ids: np.ndarray
+    tags: dict
+
+
+@dataclass
+class RelationMember:
+    id: int
+    el_type: str
+    role: str
+
+
+@dataclass
+class Relation:
+    id: int
+    members: list
+    member_ids: np.ndarray
+    tags: dict
+
+
+def tag_dict_to_str(tag_dict):
+    string = ""
+    for key, val in tag_dict.items():
+        string += key + ': ' + str(val) + ', '
+    return string
+
+
+def all_members_in_patch(relation, ways_patch_ids, nodes_in_patch_ids, relation_ids,
+                         filter_with_relations=False):
+    for id in relation.member_ids:
+        if id in relation_ids and not filter_with_relations:
+            continue
+        elif id not in ways_patch_ids and id not in nodes_in_patch_ids and id not in relation_ids and filter_with_relations:
+            return False
+        elif id not in ways_patch_ids and id not in nodes_in_patch_ids and not filter_with_relations:
+            return False
+    return True
+
+
+class OSMMapElements:
+    def __init__(self, nodes=None, ways=None, relations=None):
+        self.nodes = nodes if nodes is not None else dict()
+        self.ways = ways if ways is not None else dict()
+        self.relations = relations if relations is not None else dict()
+
+    def build_node_way_lists(self, ego_lat, ego_lon, ego_heading):
+        """Project every node/way point into the ego-local (forward, left) frame."""
+        self.node_list = list(self.nodes.values())
+        self.node_id_array = np.array([node.id for node in self.node_list])
+        if self.node_list:
+            node_ll = np.array([node.lat_lon for node in self.node_list])
+            self.node_point_array_local = wgs84_to_ego_local(
+                node_ll[:, 0], node_ll[:, 1], ego_lat, ego_lon, ego_heading
+            )
+        else:
+            self.node_point_array_local = np.zeros((0, 2))
+
+        self.way_list = list(self.ways.values())
+        self.way_id_array = np.array([way.id for way in self.way_list])
+        self.way_point_list_local = []
+        for way in self.way_list:
+            if len(way.node_lat_lon):
+                self.way_point_list_local.append(
+                    wgs84_to_ego_local(
+                        way.node_lat_lon[:, 0], way.node_lat_lon[:, 1],
+                        ego_lat, ego_lon, ego_heading,
+                    )
+                )
+            else:
+                self.way_point_list_local.append(np.zeros((0, 2)))
+
+    def get_elements_in_patch(self, patch):
+        """Extract nodes/ways/relations intersecting ``patch`` (ego-metric box)."""
+        from shapely.geometry import LineString, Point
+
+        ways_patch_intersection = [
+            LineString(way).intersection(patch) if len(way) >= 2 else LineString().intersection(patch)
+            for way in self.way_point_list_local
+        ]
+        ways_in_patch_indices = [
+            i for i in range(len(self.way_list)) if not ways_patch_intersection[i].is_empty
+        ]
+
+        ways_patch_intersection = [ways_patch_intersection[i] for i in ways_in_patch_indices]
+        ways_patch_tags = [
+            tag_dict_to_str(self.way_list[i].tags)
+            for i in ways_in_patch_indices
+        ]
+        ways_patch_ids = [self.way_id_array[i] for i in ways_in_patch_indices]
+
+        ways_patch_no_multilines = []
+        ways_patch_tags_no_multilines = []
+        ways_patch_ids_no_multilines = []
+        for id, tags, lstring in zip(ways_patch_ids, ways_patch_tags, ways_patch_intersection):
+            if lstring.geom_type == 'LineString':
+                ways_patch_ids_no_multilines.append(id)
+                ways_patch_tags_no_multilines.append(tags)
+                ways_patch_no_multilines.append(lstring)
+            if lstring.geom_type == 'MultiLineString':
+                for single_line in lstring.geoms:
+                    ways_patch_ids_no_multilines.append(id)
+                    ways_patch_tags_no_multilines.append(tags)
+                    ways_patch_no_multilines.append(single_line)
+
+        nodes_in_patch_indices = [
+            i for i in range(len(self.node_list))
+            if patch.contains(Point(self.node_point_array_local[i]))
+        ]
+        nodes_in_patch = [self.node_point_array_local[i] for i in nodes_in_patch_indices]
+        nodes_in_patch_ids = [self.node_id_array[i] for i in nodes_in_patch_indices]
+
+        relation_ids = [rel.id for rel in self.relations.values()]
+        rels_1st = [
+            rel for rel in self.relations.values()
+            if all_members_in_patch(rel, ways_patch_ids, nodes_in_patch_ids, relation_ids)
+        ]
+        rels_1st_ids = [rel.id for rel in rels_1st]
+
+        nodes_in_patch_used_indices = []
+        nodes_in_patch_used_tags = []
+
+        if rels_1st:
+            rels_in_patch = [
+                rel for rel in self.relations.values()
+                if all_members_in_patch(rel, ways_patch_ids, nodes_in_patch_ids,
+                                        rels_1st_ids, filter_with_relations=True)
+            ]
+            rels_in_patch_ids = [rel.id for rel in rels_in_patch]
+            rels_in_patch_tags = [
+                tag_dict_to_str(rel.tags) for rel in rels_in_patch
+            ]
+        else:
+            rels_in_patch = []
+            rels_in_patch_ids = []
+            rels_in_patch_tags = []
+
+        rels_node_member_indices = [list() for _ in rels_in_patch]
+        rels_way_member_indices = [list() for _ in rels_in_patch]
+        rels_relation_member_indices = [list() for _ in rels_in_patch]
+        rels_node_member_tags = [list() for _ in rels_in_patch]
+        rels_way_member_tags = [list() for _ in rels_in_patch]
+        rels_relation_member_tags = [list() for _ in rels_in_patch]
+
+        for i, rel in enumerate(rels_in_patch):
+            for member in rel.members:
+                if member.el_type == 'node':
+                    nodes_in_patch_used_indices.append(nodes_in_patch_ids.index(member.id))
+                    node_tags = self.nodes[member.id].tags
+                    nodes_in_patch_used_tags.append(
+                        tag_dict_to_str(node_tags) if node_tags else ""
+                    )
+                    rels_node_member_indices[i].append(len(nodes_in_patch_used_indices) - 1)
+                    rels_node_member_tags[i].append(
+                        'type: ' + member.el_type + ', role: ' + member.role + ', '
+                    )
+                if member.el_type == 'way':
+                    related = [j for j, id in enumerate(ways_patch_ids_no_multilines) if id == member.id]
+                    rels_way_member_indices[i].extend(related)
+                    rels_way_member_tags[i].extend(
+                        ['type: ' + member.el_type + ', role: ' + member.role + ', ' for _ in related]
+                    )
+                if member.el_type == 'relation':
+                    rels_relation_member_indices[i].append(rels_in_patch_ids.index(member.id))
+                    rels_relation_member_tags[i].append(
+                        'type: ' + member.el_type + ', role: ' + member.role + ', '
+                    )
+
+        for i in range(len(nodes_in_patch_ids)):
+            if i in nodes_in_patch_used_indices:
+                continue
+            elif self.node_list[nodes_in_patch_indices[i]].tags:
+                nodes_in_patch_used_indices.append(i)
+                nodes_in_patch_used_tags.append(
+                    tag_dict_to_str(self.node_list[nodes_in_patch_indices[i]].tags)
+                )
+
+        nodes_in_patch_used = np.array([nodes_in_patch[i] for i in nodes_in_patch_used_indices])
+
+        return dict(
+            osm_map_nodes_pts=nodes_in_patch_used,
+            osm_map_nodes_tags=nodes_in_patch_used_tags,
+            osm_map_ways_pts=ways_patch_no_multilines,
+            osm_map_ways_tags=ways_patch_tags_no_multilines,
+            osm_map_relations_tags=rels_in_patch_tags,
+            osm_map_relations_node_member_indices=rels_node_member_indices,
+            osm_map_relations_way_member_indices=rels_way_member_indices,
+            osm_map_relations_relation_member_indices=rels_relation_member_indices,
+            osm_map_relations_node_member_tags=rels_node_member_tags,
+            osm_map_relations_way_member_tags=rels_way_member_tags,
+            osm_map_relations_relation_member_tags=rels_relation_member_tags,
+        )
+
+
+def parse(xml):
+    """Parse an OSM XML file object into ``OSMMapElements`` (lat/lon retained)."""
+    nodes, ways, relations = {}, {}, {}
+    tags, refs, members = {}, [], []
+    root, context = iterparse(xml)
+
+    with log_file_on_exception(xml):
+        for event, elem in context:
+            if event == 'start':
+                continue
+            if elem.tag == 'tag':
+                tags[elem.attrib['k']] = elem.attrib['v']
+            elif elem.tag == 'node':
+                osmid = int(elem.attrib['id'])
+                lat, lon = float(elem.attrib['lat']), float(elem.attrib['lon'])
+                nodes[osmid] = ((lat, lon), tags)
+                tags = {}
+            elif elem.tag == 'nd':
+                refs.append(int(elem.attrib['ref']))
+            elif elem.tag == 'member':
+                members.append((int(elem.attrib['ref']), elem.attrib['type'], elem.attrib['role']))
+            elif elem.tag == 'way':
+                osm_id = int(elem.attrib['id'])
+                ways[osm_id] = (osm_id, tags, refs)
+                refs, tags = [], {}
+            elif elem.tag == 'relation':
+                osm_id = int(elem.attrib['id'])
+                relations[osm_id] = (osm_id, tags, members)
+                members, tags = [], {}
+            root.clear()
+
+    map_els = OSMMapElements()
+    for id, node in nodes.items():
+        map_els.nodes[id] = Node(id, np.array([node[0][0], node[0][1]]), node[1])
+    for id, way in ways.items():
+        # Some way node refs can be missing from the extract; skip those.
+        coords = [map_els.nodes[nid].lat_lon for nid in way[2] if nid in map_els.nodes]
+        map_els.ways[id] = Way(
+            id, np.array(coords) if coords else np.zeros((0, 2)),
+            np.array(way[2]), way[1],
+        )
+    for id, relation in relations.items():
+        rel_members = [RelationMember(m[0], m[1], m[2]) for m in relation[2]]
+        map_els.relations[id] = Relation(
+            id, rel_members, np.array([m.id for m in rel_members]), relation[1]
+        )
+    return map_els

--- a/Model/data_parsing/osm_sd_map/osm_tokenize.py
+++ b/Model/data_parsing/osm_sd_map/osm_tokenize.py
@@ -1,0 +1,134 @@
+"""Turn extracted OSM patch elements into model-ready ``osm_map_data``.
+
+Ports the tokenisation + fixed-point resampling from SDTagNet's
+``osm_map_pipeline`` (canonical, no-augmentation path) and drops the mmcv
+``DataContainer`` wrapping. Produces a *single-sample* dict; batch them with
+``collate.collate_osm_map_data`` before feeding ``OSMVectorMapEncoder``.
+
+The per-sample dict keys (lists are over elements within the sample):
+
+    osm_map_nodes_pts                                   tensor (Nn, pts_dim)
+    osm_map_ways_pts                                    tensor (Nw, P, pts_dim)
+    osm_map_{nodes,ways,relations}_tags_{input_ids,token_type_ids,attention_mask}
+                                                        list of 1D token tensors
+    osm_map_relations_{node,way,relation}_member_tags_{...}
+                                                        list[rel] of list[member] of 1D
+    osm_map_relations_{node,way,relation}_member_indices
+                                                        list[rel] of 1D long tensor
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+from .osm_parser import OSMMapElements
+
+_TAG_KEYS = ("input_ids", "token_type_ids", "attention_mask")
+
+
+def _to_long_list(tokenized):
+    """HF tokenizer output (dict of list-of-lists) -> dict of list of 1D tensors."""
+    out = {}
+    for key in _TAG_KEYS:
+        vals = tokenized.get(key, [])
+        out[key] = [torch.as_tensor(entry, dtype=torch.long) for entry in vals]
+    return out
+
+
+def _fixed_num_sampled_points(linestrings, pc_range, fixed_num, pts_dim):
+    """Resample each LineString to ``fixed_num`` arc-length points, clamped to pc_range."""
+    max_x = (pc_range[3] - pc_range[0]) / 2.0
+    max_y = (pc_range[4] - pc_range[1]) / 2.0
+    pts_list = []
+    for inst in linestrings:
+        distances = np.linspace(0, inst.length, fixed_num)
+        sampled = np.array([list(inst.interpolate(d).coords) for d in distances]).reshape(-1, 2)
+        pts_list.append(sampled)
+    arr = np.asarray(pts_list, dtype=np.float32)  # (Nw, fixed_num, 2)
+    t = torch.from_numpy(arr)
+    t[:, :, 0] = torch.clamp(t[:, :, 0], min=-max_x, max=max_x)
+    t[:, :, 1] = torch.clamp(t[:, :, 1], min=-max_y, max=max_y)
+    if pts_dim == 3:
+        z = torch.zeros((t.shape[0], t.shape[1], 1), dtype=t.dtype)
+        t = torch.cat([t, z], dim=2)
+    return t
+
+
+def _nodes_to_tensor(node_pts, pts_dim):
+    arr = np.asarray(node_pts, dtype=np.float32).reshape(-1, 2)
+    t = torch.from_numpy(arr)
+    if pts_dim == 3:
+        t = torch.cat([t, torch.zeros((t.shape[0], 1), dtype=t.dtype)], dim=1)
+    return t
+
+
+def tokenize_osm_elements(elements, tokenizer, pc_range, fixed_num=10, pts_dim=3):
+    """Convert a raw patch-elements dict into a single-sample ``osm_map_data`` dict.
+
+    Args:
+        elements: output of ``OSMMapElements.get_elements_in_patch``.
+        tokenizer: a HuggingFace tokenizer matching the NLP encoder.
+        pc_range: ``(x_min, y_min, z_min, x_max, y_max, z_max)`` in ego metres.
+        fixed_num: points sampled per way.
+        pts_dim: 3 (xyz) or 2 (xy). Must match the encoder's ``pts_dim``.
+    """
+    sample = {}
+
+    # --- geometry ---
+    node_pts = elements["osm_map_nodes_pts"]
+    if len(node_pts):
+        sample["osm_map_nodes_pts"] = _nodes_to_tensor(node_pts, pts_dim)
+    else:
+        sample["osm_map_nodes_pts"] = torch.zeros((0, pts_dim), dtype=torch.float32)
+
+    ways = elements["osm_map_ways_pts"]
+    if ways:
+        sample["osm_map_ways_pts"] = _fixed_num_sampled_points(ways, pc_range, fixed_num, pts_dim)
+    else:
+        sample["osm_map_ways_pts"] = torch.zeros((0, fixed_num, pts_dim), dtype=torch.float32)
+
+    # --- element tag tokens ---
+    for name in ("nodes", "ways", "relations"):
+        tags = elements[f"osm_map_{name}_tags"]
+        tok = _to_long_list(tokenizer(list(tags), padding=True)) if tags else {k: [] for k in _TAG_KEYS}
+        for key in _TAG_KEYS:
+            sample[f"osm_map_{name}_tags_{key}"] = tok[key]
+
+    # --- relation member tag tokens (nested per relation) ---
+    for name in ("node", "way", "relation"):
+        member_tags = elements[f"osm_map_relations_{name}_member_tags"]
+        nested = {key: [] for key in _TAG_KEYS}
+        for per_rel in member_tags:
+            if per_rel:
+                tok = _to_long_list(tokenizer(list(per_rel), padding=True))
+            else:
+                tok = {key: [] for key in _TAG_KEYS}
+            for key in _TAG_KEYS:
+                nested[key].append(tok[key])
+        for key in _TAG_KEYS:
+            sample[f"osm_map_relations_{name}_member_tags_{key}"] = nested[key]
+
+    # --- relation member indices ---
+    for name in ("node", "way", "relation"):
+        idx_lists = elements[f"osm_map_relations_{name}_member_indices"]
+        sample[f"osm_map_relations_{name}_member_indices"] = [
+            torch.as_tensor(idx, dtype=torch.long) for idx in idx_lists
+        ]
+
+    return sample
+
+
+def extract_osm_map_data(osm_map_elements: OSMMapElements, ego_lat, ego_lon, ego_heading,
+                         tokenizer, pc_range, fixed_num=10, pts_dim=3):
+    """End-to-end per-frame: project to ego frame, crop to pc_range, tokenise.
+
+    ``osm_map_elements`` is a parsed ``OSMMapElements`` (from
+    ``osm_parser.parse``); this is the one-call path for offline preprocessing.
+    """
+    from shapely.geometry import box
+
+    osm_map_elements.build_node_way_lists(ego_lat, ego_lon, ego_heading)
+    patch = box(pc_range[0], pc_range[1], pc_range[3], pc_range[4])
+    elements = osm_map_elements.get_elements_in_patch(patch)
+    return tokenize_osm_elements(elements, tokenizer, pc_range, fixed_num=fixed_num, pts_dim=pts_dim)

--- a/Model/data_parsing/osm_sd_map/overpass.py
+++ b/Model/data_parsing/osm_sd_map/overpass.py
@@ -1,0 +1,185 @@
+"""Overpass fetch + shared raw-OSM cache.
+
+The Overpass query here is taken verbatim from SDTagNet's
+``nlp_pretraining/get_av2_sd_maps.ipynb`` / ``get_nusc_sd_maps.ipynb`` — it is
+tuned to pull every node/way/relation (with members) inside the bbox plus the
+relations that reference them, *without* dragging in unrelated elements:
+
+    (node(S,W,N,E); rel(bn)->.x; way(S,W,N,E); node(w)->.x; rel(bw);); out meta;
+
+The cached artifact is the **raw OSM XML**, which is the single shared source
+for both map branches:
+  * the SD-map (SDTagNet) branch parses it with ``osm_parser.parse``;
+  * the rendered-tile branch (``map_rendering``) builds an osmnx graph from it
+    via ``ox.graph_from_xml`` — see ``map_rendering.cache``.
+
+XML is cached gzip-compressed, keyed by quantized centroid (same ~100 m
+quantization the rendered-tile network cache already uses), so neighbouring
+clips reuse one Overpass download.
+"""
+
+from __future__ import annotations
+
+import gzip
+import logging
+import math
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+OVERPASS_URL = "https://overpass-api.de/api/interpreter"
+
+# Mirrors the headers used in the SDTagNet retrieval notebooks. Set a unique
+# User-Agent for your own large-scale use to be polite to the public endpoint.
+DEFAULT_HEADERS = {
+    "Connection": "keep-alive",
+    "Accept": "*/*",
+    "User-Agent": "auto_e2e-sd-map",
+    "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+    "Origin": "https://overpass-turbo.eu",
+    "Referer": "https://overpass-turbo.eu/",
+}
+
+EARTH_RADIUS_M = 6_378_137.0
+
+
+def build_query(south, west, north, east):
+    """The exact tested SDTagNet Overpass query for a bbox (S, W, N, E)."""
+    return (
+        "(node({0},{1},{2},{3}); rel(bn)->.x; way({0},{1},{2},{3}); "
+        "node(w)->.x; rel(bw);); out meta;"
+    ).format(south, west, north, east)
+
+
+def bbox_from_center(center_lat, center_lon, radius_m):
+    """Axis-aligned (S, W, N, E) bbox covering a radius around a point."""
+    deg_to_m = EARTH_RADIUS_M * math.pi / 180.0
+    dlat = radius_m / deg_to_m
+    dlon = radius_m / (deg_to_m * math.cos(math.radians(center_lat)))
+    return (center_lat - dlat, center_lon - dlon,
+            center_lat + dlat, center_lon + dlon)
+
+
+def bbox_from_points(latitudes, longitudes, margin_m):
+    """(S, W, N, E) bbox covering all points plus a metric margin on each side.
+
+    This is the trajectory-aware fetch extent: it tightly bounds an episode's
+    driven path rather than a fixed radius around its centroid, so it both
+    covers long episodes (which a centroid radius can miss) and stays small for
+    short ones. ``margin_m`` is the per-side reach the consumer needs beyond the
+    trajectory (the SD-map ``pc_range`` patch reach, or the renderer's draw
+    radius).
+    """
+    lat_min, lat_max = min(latitudes), max(latitudes)
+    lon_min, lon_max = min(longitudes), max(longitudes)
+    center_lat = (lat_min + lat_max) / 2.0
+    deg_to_m = EARTH_RADIUS_M * math.pi / 180.0
+    dlat = margin_m / deg_to_m
+    dlon = margin_m / (deg_to_m * math.cos(math.radians(center_lat)))
+    return (lat_min - dlat, lon_min - dlon, lat_max + dlat, lon_max + dlon)
+
+
+def fetch_raw_osm(south, west, north, east, url=OVERPASS_URL, headers=None, timeout=180):
+    """POST the tested query to Overpass and return the raw OSM XML text."""
+    import requests
+
+    query = build_query(south, west, north, east)
+    response = requests.post(
+        url, headers=headers or DEFAULT_HEADERS, data={"data": query}, timeout=timeout
+    )
+    response.raise_for_status()
+    return response.text
+
+
+_BBOX_PREFIX = "osm_bbox_"
+_BBOX_SUFFIX = ".xml.gz"
+
+
+def _bbox_cache_name(south, west, north, east):
+    return f"{_BBOX_PREFIX}{south:.4f}_{west:.4f}_{north:.4f}_{east:.4f}{_BBOX_SUFFIX}"
+
+
+def _parse_bbox_name(name):
+    if not (name.startswith(_BBOX_PREFIX) and name.endswith(_BBOX_SUFFIX)):
+        return None
+    parts = name[len(_BBOX_PREFIX):-len(_BBOX_SUFFIX)].split("_")
+    if len(parts) != 4:
+        return None
+    try:
+        return tuple(float(p) for p in parts)
+    except ValueError:
+        return None
+
+
+def _covers(cached, requested, eps=1e-9):
+    """True if cached (S,W,N,E) bbox fully contains the requested one."""
+    cs, cw, cn, ce = cached
+    rs, rw, rn, re = requested
+    return cs <= rs + eps and cw <= rw + eps and cn >= rn - eps and ce >= re - eps
+
+
+def _read_gz(path):
+    try:
+        with gzip.open(path, "rt", encoding="utf-8") as f:
+            return f.read()
+    except OSError as exc:
+        logger.warning("failed to read cached OSM %s: %s", path, exc)
+        return None
+
+
+def load_or_fetch_osm_bbox(south, west, north, east, cache_dir,
+                           url=OVERPASS_URL, headers=None, timeout=180,
+                           reuse_covering=True):
+    """Return raw OSM XML for a bbox, using a gzip cache keyed by the bbox.
+
+    The cache is shared by both map branches. Because they request different
+    margins, a request is also served by any *already cached* XML whose bbox
+    fully contains it (``reuse_covering``) — so e.g. the SD-map branch reuses
+    the renderer's larger fetch for the same area instead of downloading again.
+
+    Returns the XML text, or ``None`` if the fetch fails.
+    """
+    cache_dir = Path(cache_dir) if cache_dir is not None else None
+    req = (south, west, north, east)
+
+    if cache_dir is not None and cache_dir.exists():
+        exact = cache_dir / _bbox_cache_name(*req)
+        if exact.exists():
+            xml = _read_gz(exact)
+            if xml is not None:
+                return xml
+        if reuse_covering:
+            for p in cache_dir.glob(f"{_BBOX_PREFIX}*{_BBOX_SUFFIX}"):
+                cached = _parse_bbox_name(p.name)
+                if cached is not None and _covers(cached, req):
+                    xml = _read_gz(p)
+                    if xml is not None:
+                        return xml
+
+    try:
+        xml = fetch_raw_osm(south, west, north, east, url=url, headers=headers, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 — network/Overpass failures vary
+        logger.warning("Overpass fetch bbox (%.4f, %.4f, %.4f, %.4f) failed: %s",
+                       south, west, north, east, exc)
+        return None
+
+    if cache_dir is not None:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        with gzip.open(cache_dir / _bbox_cache_name(*req), "wt", encoding="utf-8") as f:
+            f.write(xml)
+    return xml
+
+
+def load_or_fetch_osm(center_lat, center_lon, radius_m, cache_dir,
+                      url=OVERPASS_URL, headers=None, timeout=180):
+    """Centroid+radius convenience wrapper over :func:`load_or_fetch_osm_bbox`."""
+    south, west, north, east = bbox_from_center(center_lat, center_lon, radius_m)
+    return load_or_fetch_osm_bbox(south, west, north, east, cache_dir,
+                                  url=url, headers=headers, timeout=timeout)
+
+
+def load_or_fetch_osm_for_trace(latitudes, longitudes, margin_m, cache_dir,
+                                url=OVERPASS_URL, headers=None, timeout=180):
+    """Fetch raw OSM covering a whole trajectory (bbox of points + margin)."""
+    bbox = bbox_from_points(latitudes, longitudes, margin_m)
+    return load_or_fetch_osm_bbox(*bbox, cache_dir, url=url, headers=headers, timeout=timeout)

--- a/Model/data_parsing/osm_sd_map/visualize.py
+++ b/Model/data_parsing/osm_sd_map/visualize.py
@@ -1,0 +1,206 @@
+"""Visualize a tokenised ``osm_map_data`` sample (SDTagNet-style) + validate it.
+
+Renders exactly what the OSM vector encoder consumes — the resampled way
+polylines, node points, decoded tag text, and relation member links — in the
+ego frame, so you can eyeball that the data pipeline (Overpass query, ego
+projection, patch crop, tokenisation) is correct on a real OSM map. The style
+mirrors SDTagNet's ``av2_vis_pred.py`` OSM panel: highway ways green, other ways
+red, nodes blue, tags as boxed text, relation members linked by arrows to the
+relation centroid.
+
+Run directly for an end-to-end real-data check (fetch real OSM, tokenise,
+visualise, and optionally run the encoder):
+
+    python -m data_parsing.osm_sd_map.visualize \
+        --lat 48.0 --lon 8.0 --heading 0.0 \
+        --download-nlp --run-encoder --out osm_map_vis.png
+
+The encoder/tokeniser need the NLP checkpoint (``--nlp-model-path`` or
+``--download-nlp``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+
+import numpy as np
+
+
+def _decode(tokenizer, token_lists):
+    if tokenizer is None:
+        return ["" for _ in token_lists]
+    return tokenizer.batch_decode([t.tolist() for t in token_lists], skip_special_tokens=True)
+
+
+def visualize_osm_map_data(sample, pc_range, out_path, tokenizer=None,
+                           clip_text=True, title=None):
+    """Render one (single-sample) ``osm_map_data`` dict to ``out_path``.
+
+    Args:
+        sample: a per-frame dict from ``osm_tokenize.extract_osm_map_data``.
+        pc_range: ``(x_min, y_min, z_min, x_max, y_max, z_max)`` ego metres.
+        out_path: output PNG path.
+        tokenizer: HF tokenizer to decode tag tokens to text (optional; without
+            it geometry is drawn but no labels).
+        clip_text: truncate long tag strings in the figure.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    nodes_pts = sample["osm_map_nodes_pts"]
+    ways_pts = sample["osm_map_ways_pts"]
+    node_tags = _decode(tokenizer, sample["osm_map_nodes_tags_input_ids"])
+    way_tags = _decode(tokenizer, sample["osm_map_ways_tags_input_ids"])
+    rel_tags = _decode(tokenizer, sample["osm_map_relations_tags_input_ids"])
+
+    fig = plt.figure(figsize=(8, 4))
+    plt.xlim(pc_range[0], pc_range[3])
+    plt.ylim(pc_range[1], pc_range[4])
+    plt.gca().set_aspect("equal")
+    plt.axis("off")
+    if title:
+        plt.title(title, fontsize=6)
+
+    text_bbox = dict(boxstyle="square", ec=(0.3, 0.3, 0.3, 0.3), fc=(0.3, 0.3, 0.3, 0.3))
+
+    def _label(x, y, s):
+        if not s:
+            return
+        if clip_text and len(s) > 60:
+            s = s[:60] + "..."
+        plt.text(x, y, s, color="black", ha="center", va="center", fontsize=3, bbox=text_bbox)
+
+    # node labels
+    for i, s in enumerate(node_tags):
+        _label(float(nodes_pts[i][0]), float(nodes_pts[i][1]), s)
+    # way labels (placed at the last resampled point, matching SDTagNet)
+    for i, s in enumerate(way_tags):
+        _label(float(ways_pts[i][-1][0]), float(ways_pts[i][-1][1]), s)
+
+    # relation member links + label at centroid
+    node_idx = sample["osm_map_relations_node_member_indices"]
+    way_idx = sample["osm_map_relations_way_member_indices"]
+    for i, s in enumerate(rel_tags):
+        member_pts = []
+        for idx in (node_idx[i] if len(node_idx) > i else []):
+            member_pts.append(nodes_pts[idx].squeeze().numpy()[:2])
+        for idx in (way_idx[i] if len(way_idx) > i else []):
+            member_pts.append(np.average(ways_pts[idx].squeeze().numpy(), axis=0)[:2])
+        if not member_pts:
+            continue
+        member_pts = np.vstack(member_pts)
+        center = np.average(member_pts, axis=0)
+        for pt in member_pts:
+            d = center - pt
+            plt.arrow(pt[0], pt[1], d[0], d[1], color="black", linewidth=0.6, alpha=0.8, zorder=5)
+        _label(center[0], center[1], s)
+
+    # geometry
+    if nodes_pts.numel():
+        plt.scatter(nodes_pts[:, 0], nodes_pts[:, 1], linewidth=1.5, color="blue", zorder=4)
+    for i, line in enumerate(ways_pts):
+        color = "green" if "highway" in (way_tags[i] if i < len(way_tags) else "") else "red"
+        plt.plot(line[:, 0], line[:, 1], linewidth=2, alpha=0.8, color=color)
+
+    # ego marker at origin (forward = +x)
+    plt.scatter([0], [0], marker="*", s=120, color="black", zorder=6)
+    plt.arrow(0, 0, 4, 0, color="black", width=0.3, zorder=6)
+
+    plt.savefig(out_path, format="png", dpi=400, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+def _build_sample(args, tokenizer, pc_range):
+    from .osm_parser import parse
+    from .osm_tokenize import extract_osm_map_data
+    from .overpass import load_or_fetch_osm
+
+    if args.osm_file:
+        with open(args.osm_file, "r", encoding="utf-8") as f:
+            xml = f.read()
+    else:
+        xml = load_or_fetch_osm(args.lat, args.lon, args.radius, args.raw_osm_cache_dir)
+        if xml is None:
+            raise SystemExit("Overpass fetch failed and no --osm-file given.")
+
+    osm = parse(io.StringIO(xml))
+    print(f"parsed OSM: {len(osm.nodes)} nodes, {len(osm.ways)} ways, {len(osm.relations)} relations")
+    sample = extract_osm_map_data(
+        osm, args.lat, args.lon, args.heading, tokenizer, pc_range,
+        fixed_num=args.fixed_num, pts_dim=3,
+    )
+    n_nodes = sample["osm_map_nodes_pts"].shape[0]
+    n_ways = sample["osm_map_ways_pts"].shape[0]
+    n_rels = len(sample["osm_map_relations_tags_input_ids"])
+    print(f"in-patch elements: {n_nodes} nodes, {n_ways} ways, {n_rels} relations")
+    return sample
+
+
+def _run_encoder(sample, nlp_model_path, pc_range):
+    import torch
+
+    from .collate import collate_osm_batch
+    from model_components.map_encoder.osm_vector import OSMVectorMapEncoder
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    enc = OSMVectorMapEncoder(nlp_model_path=nlp_model_path, pc_range=pc_range).to(device).eval()
+    batch = collate_osm_batch([sample])
+    # Move the geometry tensors to the encoder's device (the encoder places its
+    # tag tokens on the geometry's device).
+    for key in ("osm_map_nodes_pts", "osm_map_ways_pts"):
+        batch[key] = [t.to(device) for t in batch[key]]
+    with torch.no_grad():
+        tokens, mask = enc(batch)
+    valid = int((~mask).sum().item())
+    print(f"encoder OK [{device}]: tokens {tuple(tokens.shape)}, "
+          f"valid {valid}/{mask.shape[1]}, finite={bool(torch.isfinite(tokens).all())}")
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--lat", type=float, required=True)
+    p.add_argument("--lon", type=float, required=True)
+    p.add_argument("--heading", type=float, default=0.0, help="radians, 0=north")
+    p.add_argument("--osm-file", default=None, help="local .osm XML; else fetch via Overpass")
+    p.add_argument("--radius", type=int, default=800, help="Overpass fetch radius (m)")
+    p.add_argument("--raw-osm-cache-dir", default=None)
+    p.add_argument("--nlp-model-path", default=None, help="local SentenceTransformer checkpoint dir")
+    p.add_argument("--download-nlp", action="store_true", help="download NLP weights if path missing")
+    p.add_argument("--nlp-cache-dir", default=None,
+                   help="where --download-nlp stores weights (default: <repo>/checkpoints/sdtagnet_nlp)")
+    p.add_argument("--pc-range", type=float, nargs=6,
+                   default=[-60.0, -30.0, -5.0, 60.0, 30.0, 3.0])
+    p.add_argument("--fixed-num", type=int, default=10)
+    p.add_argument("--out", default="osm_map_vis.png")
+    p.add_argument("--run-encoder", action="store_true", help="also run the encoder forward")
+    args = p.parse_args()
+
+    pc_range = tuple(args.pc_range)
+
+    nlp_path = args.nlp_model_path
+    if nlp_path is None and args.download_nlp:
+        from .nlp_download import download_nlp_weights
+        nlp_path = download_nlp_weights(
+            **({"target_dir": args.nlp_cache_dir} if args.nlp_cache_dir else {})
+        )
+    tokenizer = None
+    if nlp_path is not None:
+        from transformers import AutoTokenizer
+        tokenizer = AutoTokenizer.from_pretrained(nlp_path)
+
+    sample = _build_sample(args, tokenizer, pc_range)
+    out = visualize_osm_map_data(sample, pc_range, args.out, tokenizer=tokenizer,
+                                 title=f"OSM SD map @ ({args.lat:.5f}, {args.lon:.5f})")
+    print(f"wrote {out}")
+
+    if args.run_encoder:
+        if nlp_path is None:
+            raise SystemExit("--run-encoder needs --nlp-model-path or --download-nlp")
+        _run_encoder(sample, nlp_path, pc_range)
+
+
+if __name__ == "__main__":
+    main()

--- a/Model/data_parsing/osm_sd_map/wgs84_to_local.py
+++ b/Model/data_parsing/osm_sd_map/wgs84_to_local.py
@@ -1,0 +1,53 @@
+"""WGS84 (lat/lon) -> ego-local metric frame.
+
+Replaces SDTagNet's dataset-specific city-coordinate conversions
+(``av2_to_wgs_conversion`` / ``nusc_to_wgs_conversion``) with a generic
+equirectangular projection centered + rotated on the ego pose, so any
+GPS-bearing dataset can be used. Shares the small-window equirectangular
+approximation with ``map_rendering.gps_to_map``.
+
+Output convention matches the model's ego/BEV frame and the SDTagNet
+``pc_range`` layout: **X = forward, Y = left, Z = up** (metres).
+
+``ego_heading`` is radians, compass-style (0 = facing north, increasing toward
+east) — the same convention produced by ``map_rendering.cache._heading_from_trace``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+# WGS84 mean Earth radius (m); matches map_rendering.gps_to_map.
+EARTH_RADIUS_M = 6_378_137.0
+
+
+def wgs84_to_ego_local(latitudes, longitudes, ego_lat, ego_lon, ego_heading):
+    """Project (lat, lon) arrays into the ego-local (forward, left) frame.
+
+    Args:
+        latitudes, longitudes: array-likes of equal shape (degrees).
+        ego_lat, ego_lon: ego position (degrees).
+        ego_heading: ego heading (radians, 0 = north, +toward east).
+
+    Returns:
+        (N, 2) float array of (x_forward, y_left) in metres.
+    """
+    lats = np.asarray(latitudes, dtype=float).reshape(-1)
+    lons = np.asarray(longitudes, dtype=float).reshape(-1)
+    if lats.shape != lons.shape:
+        raise ValueError("latitudes and longitudes must have the same shape")
+
+    deg_to_m = EARTH_RADIUS_M * math.pi / 180.0
+    cos_lat = math.cos(math.radians(ego_lat))
+    east = (lons - ego_lon) * cos_lat * deg_to_m
+    north = (lats - ego_lat) * deg_to_m
+
+    sin_h = math.sin(ego_heading)
+    cos_h = math.cos(ego_heading)
+    # Ego forward unit vector in (east, north) is (sin h, cos h); left is that
+    # rotated +90 deg CCW = (-cos h, sin h).
+    x_forward = east * sin_h + north * cos_h
+    y_left = -east * cos_h + north * sin_h
+    return np.stack([x_forward, y_left], axis=1)

--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -13,6 +13,7 @@ class AutoE2E(nn.Module):
                  num_timesteps=64, num_signals=2, egomotion_dim=256,
                  visual_history_dim=896,
                  map_type="rasterized", map_in_channels=3,
+                 map_encoder_kwargs=None,
                  map_fusion_mode="residual", map_fusion_kwargs=None,
                  planner_mode="gru", planner_kwargs=None):
         super(AutoE2E, self).__init__()
@@ -31,26 +32,43 @@ class AutoE2E(nn.Module):
             view_fusion_kwargs=view_fusion_kwargs,
         )
 
-        # For BEV fusion mode the spatial size is bev_h × bev_w (potentially non-square).
-        # For concat/cross_attn it is image_feature_size × image_feature_size.
-        if fusion_mode == "bev":
-            vfk = view_fusion_kwargs or {"bev_h": 450, "bev_w": 300}
-            map_output_h = vfk["bev_h"]
-            map_output_w = vfk["bev_w"]
+        # Two map-branch flavours:
+        #   * "rasterized": a rendered map image -> spatial map BEV features that
+        #     are fused with the image BEV (residual / cross_attn).
+        #   * "osm_vector": OSM vector elements -> a token sequence that the image
+        #     BEV cross-attends to (use map_fusion_mode="osm_cross_attn").
+        # The osm_vector path takes a ragged osm_map_data dict in place of the
+        # rendered map image and needs no fixed output grid size.
+        self._osm_vector_mode = map_type == "osm_vector"
+
+        if self._osm_vector_mode:
+            self.MapEncoder = build_map_encoder(
+                map_type,
+                embed_dim=embed_dim,
+                **(map_encoder_kwargs or {}),
+            )
         else:
-            map_output_h = image_feature_size
-            map_output_w = image_feature_size
- 
-        # Map encoder: encodes the BEV nav-map image into spatial map features
-        self.MapEncoder = build_map_encoder(
-            map_type,
-            in_channels=map_in_channels,
-            embed_dim=embed_dim,
-            output_h=map_output_h,
-            output_w=map_output_w,
-        )
- 
-        # Map BEV fusion: combines image BEV features with map BEV features
+            # For BEV fusion mode the spatial size is bev_h × bev_w (potentially
+            # non-square). For concat/cross_attn it is image_feature_size².
+            if fusion_mode == "bev":
+                vfk = view_fusion_kwargs or {"bev_h": 450, "bev_w": 300}
+                map_output_h = vfk["bev_h"]
+                map_output_w = vfk["bev_w"]
+            else:
+                map_output_h = image_feature_size
+                map_output_w = image_feature_size
+
+            # Map encoder: encodes the BEV nav-map image into spatial map features
+            self.MapEncoder = build_map_encoder(
+                map_type,
+                in_channels=map_in_channels,
+                embed_dim=embed_dim,
+                output_h=map_output_h,
+                output_w=map_output_w,
+                **(map_encoder_kwargs or {}),
+            )
+
+        # Map BEV fusion: combines image BEV features with map features
         self.MapBEVFusion = build_map_bev_fusion(
             map_fusion_mode,
             embed_dim=embed_dim,
@@ -110,10 +128,15 @@ class AutoE2E(nn.Module):
         image_bev = self.FeatureFusion(features, B, V, camera_params=camera_params)
 
         # --- Map branch ---
-        map_bev = self.MapEncoder(map_input)
-
-        # --- Fuse image BEV + map BEV ---
-        fused_features = self.MapBEVFusion(image_bev, map_bev)
+        # In osm_vector mode, map_input is the ragged osm_map_data dict and the
+        # encoder returns (tokens, key_padding_mask) which the BEV cross-attends
+        # to. Otherwise map_input is a rendered map image -> spatial map BEV.
+        if self._osm_vector_mode:
+            osm_tokens, osm_key_padding_mask = self.MapEncoder(map_input)
+            fused_features = self.MapBEVFusion(image_bev, osm_tokens, osm_key_padding_mask)
+        else:
+            map_bev = self.MapEncoder(map_input)
+            fused_features = self.MapBEVFusion(image_bev, map_bev)
 
         if mode == "train":
             if trajectory_target is None:

--- a/Model/model_components/map_encoder/__init__.py
+++ b/Model/model_components/map_encoder/__init__.py
@@ -1,9 +1,11 @@
 import torch.nn as nn
 from .raster_map_encoder import RasterizedMapEncoder
+from .osm_vector import OSMVectorMapEncoder
 from .map_bev_fusion import MAP_FUSION_REGISTRY, build_map_bev_fusion
 
 MAP_ENCODER_REGISTRY = {
     "rasterized": RasterizedMapEncoder,
+    "osm_vector": OSMVectorMapEncoder,
 }
 
 
@@ -31,4 +33,5 @@ __all__ = [
     "build_map_encoder",
     "build_map_bev_fusion",
     "RasterizedMapEncoder",
+    "OSMVectorMapEncoder",
 ]

--- a/Model/model_components/map_encoder/map_bev_fusion/__init__.py
+++ b/Model/model_components/map_encoder/map_bev_fusion/__init__.py
@@ -1,9 +1,11 @@
 from .residual_fusion import ResidualMapFusion
 from .cross_attention_fusion import MapCrossAttentionFusion
+from .osm_cross_attn_fusion import OSMCrossAttnFusion
 
 MAP_FUSION_REGISTRY = {
     "residual": ResidualMapFusion,
     "cross_attn": MapCrossAttentionFusion,
+    "osm_cross_attn": OSMCrossAttnFusion,
 }
 
 

--- a/Model/model_components/map_encoder/map_bev_fusion/osm_cross_attn_fusion.py
+++ b/Model/model_components/map_encoder/map_bev_fusion/osm_cross_attn_fusion.py
@@ -1,0 +1,123 @@
+"""Token cross-attention fusion of OSM vector features into the image BEV.
+
+Each BEV cell attends to the SD-map token sequence produced by
+``OSMVectorMapEncoder``. Unlike ``MapCrossAttentionFusion`` (which fuses two
+spatial grids), the keys/values here are a *variable-length, padded token set*,
+so this module:
+
+  * uses ``F.scaled_dot_product_attention`` (flash / mem-efficient backend) so
+    the full BEV grid (e.g. 450x300 = 135k queries) never materialises a
+    ``Q x K`` weight matrix,
+  * honours the encoder's ``key_padding_mask`` (padded tokens are ignored),
+  * prepends a learnable null token so a sample with no OSM elements (all keys
+    masked) still has one valid key and cannot produce NaNs,
+  * gates the map contribution with a per-channel parameter initialised to zero,
+    so at the start of training the output equals ``image_bev`` exactly (same
+    convention as ``ResidualMapFusion``).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class OSMCrossAttnFusion(nn.Module):
+    """Fuse OSM map tokens into image BEV via masked cross-attention.
+
+    Args:
+        embed_dim: Channel dimension of the BEV features and map tokens.
+        num_heads: Number of attention heads. Must divide ``embed_dim``.
+        dropout: Dropout on attention weights (train only) and in the FFN.
+    """
+
+    def __init__(self, embed_dim: int = 256, num_heads: int = 8, dropout: float = 0.1) -> None:
+        super().__init__()
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})."
+            )
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.dropout = dropout
+
+        self.norm_q = nn.LayerNorm(embed_dim)
+        self.norm_kv = nn.LayerNorm(embed_dim)
+        self.q_proj = nn.Linear(embed_dim, embed_dim)
+        self.k_proj = nn.Linear(embed_dim, embed_dim)
+        self.v_proj = nn.Linear(embed_dim, embed_dim)
+        self.out_proj = nn.Linear(embed_dim, embed_dim)
+
+        self.ffn = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim * 2),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(embed_dim * 2, embed_dim),
+            nn.Dropout(dropout),
+        )
+        self.norm_ffn = nn.LayerNorm(embed_dim)
+
+        # Learnable "no map information" key so attention always has a valid key.
+        self.null_token = nn.Parameter(torch.zeros(1, 1, embed_dim))
+        nn.init.normal_(self.null_token, std=0.02)
+
+        # Per-channel gate, zero-initialised: map has no effect at training start.
+        self.alpha = nn.Parameter(torch.zeros(embed_dim))
+
+    def _heads(self, x: torch.Tensor) -> torch.Tensor:
+        # (B, L, C) -> (B, num_heads, L, head_dim)
+        B, L, _ = x.shape
+        return x.view(B, L, self.num_heads, self.head_dim).transpose(1, 2)
+
+    def forward(
+        self,
+        image_bev: torch.Tensor,
+        osm_tokens: torch.Tensor,
+        key_padding_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Args:
+            image_bev: (B, embed_dim, H, W) — queries.
+            osm_tokens: (B, N, embed_dim) — SD-map tokens (keys/values).
+            key_padding_mask: (B, N) bool, ``True`` at padded tokens. ``None``
+                treats all tokens as valid.
+
+        Returns:
+            (B, embed_dim, H, W) image BEV updated with SD-map context.
+        """
+        B, C, H, W = image_bev.shape
+
+        q = image_bev.permute(0, 2, 3, 1).reshape(B, H * W, C)
+
+        # Prepend the always-valid null token to keys/values.
+        null = self.null_token.expand(B, -1, -1)
+        kv = torch.cat([null, osm_tokens], dim=1)
+        kv = self.norm_kv(kv)
+
+        if key_padding_mask is not None:
+            null_valid = torch.zeros((B, 1), dtype=torch.bool, device=kv.device)
+            padding = torch.cat([null_valid, key_padding_mask], dim=1)  # (B, N+1)
+            # SDPA bool mask: True = participate. Invert padding, broadcast over
+            # heads and queries -> (B, 1, 1, N+1).
+            attn_mask = (~padding)[:, None, None, :]
+        else:
+            attn_mask = None
+
+        qh = self._heads(self.q_proj(self.norm_q(q)))
+        kh = self._heads(self.k_proj(kv))
+        vh = self._heads(self.v_proj(kv))
+
+        attn = F.scaled_dot_product_attention(
+            qh, kh, vh, attn_mask=attn_mask,
+            dropout_p=self.dropout if self.training else 0.0,
+        )  # (B, num_heads, H*W, head_dim)
+        attn = attn.transpose(1, 2).reshape(B, H * W, C)
+        attn = self.out_proj(attn)
+
+        # Map-derived context (attention + FFN), gated to zero at init.
+        h = attn + self.ffn(self.norm_ffn(attn))
+        out = q + self.alpha * h
+
+        return out.reshape(B, H, W, C).permute(0, 3, 1, 2).contiguous()

--- a/Model/model_components/map_encoder/osm_vector/__init__.py
+++ b/Model/model_components/map_encoder/osm_vector/__init__.py
@@ -1,0 +1,3 @@
+from .osm_map_encoder import OSMVectorMapEncoder, SineContinuousPositionalEncoding
+
+__all__ = ["OSMVectorMapEncoder", "SineContinuousPositionalEncoding"]

--- a/Model/model_components/map_encoder/osm_vector/osm_map_encoder.py
+++ b/Model/model_components/map_encoder/osm_vector/osm_map_encoder.py
@@ -1,0 +1,392 @@
+"""Point-level SD-map (OpenStreetMap) vector encoder.
+
+Ported from SDTagNet (`OSMMapEncoderPointLevel`, NeurIPS 2025) and stripped of
+its mmdetection3d / mmcv dependencies and ablation-only code paths. Only the
+canonical configuration is kept:
+
+  * point-level tokens (every way point and node is its own token),
+  * NLP tag embeddings from a SentenceTransformer (text annotations),
+  * orthogonal random feature (ORF) graph identifiers with a fixed member
+    ordering (``fixed_orf_order=True``, ``use_orf_graph_ident=True``),
+  * a continuous sine positional encoding of the point geometry.
+
+Dropped from the original: the SMERF one-hot-class baseline, the P-MapNet BEV
+mode, ``render_bev_feats`` / ``draw_*`` rasterisation, ``use_queries_for_bev``,
+learned positional encoding, the non-ORF relation expansion branch, and the
+way-level ``OSMMapEncoder`` variant.
+
+The encoder consumes the ragged ``osm_map_data`` dict produced by
+``data_parsing.osm_sd_map`` (see that package for the exact contract) and
+returns a padded token sequence plus a key-padding mask:
+
+    tokens, key_padding_mask = encoder(osm_map_data)
+    # tokens:           (B, N_max, embed_dim)
+    # key_padding_mask: (B, N_max)  True where padded (no real element)
+
+These feed the token cross-attention map fusion (``osm_cross_attn``).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# ---------------------------------------------------------------------------
+# Orthogonal random feature (ORF) graph identifiers
+# ---------------------------------------------------------------------------
+
+@torch.no_grad()
+def _orthogonal_matrix_chunk(cols, device=None):
+    unstructured_block = torch.randn((cols, cols), device=device)
+    q, _ = torch.linalg.qr(unstructured_block, mode="reduced")
+    return q.t()
+
+
+@torch.no_grad()
+def gaussian_orthogonal_random_matrix(nb_rows, nb_columns, device=None):
+    """Create a 2D Gaussian orthogonal matrix of shape (nb_rows, nb_columns)."""
+    nb_full_blocks = int(nb_rows / nb_columns)
+
+    block_list = []
+    for _ in range(nb_full_blocks):
+        block_list.append(_orthogonal_matrix_chunk(nb_columns, device=device))
+
+    remaining_rows = nb_rows - nb_full_blocks * nb_columns
+    if remaining_rows > 0:
+        q = _orthogonal_matrix_chunk(nb_columns, device=device)
+        block_list.append(q[:remaining_rows])
+
+    final_matrix = torch.cat(block_list)
+    normalizer = final_matrix.norm(p=2, dim=1, keepdim=True)
+    normalizer[normalizer == 0] = 1e-5
+    return final_matrix / normalizer
+
+
+# ---------------------------------------------------------------------------
+# Continuous sine positional encoding (geometry)
+# ---------------------------------------------------------------------------
+
+class SineContinuousPositionalEncoding(nn.Module):
+    """Sine positional encoding of continuous coordinates.
+
+    Maps ``(B, N, D)`` point coordinates to ``(B, N, D * num_feats)``. With
+    ``normalize=True`` the input is first shifted by ``offset`` and scaled by
+    ``range`` (per coordinate) into ``[0, scale]``.
+    """
+
+    def __init__(self, num_feats, temp=10000, normalize=False, range=None,
+                 offset=0.0, scale=2 * torch.pi):
+        super().__init__()
+        self.num_feats = num_feats
+        self.temp = temp
+        self.normalize = normalize
+        self.register_buffer(
+            "range",
+            torch.tensor(range, dtype=torch.float32) if range is not None else None,
+            persistent=False,
+        )
+        self.register_buffer(
+            "offset",
+            torch.tensor(offset, dtype=torch.float32) if offset is not None else None,
+            persistent=False,
+        )
+        self.scale = scale
+
+    def forward(self, x):
+        B, N, D = x.shape
+        if self.normalize:
+            x = (x - self.offset.to(x.device)) / self.range.to(x.device) * self.scale
+        dim_t = torch.arange(self.num_feats, dtype=torch.float32, device=x.device)
+        dim_t = self.temp ** (2 * (dim_t // 2) / self.num_feats)
+        pos_x = x[..., None] / dim_t  # [B, N, D, num_feats]
+        pos_x = torch.stack(
+            (pos_x[:, :, :, 0::2].sin(), pos_x[:, :, :, 1::2].cos()), dim=3
+        ).view(B, N, D * self.num_feats)
+        return pos_x
+
+
+# ---------------------------------------------------------------------------
+# Encoder
+# ---------------------------------------------------------------------------
+
+class OSMVectorMapEncoder(nn.Module):
+    """Encode OSM vector elements into a transformer token sequence.
+
+    Args:
+        embed_dim: Output token dimension (and transformer width).
+        input_dim: Dimension of a raw token before ``map_embedding``. Must
+            equal ``pts_dim * pos_num_feats + nlp_embed_dim + 2 * orf_dim``.
+        hidden_dim: Transformer feedforward dimension.
+        orf_dim: ORF graph-identifier dimension (per element; tiled x2 per
+            token so it contributes ``2 * orf_dim`` channels).
+        nlp_model_path: Local path to the SentenceTransformer tag encoder.
+            Required. Use ``data_parsing.osm_sd_map.download_nlp_weights`` to
+            fetch it from HuggingFace if you don't have it locally.
+        nlp_embed_dim: Output dimension of the SentenceTransformer.
+        nheads / nlayers: Transformer encoder depth/width.
+        nlp_pad_token / nlp_max_tokens: tag tokenizer padding value / cap.
+        pos_num_feats / pos_temp / pc_range: configure the geometry positional
+            encoding. ``pc_range`` is ``(x_min, y_min, z_min, x_max, y_max,
+            z_max)`` in ego metres; coordinates are normalised into it.
+        pts_dim: Coordinate dimension (3 = xyz, 2 = xy). Must match the data.
+    """
+
+    def __init__(self,
+                 embed_dim=256,
+                 input_dim=320,
+                 hidden_dim=256,
+                 orf_dim=64,
+                 nlp_model_path=None,
+                 nlp_model=None,
+                 nlp_embed_dim=144,
+                 nheads=4,
+                 nlayers=6,
+                 nlp_pad_token=0,
+                 nlp_max_tokens=256,
+                 pos_num_feats=16,
+                 pos_temp=1000,
+                 pc_range=(-60.0, -30.0, -5.0, 60.0, 30.0, 3.0),
+                 pts_dim=3):
+        super().__init__()
+
+        self.embed_dim = embed_dim
+        self.input_dim = input_dim
+        self.orf_dim = orf_dim
+        self.nlp_embed_dim = nlp_embed_dim
+        self.nlp_pad_token = nlp_pad_token
+        self.nlp_max_tokens = nlp_max_tokens
+        self.pts_dim = pts_dim
+
+        expected_input = pts_dim * pos_num_feats + nlp_embed_dim + 2 * orf_dim
+        if input_dim != expected_input:
+            raise ValueError(
+                f"input_dim={input_dim} is inconsistent with "
+                f"pts_dim*pos_num_feats + nlp_embed_dim + 2*orf_dim = "
+                f"{pts_dim}*{pos_num_feats} + {nlp_embed_dim} + 2*{orf_dim} = "
+                f"{expected_input}."
+            )
+
+        self.map_embedding = nn.Linear(input_dim, embed_dim)
+
+        # Geometry positional encoding, normalised into pc_range.
+        self.pos_encoder = SineContinuousPositionalEncoding(
+            num_feats=pos_num_feats,
+            temp=pos_temp,
+            normalize=True,
+            range=[pc_range[3] - pc_range[0],
+                   pc_range[4] - pc_range[1],
+                   pc_range[5] - pc_range[2]][:pts_dim],
+            offset=[pc_range[0], pc_range[1], pc_range[2]][:pts_dim],
+        )
+
+        # The NLP tag encoder embeds OSM tag strings. Either inject a pre-built
+        # module (``nlp_model``, e.g. for tests) or give a local checkpoint path
+        # (``nlp_model_path``); the SentenceTransformer import is lazy so the
+        # heavy NLP stack is only required when actually loading from a path.
+        if nlp_model is not None:
+            self.nlp_model = nlp_model
+        elif nlp_model_path is not None:
+            from sentence_transformers import SentenceTransformer
+            # Force CPU at construction: SentenceTransformer otherwise auto-moves
+            # itself to CUDA, leaving this module split across devices until
+            # `.to(...)` is called. Constructing on CPU keeps it single-device
+            # (standard nn.Module behaviour) so `encoder.to(device)` moves
+            # everything — including the NLP model — together.
+            self.nlp_model = SentenceTransformer(nlp_model_path, device="cpu")
+        else:
+            raise ValueError(
+                "Provide nlp_model_path (download via "
+                "data_parsing.osm_sd_map.download_nlp_weights) or an explicit "
+                "nlp_model module."
+            )
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=embed_dim, nhead=nheads, dim_feedforward=hidden_dim,
+            batch_first=True,
+        )
+        self.transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=nlayers)
+
+    # -- helpers -----------------------------------------------------------
+
+    @staticmethod
+    def _num_nodes(osm_map_data, b_idx):
+        nodes_pts = osm_map_data["osm_map_nodes_pts"][b_idx]
+        if not nodes_pts.numel():
+            return 0
+        if nodes_pts.dim() == 1:
+            osm_map_data["osm_map_nodes_pts"][b_idx] = nodes_pts.unsqueeze(0)
+            return 1
+        return len(nodes_pts)
+
+    def _counts(self, osm_map_data, b_idx):
+        num_nodes = self._num_nodes(osm_map_data, b_idx)
+        num_ways, num_way_pts, pts_dim = osm_map_data["osm_map_ways_pts"][b_idx].shape
+        num_rels = len(osm_map_data["osm_map_relations_tags_input_ids"][b_idx])
+        num_rel_node = sum(len(m) for m in osm_map_data["osm_map_relations_node_member_indices"][b_idx])
+        num_rel_way = sum(len(m) for m in osm_map_data["osm_map_relations_way_member_indices"][b_idx])
+        num_rel_rel = sum(len(m) for m in osm_map_data["osm_map_relations_relation_member_indices"][b_idx])
+        total = (num_nodes + num_ways * num_way_pts + num_rels
+                 + num_rel_node + num_rel_way + num_rel_rel)
+        return num_nodes, num_ways, num_way_pts, pts_dim, num_rels, total
+
+    def add_orf_identifiers(self, map_features, osm_map_data, b_idx):
+        """Append ORF graph identifiers (fixed member order) to each token."""
+        num_nodes, num_ways, num_way_pts, _, num_rels, _ = self._counts(osm_map_data, b_idx)
+        device = osm_map_data["osm_map_ways_pts"][b_idx].device
+
+        n_orf = num_nodes + num_ways + num_rels
+        orf_mat = gaussian_orthogonal_random_matrix(n_orf, n_orf, device=device)
+        if n_orf < self.orf_dim:
+            orf_ident = F.pad(orf_mat, (0, self.orf_dim - n_orf), "constant", 0)
+        else:
+            orf_ident = orf_mat[:, :self.orf_dim]
+
+        orf_tiled = torch.tile(orf_ident, (1, 2))
+
+        # Element-level identifiers: nodes, then ways expanded per way point.
+        orf_idents = [torch.cat([
+            orf_tiled[:num_nodes],
+            torch.repeat_interleave(orf_tiled[num_nodes:num_nodes + num_ways], num_way_pts, dim=0),
+            orf_tiled[num_nodes + num_ways:],
+        ], dim=0)]
+
+        # Relation member identifiers (fixed order: all node members of all
+        # relations, then all way members, then all relation members). Each is
+        # [relation_ident | member_ident].
+        node_idx = osm_map_data["osm_map_relations_node_member_indices"][b_idx]
+        way_idx = osm_map_data["osm_map_relations_way_member_indices"][b_idx]
+        rel_idx = osm_map_data["osm_map_relations_relation_member_indices"][b_idx]
+
+        for i in range(num_rels):
+            for member in node_idx[i]:
+                if member.numel():
+                    orf_idents.append(torch.cat([
+                        orf_ident[num_nodes + num_ways + i],
+                        orf_ident[member.to(torch.long)],
+                    ]).unsqueeze(0))
+        for i in range(num_rels):
+            for member in way_idx[i]:
+                if member.numel():
+                    orf_idents.append(torch.cat([
+                        orf_ident[num_nodes + num_ways + i],
+                        orf_ident[num_nodes + member.to(torch.long)],
+                    ]).unsqueeze(0))
+        for i in range(num_rels):
+            for member in rel_idx[i]:
+                if member.numel():
+                    orf_idents.append(torch.cat([
+                        orf_ident[num_nodes + num_ways + i],
+                        orf_ident[num_nodes + num_ways + member.to(torch.long)],
+                    ]).unsqueeze(0))
+
+        orf_idents = torch.cat(orf_idents)
+        return torch.cat([map_features, orf_idents], dim=1)
+
+    def get_nlp_model_input(self, osm_map_data, b_idx):
+        """Assemble + pad the tag token tensors for one sample's elements.
+
+        Order matches the geometry/embedding layout: nodes, ways, relations,
+        then flattened relation node/way/relation members.
+        """
+        def flatten(nested):
+            return [x for xs in nested for x in xs]
+
+        out = {"input_ids": [], "token_type_ids": [], "attention_mask": []}
+        d = osm_map_data
+        for key in out:
+            out[key].extend(d[f"osm_map_nodes_tags_{key}"][b_idx])
+            out[key].extend(d[f"osm_map_ways_tags_{key}"][b_idx])
+            out[key].extend(d[f"osm_map_relations_tags_{key}"][b_idx])
+            out[key].extend(flatten(d[f"osm_map_relations_node_member_tags_{key}"][b_idx]))
+            out[key].extend(flatten(d[f"osm_map_relations_way_member_tags_{key}"][b_idx]))
+            out[key].extend(flatten(d[f"osm_map_relations_relation_member_tags_{key}"][b_idx]))
+
+        device = d["osm_map_ways_pts"][b_idx].device
+        for key in out:
+            seq = [el if len(el) > 0 else torch.tensor([], dtype=torch.long, device=device)
+                   for el in out[key]]
+            # Tag tokens may arrive on CPU (only geometry is moved to device by
+            # the data loader); move the padded batch to the encoder's device so
+            # the NLP model sees device-consistent input.
+            out[key] = nn.utils.rnn.pad_sequence(
+                seq, batch_first=True, padding_value=self.nlp_pad_token
+            )[..., :self.nlp_max_tokens].to(device)
+        return out
+
+    def build_map_features(self, osm_map_data):
+        """Build the per-sample raw token matrices and their valid lengths."""
+        map_features = []
+        lengths = []
+        B = len(osm_map_data["osm_map_ways_pts"])
+
+        for b_idx in range(B):
+            num_nodes, num_ways, num_way_pts, pts_dim, _, total = self._counts(
+                osm_map_data, b_idx
+            )
+            device = osm_map_data["osm_map_ways_pts"][b_idx].device
+            dtype = osm_map_data["osm_map_ways_pts"][b_idx].dtype
+
+            # A sample with no OSM elements contributes an all-padding row block;
+            # skip the NLP/ORF work (both choke on zero elements) and let the
+            # key-padding mask gate it out downstream.
+            if total == 0:
+                map_features.append(torch.zeros((0, self.input_dim), device=device, dtype=torch.float32))
+                lengths.append(0)
+                continue
+
+            # Geometry: one row per node + one row per way point.
+            geom = torch.zeros((num_nodes + num_ways * num_way_pts, pts_dim),
+                               device=device, dtype=dtype)
+            if num_nodes:
+                geom[:num_nodes, :] = osm_map_data["osm_map_nodes_pts"][b_idx]
+            if num_ways:
+                geom[num_nodes:, :] = osm_map_data["osm_map_ways_pts"][b_idx].view(
+                    num_ways * num_way_pts, pts_dim
+                )
+
+            # NLP tag embeddings for every element (+ relation members).
+            nlp_input = self.get_nlp_model_input(osm_map_data, b_idx)
+            embeddings = self.nlp_model.forward(nlp_input)["sentence_embedding"]
+
+            map_feat = self.pos_encoder(geom.unsqueeze(0)).squeeze(0)
+            # Pad geometry rows up to total token count (member/relation tokens
+            # carry no geometry of their own).
+            map_feat = F.pad(map_feat, (0, 0, 0, total - map_feat.shape[0]), "constant", 0)
+
+            emb_query = torch.cat([
+                embeddings[:num_nodes],
+                torch.repeat_interleave(embeddings[num_nodes:num_nodes + num_ways], num_way_pts, dim=0),
+                embeddings[num_nodes + num_ways:],
+            ], dim=0)
+            map_feat = torch.cat([map_feat, emb_query], dim=1)
+            map_feat = self.add_orf_identifiers(map_feat, osm_map_data, b_idx)
+
+            map_features.append(map_feat)
+            lengths.append(total)
+
+        padded = nn.utils.rnn.pad_sequence(map_features, batch_first=True, padding_value=0)
+        return padded.to(torch.float32), lengths
+
+    def forward(self, osm_map_data):
+        """Encode OSM data into a padded token sequence + key-padding mask.
+
+        Returns:
+            tokens: ``(B, N_max, embed_dim)``.
+            key_padding_mask: ``(B, N_max)`` bool, ``True`` at padded positions.
+        """
+        map_features, lengths = self.build_map_features(osm_map_data)
+        map_features = self.map_embedding(map_features)
+        # Note: like the original SDTagNet encoder we do NOT mask the self-attention
+        # here — padded tokens are gated out downstream via key_padding_mask. The
+        # transformer is skipped only in the degenerate all-empty case (N_max == 0).
+        if map_features.shape[1] > 0:
+            map_features = self.transformer_encoder(map_features)
+
+        B, N_max, _ = map_features.shape
+        key_padding_mask = torch.ones((B, N_max), dtype=torch.bool, device=map_features.device)
+        for b, n in enumerate(lengths):
+            if n:
+                key_padding_mask[b, :n] = False
+        return map_features, key_padding_mask

--- a/Model/tests/conftest.py
+++ b/Model/tests/conftest.py
@@ -78,13 +78,17 @@ class MockBackbone(nn.Module):
 
 def _build_model_with_mock_backbone(num_views, fusion_mode, device,
                                     num_timesteps=64, map_fusion_mode="residual",
-                                    planner_mode="gru", planner_kwargs=None):
+                                    planner_mode="gru", planner_kwargs=None,
+                                    **model_kwargs):
     """Construct AutoE2E with the mock backbone injected.
 
     Patches Backbone at the module level during construction to avoid
     loading pretrained weights entirely. Forces BEV fusion to a small
     8x8 grid so tests stay fast and memory-light; the production default
     (450x300) is exercised by dedicated configuration tests.
+
+    Extra ``model_kwargs`` (e.g. ``map_type``, ``map_encoder_kwargs``) are
+    forwarded to ``AutoE2E`` for map-branch variants.
     """
     from unittest.mock import patch
     from model_components.auto_e2e import AutoE2E
@@ -100,6 +104,7 @@ def _build_model_with_mock_backbone(num_views, fusion_mode, device,
             planner_mode=planner_mode,
             planner_kwargs=planner_kwargs,
             map_fusion_mode=map_fusion_mode,
+            **model_kwargs,
         )
     return model.to(device)
 

--- a/Model/tests/test_osm_sd_map_data.py
+++ b/Model/tests/test_osm_sd_map_data.py
@@ -1,0 +1,222 @@
+"""Tests for the OSM SD-map data pipeline (coords, parser, tokenizer, overpass query).
+
+shapely-dependent tests are skipped when shapely is unavailable. The HF download
+and live Overpass fetch are not exercised (network); only the pure query/bbox
+construction and offline parsing/tokenisation are tested.
+"""
+
+import io
+import math
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.append('..')
+
+from data_parsing.osm_sd_map.wgs84_to_local import wgs84_to_ego_local
+from data_parsing.osm_sd_map.overpass import build_query, bbox_from_center
+
+
+class TestWGS84ToLocal:
+    def test_ego_at_origin(self):
+        out = wgs84_to_ego_local([48.0], [8.0], 48.0, 8.0, 0.0)
+        assert np.allclose(out, [[0.0, 0.0]], atol=1e-6)
+
+    def test_north_is_forward_when_heading_north(self):
+        # A point due north of ego, heading north -> +x (forward), ~0 y.
+        out = wgs84_to_ego_local([48.001], [8.0], 48.0, 8.0, 0.0)
+        assert out[0, 0] > 1.0  # forward positive
+        assert abs(out[0, 1]) < 1e-3  # no lateral
+
+    def test_west_is_left_when_heading_north(self):
+        # A point due west, heading north -> left (+y), ~0 forward.
+        out = wgs84_to_ego_local([48.0], [7.999], 48.0, 8.0, 0.0)
+        assert out[0, 1] > 1.0  # left positive
+        assert abs(out[0, 0]) < 1e-3
+
+    def test_heading_rotates_frame(self):
+        # Heading east: a point due north is now to the ego's left (+y) and
+        # straight ahead is east, so forward (x) of a northern point is ~0.
+        out = wgs84_to_ego_local([48.001], [8.0], 48.0, 8.0, math.pi / 2)
+        assert out[0, 1] > 1.0          # north is on the left when facing east
+        assert abs(out[0, 0]) < 1e-3    # north is not ahead when facing east
+
+
+class TestOverpassQuery:
+    def test_query_is_exact_tested_string(self):
+        q = build_query(1.0, 2.0, 3.0, 4.0)
+        assert q == ("(node(1.0,2.0,3.0,4.0); rel(bn)->.x; way(1.0,2.0,3.0,4.0); "
+                     "node(w)->.x; rel(bw);); out meta;")
+
+    def test_bbox_order_and_span(self):
+        s, w, n, e = bbox_from_center(48.0, 8.0, 800)
+        assert s < 48.0 < n and w < 8.0 < e
+
+
+class TestTraceBboxCache:
+    def test_bbox_from_points_covers_all_points(self):
+        from data_parsing.osm_sd_map.overpass import bbox_from_points
+        lats, lons = [48.0, 48.01, 47.995], [8.0, 8.02, 7.99]
+        s, w, n, e = bbox_from_points(lats, lons, margin_m=100)
+        assert s < min(lats) and n > max(lats)
+        assert w < min(lons) and e > max(lons)
+
+    def test_patch_reach_is_corner_distance(self):
+        from data_parsing.osm_sd_map.cache import patch_reach_m
+        r = patch_reach_m((-60.0, -30.0, -5.0, 60.0, 30.0, 3.0), buffer_m=0.0)
+        assert abs(r - (60.0 ** 2 + 30.0 ** 2) ** 0.5) < 1e-6
+
+    def test_containment_reuse_avoids_fetch(self, tmp_path):
+        import gzip
+        from unittest import mock
+        from data_parsing.osm_sd_map import overpass
+
+        # Pre-populate a large covering bbox cache file.
+        big = (47.99, 7.99, 48.02, 8.03)
+        with gzip.open(tmp_path / overpass._bbox_cache_name(*big), "wt", encoding="utf-8") as f:
+            f.write("<osm>COVER</osm>")
+
+        # A request fully inside the cached bbox must reuse it (no network).
+        def _boom(*a, **k):
+            raise AssertionError("fetch_raw_osm should not be called on a cache hit")
+
+        with mock.patch.object(overpass, "fetch_raw_osm", _boom):
+            xml = overpass.load_or_fetch_osm_bbox(48.0, 8.0, 48.005, 8.01, tmp_path)
+        assert xml == "<osm>COVER</osm>"
+
+    def test_fetch_then_reuse(self, tmp_path):
+        from unittest import mock
+        from data_parsing.osm_sd_map import overpass
+
+        with mock.patch.object(overpass, "fetch_raw_osm", lambda *a, **k: "<osm>NEW</osm>"):
+            first = overpass.load_or_fetch_osm_bbox(10.0, 10.0, 10.002, 10.002, tmp_path)
+        assert first == "<osm>NEW</osm>"
+
+        # A contained request reuses the just-written file without fetching.
+        def _boom(*a, **k):
+            raise AssertionError("should reuse covering cache, not fetch")
+
+        with mock.patch.object(overpass, "fetch_raw_osm", _boom):
+            second = overpass.load_or_fetch_osm_bbox(10.0005, 10.0005, 10.001, 10.001, tmp_path)
+        assert second == "<osm>NEW</osm>"
+
+
+_OSM_XML = """<?xml version='1.0'?>
+<osm version='0.6'>
+  <node id='1' lat='48.0000' lon='8.0000'><tag k='highway' v='traffic_signals'/></node>
+  <node id='2' lat='48.0002' lon='8.0000'/>
+  <node id='3' lat='48.0002' lon='8.0003'/>
+  <way id='10'>
+    <nd ref='2'/><nd ref='3'/>
+    <tag k='highway' v='residential'/><tag k='name' v='Test St'/>
+  </way>
+  <relation id='100'>
+    <member type='way' ref='10' role='street'/>
+    <member type='node' ref='1' role='sign'/>
+    <tag k='type' v='associatedStreet'/>
+  </relation>
+</osm>
+"""
+
+
+class _FakeTokenizer:
+    """Minimal HF-tokenizer-like callable returning a dict of lists."""
+
+    def __call__(self, strings, padding=True):
+        ids = [[1] + [ord(c) % 50 + 2 for c in s[:6]] for s in strings]
+        maxlen = max((len(x) for x in ids), default=0)
+        ids = [x + [0] * (maxlen - len(x)) for x in ids]
+        return {
+            "input_ids": ids,
+            "token_type_ids": [[0] * len(x) for x in ids],
+            "attention_mask": [[1 if t else 0 for t in x] for x in ids],
+        }
+
+
+class TestParserAndTokenize:
+    def test_parse_and_extract(self):
+        pytest.importorskip("shapely")
+        from data_parsing.osm_sd_map.osm_parser import parse
+        from data_parsing.osm_sd_map.osm_tokenize import extract_osm_map_data
+
+        osm = parse(io.StringIO(_OSM_XML))
+        assert len(osm.nodes) == 3 and len(osm.ways) == 1 and len(osm.relations) == 1
+
+        pc_range = (-60.0, -30.0, -5.0, 60.0, 30.0, 3.0)
+        sample = extract_osm_map_data(
+            osm, ego_lat=48.0001, ego_lon=8.00015, ego_heading=0.0,
+            tokenizer=_FakeTokenizer(), pc_range=pc_range, fixed_num=10, pts_dim=3,
+        )
+        # geometry tensors
+        assert sample["osm_map_ways_pts"].shape[1:] == (10, 3)
+        assert sample["osm_map_nodes_pts"].shape[-1] == 3
+        # tag token lists exist and are 1D long tensors
+        for t in sample["osm_map_ways_tags_input_ids"]:
+            assert t.dtype.is_floating_point is False and t.dim() == 1
+
+
+class _RoundTripTokenizer:
+    """Char-level reversible tokenizer (2=CLS, 3=SEP, 0=PAD) so tag text
+    survives encode -> decode for a realistic visualisation check."""
+
+    def __call__(self, strings, padding=True):
+        ids = [[2] + [ord(c) for c in s] + [3] for s in strings]
+        maxlen = max((len(x) for x in ids), default=0)
+        ids = [x + [0] * (maxlen - len(x)) for x in ids]
+        return {
+            "input_ids": ids,
+            "token_type_ids": [[0] * len(x) for x in ids],
+            "attention_mask": [[1 if t else 0 for t in x] for x in ids],
+        }
+
+    def batch_decode(self, id_lists, skip_special_tokens=True):
+        return ["".join(chr(i) for i in ids if i not in (0, 2, 3)) for ids in id_lists]
+
+
+def _realistic_elements():
+    """A small but realistic in-patch OSM scene in the ego (forward, left) frame."""
+    from shapely.geometry import LineString
+
+    return dict(
+        # a traffic signal 8 m ahead, 3 m left
+        osm_map_nodes_pts=np.array([[8.0, 3.0]]),
+        osm_map_nodes_tags=["highway: traffic_signals, "],
+        # a main road ahead and a crossing side road
+        osm_map_ways_pts=[
+            LineString([(-40.0, -2.0), (0.0, -2.0), (40.0, -2.0)]),
+            LineString([(0.0, -28.0), (0.0, 0.0), (0.0, 28.0)]),
+        ],
+        osm_map_ways_tags=[
+            "highway: secondary, name: Main Street, lanes: 2, surface: asphalt, ",
+            "highway: residential, name: Side Road, oneway: yes, ",
+        ],
+        osm_map_relations_tags=["type: associatedStreet, name: Main Street, "],
+        osm_map_relations_node_member_indices=[[0]],
+        osm_map_relations_way_member_indices=[[0]],
+        osm_map_relations_relation_member_indices=[[]],
+        osm_map_relations_node_member_tags=[["type: node, role: sign, "]],
+        osm_map_relations_way_member_tags=[["type: way, role: street, "]],
+        osm_map_relations_relation_member_tags=[[]],
+    )
+
+
+class TestVisualize:
+    def test_writes_png_with_realistic_scene(self, tmp_path):
+        pytest.importorskip("shapely")
+        pytest.importorskip("matplotlib")
+        from data_parsing.osm_sd_map.osm_tokenize import tokenize_osm_elements
+        from data_parsing.osm_sd_map.visualize import visualize_osm_map_data
+
+        pc_range = (-60.0, -30.0, -5.0, 60.0, 30.0, 3.0)
+        tokenizer = _RoundTripTokenizer()
+        sample = tokenize_osm_elements(_realistic_elements(), tokenizer, pc_range,
+                                       fixed_num=10, pts_dim=3)
+
+        # tags round-trip through the tokenizer so the figure shows real text
+        decoded = tokenizer.batch_decode([t.tolist() for t in sample["osm_map_ways_tags_input_ids"]])
+        assert any("Main Street" in d for d in decoded)
+
+        out = tmp_path / "osm.png"
+        visualize_osm_map_data(sample, pc_range, str(out), tokenizer=tokenizer)
+        assert out.exists() and out.stat().st_size > 0

--- a/Model/tests/test_osm_vector.py
+++ b/Model/tests/test_osm_vector.py
@@ -1,0 +1,282 @@
+"""Tests for the OSM vector map encoder, token cross-attention fusion, the
+ragged collate, and the AutoE2E ``osm_vector`` integration.
+
+The heavy SentenceTransformer tag encoder is replaced by a tiny ``_FakeNLP``
+module (dependency-injected via ``nlp_model=``), so these tests run fully
+offline with no checkpoint, no network, and no sentence-transformers install.
+Data-pipeline tests that need shapely/numpy are guarded with importorskip.
+"""
+
+import sys
+
+import pytest
+import torch
+import torch.nn as nn
+
+sys.path.append('..')
+
+from model_components.map_encoder import (
+    MAP_ENCODER_REGISTRY,
+    MAP_FUSION_REGISTRY,
+    build_map_bev_fusion,
+    build_map_encoder,
+)
+from model_components.map_encoder.osm_vector import OSMVectorMapEncoder
+from model_components.map_encoder.map_bev_fusion.osm_cross_attn_fusion import OSMCrossAttnFusion
+from data_parsing.osm_sd_map.collate import collate_osm_batch
+
+
+_NLP_EMBED_DIM = 8
+_POS_NUM_FEATS = 4
+_ORF_DIM = 4
+_PTS_DIM = 3
+_EMBED_DIM = 32
+_INPUT_DIM = _PTS_DIM * _POS_NUM_FEATS + _NLP_EMBED_DIM + 2 * _ORF_DIM  # 28
+
+
+class _FakeNLP(nn.Module):
+    """Stand-in for the SentenceTransformer: input_ids -> mean token embedding."""
+
+    def __init__(self, vocab=64, embed_dim=_NLP_EMBED_DIM):
+        super().__init__()
+        self.embedding = nn.Embedding(vocab, embed_dim)
+        self.vocab = vocab
+
+    def forward(self, features):
+        ids = features["input_ids"].long().clamp(0, self.vocab - 1)  # (N, L)
+        emb = self.embedding(ids).mean(dim=1)  # (N, embed_dim)
+        return {"sentence_embedding": emb}
+
+
+def _make_encoder(device, **overrides):
+    kwargs = dict(
+        embed_dim=_EMBED_DIM, input_dim=_INPUT_DIM, hidden_dim=_EMBED_DIM,
+        orf_dim=_ORF_DIM, nlp_model=_FakeNLP(), nlp_embed_dim=_NLP_EMBED_DIM,
+        nheads=4, nlayers=2, pos_num_feats=_POS_NUM_FEATS, pts_dim=_PTS_DIM,
+    )
+    kwargs.update(overrides)
+    return OSMVectorMapEncoder(**kwargs).to(device)
+
+
+def _rand_tokens(n, lo=2, hi=5):
+    """List of n 1D token tensors of random length."""
+    return [torch.randint(1, 60, (int(torch.randint(lo, hi, (1,))),), dtype=torch.long)
+            for _ in range(n)]
+
+
+def _make_sample(num_nodes=3, num_ways=2, num_way_pts=10, with_relation=False):
+    """Build one tokenized osm_map_data sample dict."""
+    s = {
+        "osm_map_nodes_pts": torch.randn(num_nodes, _PTS_DIM),
+        "osm_map_ways_pts": torch.randn(num_ways, num_way_pts, _PTS_DIM),
+    }
+    for name, n in (("nodes", num_nodes), ("ways", num_ways)):
+        toks = _rand_tokens(n)
+        s[f"osm_map_{name}_tags_input_ids"] = toks
+        s[f"osm_map_{name}_tags_token_type_ids"] = [torch.zeros_like(t) for t in toks]
+        s[f"osm_map_{name}_tags_attention_mask"] = [torch.ones_like(t) for t in toks]
+
+    if with_relation:
+        rel_toks = _rand_tokens(1)
+        s["osm_map_relations_tags_input_ids"] = rel_toks
+        s["osm_map_relations_tags_token_type_ids"] = [torch.zeros_like(t) for t in rel_toks]
+        s["osm_map_relations_tags_attention_mask"] = [torch.ones_like(t) for t in rel_toks]
+        # one node member (-> node 0) and one way member (-> way 0)
+        nm, wm = _rand_tokens(1), _rand_tokens(1)
+        s["osm_map_relations_node_member_tags_input_ids"] = [nm]
+        s["osm_map_relations_node_member_tags_token_type_ids"] = [[torch.zeros_like(t) for t in nm]]
+        s["osm_map_relations_node_member_tags_attention_mask"] = [[torch.ones_like(t) for t in nm]]
+        s["osm_map_relations_way_member_tags_input_ids"] = [wm]
+        s["osm_map_relations_way_member_tags_token_type_ids"] = [[torch.zeros_like(t) for t in wm]]
+        s["osm_map_relations_way_member_tags_attention_mask"] = [[torch.ones_like(t) for t in wm]]
+        s["osm_map_relations_relation_member_tags_input_ids"] = [[]]
+        s["osm_map_relations_relation_member_tags_token_type_ids"] = [[]]
+        s["osm_map_relations_relation_member_tags_attention_mask"] = [[]]
+        s["osm_map_relations_node_member_indices"] = [torch.tensor([0], dtype=torch.long)]
+        s["osm_map_relations_way_member_indices"] = [torch.tensor([0], dtype=torch.long)]
+        s["osm_map_relations_relation_member_indices"] = [torch.tensor([], dtype=torch.long)]
+    else:
+        for key in ("input_ids", "token_type_ids", "attention_mask"):
+            for name in ("", "node_member_", "way_member_", "relation_member_"):
+                s[f"osm_map_relations_{name}tags_{key}" if name else f"osm_map_relations_tags_{key}"] = []
+        for name in ("node", "way", "relation"):
+            s[f"osm_map_relations_{name}_member_indices"] = []
+    return s
+
+
+def _make_batch(samples, device):
+    batch = collate_osm_batch(samples)
+    # Move geometry tensors to device (tag tokens stay on CPU then are used by
+    # the (CPU/GPU) nlp model on the encoder's device via get_nlp_model_input).
+    for b in range(len(samples)):
+        batch["osm_map_nodes_pts"][b] = batch["osm_map_nodes_pts"][b].to(device)
+        batch["osm_map_ways_pts"][b] = batch["osm_map_ways_pts"][b].to(device)
+    return batch
+
+
+class TestOSMVectorEncoder:
+    def test_output_shape_and_mask(self, device):
+        enc = _make_encoder(device)
+        batch = _make_batch([_make_sample(3, 2), _make_sample(1, 4)], device)
+        tokens, mask = enc(batch)
+        assert tokens.dim() == 3 and tokens.shape[0] == 2 and tokens.shape[2] == _EMBED_DIM
+        assert mask.shape == tokens.shape[:2]
+        # sample 0 valid length = 3 nodes + 2 ways * 10 pts = 23
+        assert (~mask[0]).sum().item() == 3 + 2 * 10
+        assert (~mask[1]).sum().item() == 1 + 4 * 10
+
+    def test_relations_increase_token_count(self, device):
+        enc = _make_encoder(device)
+        batch = _make_batch([_make_sample(2, 1, with_relation=True)], device)
+        tokens, mask = enc(batch)
+        # 2 nodes + 1 way*10 + 1 rel + 1 node member + 1 way member = 15
+        assert (~mask[0]).sum().item() == 2 + 10 + 1 + 1 + 1
+
+    def test_gradient_flows(self, device):
+        enc = _make_encoder(device)
+        batch = _make_batch([_make_sample(2, 2)], device)
+        tokens, _ = enc(batch)
+        tokens.sum().backward()
+        grads = [p.grad for n, p in enc.named_parameters()
+                 if "map_embedding" in n and p.requires_grad]
+        assert any(g is not None and g.abs().max() > 0 for g in grads)
+
+    def test_input_dim_mismatch_raises(self, device):
+        with pytest.raises(ValueError, match="inconsistent"):
+            OSMVectorMapEncoder(embed_dim=_EMBED_DIM, input_dim=999,
+                                orf_dim=_ORF_DIM, nlp_model=_FakeNLP(),
+                                nlp_embed_dim=_NLP_EMBED_DIM,
+                                pos_num_feats=_POS_NUM_FEATS, pts_dim=_PTS_DIM)
+
+    def test_requires_nlp(self):
+        with pytest.raises(ValueError, match="nlp_model_path"):
+            OSMVectorMapEncoder(embed_dim=_EMBED_DIM, input_dim=_INPUT_DIM,
+                                orf_dim=_ORF_DIM, nlp_embed_dim=_NLP_EMBED_DIM,
+                                pos_num_feats=_POS_NUM_FEATS, pts_dim=_PTS_DIM)
+
+
+class TestOSMCrossAttnFusion:
+    def test_output_shape(self, device):
+        fusion = OSMCrossAttnFusion(embed_dim=32, num_heads=4).to(device)
+        image_bev = torch.randn(2, 32, 6, 5, device=device)
+        tokens = torch.randn(2, 7, 32, device=device)
+        mask = torch.zeros(2, 7, dtype=torch.bool, device=device)
+        out = fusion(image_bev, tokens, mask)
+        assert out.shape == image_bev.shape
+
+    def test_zero_gate_returns_image_bev(self, device):
+        fusion = OSMCrossAttnFusion(embed_dim=32, num_heads=4).to(device)
+        assert torch.all(fusion.alpha == 0)
+        image_bev = torch.randn(1, 32, 4, 4, device=device)
+        tokens = torch.randn(1, 5, 32, device=device)
+        out = fusion(image_bev, tokens, torch.zeros(1, 5, dtype=torch.bool, device=device))
+        assert torch.allclose(out, image_bev, atol=1e-5)
+
+    def test_nonzero_gate_map_influences_output(self, device):
+        fusion = OSMCrossAttnFusion(embed_dim=32, num_heads=4).to(device).eval()
+        with torch.no_grad():
+            fusion.alpha.fill_(1.0)
+        image_bev = torch.randn(1, 32, 4, 4, device=device)
+        mask = torch.zeros(1, 5, dtype=torch.bool, device=device)
+        out_a = fusion(image_bev, torch.randn(1, 5, 32, device=device), mask)
+        out_b = fusion(image_bev, torch.randn(1, 5, 32, device=device), mask)
+        assert not torch.allclose(out_a, out_b, atol=1e-5)
+
+    def test_all_masked_tokens_no_nan(self, device):
+        """A sample with every token padded must not NaN (null token saves it)."""
+        fusion = OSMCrossAttnFusion(embed_dim=32, num_heads=4).to(device)
+        with torch.no_grad():
+            fusion.alpha.fill_(1.0)
+        image_bev = torch.randn(1, 32, 4, 4, device=device)
+        tokens = torch.randn(1, 5, 32, device=device)
+        mask = torch.ones(1, 5, dtype=torch.bool, device=device)  # all padded
+        out = fusion(image_bev, tokens, mask)
+        assert torch.isfinite(out).all()
+
+    def test_padding_mask_changes_result(self, device):
+        fusion = OSMCrossAttnFusion(embed_dim=32, num_heads=4).to(device).eval()
+        with torch.no_grad():
+            fusion.alpha.fill_(1.0)
+        image_bev = torch.randn(1, 32, 4, 4, device=device)
+        tokens = torch.randn(1, 6, 32, device=device)
+        m_none = torch.zeros(1, 6, dtype=torch.bool, device=device)
+        m_half = m_none.clone()
+        m_half[0, 3:] = True
+        assert not torch.allclose(fusion(image_bev, tokens, m_none),
+                                  fusion(image_bev, tokens, m_half), atol=1e-5)
+
+    def test_embed_dim_divisible_by_heads(self):
+        with pytest.raises(ValueError, match="divisible"):
+            OSMCrossAttnFusion(embed_dim=30, num_heads=4)
+
+
+class TestRegistries:
+    def test_osm_vector_registered(self):
+        assert "osm_vector" in MAP_ENCODER_REGISTRY
+
+    def test_osm_cross_attn_registered(self):
+        assert "osm_cross_attn" in MAP_FUSION_REGISTRY
+
+    def test_build_osm_cross_attn(self, device):
+        fusion = build_map_bev_fusion("osm_cross_attn", embed_dim=32).to(device)
+        assert isinstance(fusion, OSMCrossAttnFusion)
+
+    def test_build_osm_vector_encoder(self, device):
+        enc = build_map_encoder("osm_vector", embed_dim=_EMBED_DIM, input_dim=_INPUT_DIM,
+                                orf_dim=_ORF_DIM, nlp_model=_FakeNLP(),
+                                nlp_embed_dim=_NLP_EMBED_DIM, pos_num_feats=_POS_NUM_FEATS,
+                                pts_dim=_PTS_DIM)
+        assert isinstance(enc, OSMVectorMapEncoder)
+
+
+class TestCollate:
+    def test_groups_osm_keys_and_stacks_rest(self):
+        a = {"img": torch.zeros(3), **_make_sample(2, 1)}
+        b = {"img": torch.ones(3), **_make_sample(1, 2)}
+        out = collate_osm_batch([a, b])
+        assert out["img"].shape == (2, 3)  # stacked
+        assert isinstance(out["osm_map_nodes_pts"], list) and len(out["osm_map_nodes_pts"]) == 2
+        assert out["osm_map_nodes_pts"][0].shape[0] == 2
+
+
+class TestAutoE2EOSMIntegration:
+    def _make_model(self, build_mock_model, device):
+        return build_mock_model(
+            num_views=7, fusion_mode="bev", device=device,
+            map_type="osm_vector",
+            map_encoder_kwargs=dict(
+                input_dim=_INPUT_DIM, orf_dim=_ORF_DIM, nlp_model=_FakeNLP(),
+                nlp_embed_dim=_NLP_EMBED_DIM, nheads=4, nlayers=2,
+                pos_num_feats=_POS_NUM_FEATS, pts_dim=_PTS_DIM,
+            ),
+            map_fusion_mode="osm_cross_attn",
+        )
+
+    def test_forward_infer(self, build_mock_model, device):
+        model = self._make_model(build_mock_model, device).eval()
+        visual = torch.randn(2, 7, 3, 256, 256, device=device)
+        osm = _make_batch([_make_sample(3, 2, with_relation=True), _make_sample(2, 1)], device)
+        vis_hist = torch.randn(2, 896, device=device)
+        ego = torch.randn(2, 256, device=device)
+        traj, ego_hidden, _ = model(visual, osm, vis_hist, ego, mode="infer")
+        assert traj.shape == (2, 128)
+        assert torch.isfinite(traj).all()
+
+    def test_train_grads_reach_map_encoder(self, build_mock_model, device):
+        model = self._make_model(build_mock_model, device).train()
+        visual = torch.randn(2, 7, 3, 256, 256, device=device)
+        osm = _make_batch([_make_sample(3, 2), _make_sample(2, 2)], device)
+        vis_hist = torch.randn(2, 896, device=device)
+        ego = torch.randn(2, 256, device=device)
+        target = torch.randn(2, 128, device=device)
+        # Open the fusion gate so map gradients are non-zero.
+        with torch.no_grad():
+            model.MapBEVFusion.alpha.fill_(0.5)
+        loss, ego_hidden, future = model(visual, osm, vis_hist, ego, mode="train",
+                                         trajectory_target=target)
+        (loss + ego_hidden.sum() + sum(f.sum() for f in future)).backward()
+        assert model.MapBEVFusion.alpha.grad is not None
+        assert model.MapBEVFusion.alpha.grad.abs().max() > 0
+        # gradient reaches the OSM encoder's learned projection too
+        assert model.MapEncoder.map_embedding.weight.grad is not None
+        assert model.MapEncoder.map_embedding.weight.grad.abs().max() > 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,10 @@ pytest==9.0.3
 ruff==0.15.16
 timm==1.0.27
 torch==2.4.1
+sentence-transformers==3.3.1
+transformers==4.46.3
+shapely==2.0.6
+pyproj==3.7.0
+requests==2.32.3
+huggingface_hub==0.26.5
+matplotlib==3.9.2


### PR DESCRIPTION
Hi, as mentioned in this issue https://github.com/autowarefoundation/auto_e2e/issues/47, I tried to integrate the SDTagNet SD map encoder as a vector map branch.  It would be awesome if vector map branches could make it into the model somehow! This is a early draft and you are very welcome to propose or implement any changes :smile: I tested that the tests still pass as before (3 fail even before) and there is a test visualization of the parsed OSM map data (from a random position, thats why it is not on a road): 

<img width="3041" height="1379" alt="osm_map_vis" src="https://github.com/user-attachments/assets/9326ae41-51f4-4ab5-84b8-d24cf8aec486" />

I tried to make as little changes as possible to the original encoder, but to have one cache of the maps that works for both branches some changes had to be made there and now the raw OSM xml maps are cached and converted when loading for the original branch. I did not test myself if the original branch still works with these changes, I didn't find any visualization where I could test that easily, if I missed some script for that I could also try that quickly.

## Changes

### Model (`Model/model_components/map_encoder/`)
- **`osm_vector/osm_map_encoder.py`** — `OSMVectorMapEncoder`, ported from
  `OSMMapEncoderPointLevel`, stripped of mmdetection3d/mmcv and ablation-only
  code (kept only the canonical config: point-level tokens, NLP tag embeddings,
  ORF graph identifiers with fixed order, sine continuous positional encoding).
  Returns `(tokens [B,N,C], key_padding_mask [B,N])`. NLP model is loaded lazily
  from a local path or injected (for tests); constructed on CPU so the module is
  single-device until `.to()`.
- **`map_bev_fusion/osm_cross_attn_fusion.py`** — `OSMCrossAttnFusion`: BEV cells
  cross-attend to OSM tokens via `F.scaled_dot_product_attention` (mem-efficient
  backend, so the full 450×300 grid never materialises a QK matrix), honours the
  padding mask, has a learnable null token (no NaN when a sample has no OSM), and
  a zero-init per-channel gate (training starts identical to no-map).
- Registered `osm_vector` / `osm_cross_attn`; wired into `AutoE2E` behind
  `map_type` (default path byte-identical; new `map_encoder_kwargs` passthrough).

### Data pipeline (`Model/data_parsing/osm_sd_map/`)
- `osm_parser.py` — OSM XML parser + ego-centric patch extraction (ported;
  city-coord conversion replaced by generic `wgs84_to_local.py`, ego frame
  X=forward/Y=left/Z=up).
- `overpass.py` — the exact tested SDTagNet Overpass query; **trajectory-bbox**
  fetch with a shared gzip cache and **containment reuse** (a request is served
  by any cached XML whose bbox covers it).
- `osm_tokenize.py` — fixed-point way resampling + tag tokenisation → the
  ragged `osm_map_data` dict.
- `cache.py` — per-episode tokenised `.pt` shards; one Overpass fetch per
  episode sized to the trajectory.
- `collate.py` — `collate_osm_batch` for ragged OSM fields (standard keys still
  default-collated).
- `nlp_download.py` — downloads + extracts the trained tag encoder from
  `immel-f/SDTagNet` (`nlp_encoder/bert-144-osm-tags-embed-from_scratch.tar.gz`).
- `visualize.py` — SDTagNet-style SD-map figure + a real-data validation CLI
  (`python -m data_parsing.osm_sd_map.visualize ... --run-encoder`).
- `L2DDataset` — flag-gated `osm_cache_dir` merges per-frame OSM into samples,
  plus `episode_ego_poses()` for building the cache.

### Shared cache (both branches)
Both the rendered-tile and vector branches now fetch by **trajectory bounding
box + margin** instead of a fixed centroid radius — this fixes a latent bug
where episodes longer than ~1.5 km silently lost OSM at the trajectory ends.
The renderer (`map_rendering/cache.py`) builds its graph from the same shared
raw-OSM XML via `ox.graph_from_xml`. The vector branch's fetch margin defaults
to the renderer's render radius (`DEFAULT_FETCH_MARGIN_M=800`) so they share one
download; pass `fetch_margin_m=patch_reach_m(pc_range)` for a minimal
vector-only fetch.

### Dependencies
Added to `requirements.txt` (NLP path is required, not optional):
`sentence-transformers`, `transformers`, `shapely`, `pyproj`, `requests`,
`huggingface_hub`, `matplotlib`.

### Misc
- `.gitignore`: `checkpoints/`, `cache/`, `*.osm.gz`, `osm_bbox_*.xml.gz`,
  `graph_*.pkl`, `osm_map_vis.png`.

## Testing
- New offline suites (`tests/test_osm_vector.py`, `tests/test_osm_sd_map_data.py`):
  encoder shapes/mask/relations/grad, fusion (zero-gate / null-token / masking),
  registries, collate, AutoE2E `osm_vector` end-to-end, WGS84→ego transform,
  exact Overpass query string, parser+tokenise, trace-bbox + containment-reuse
  cache, and the visualizer (realistic scene). Heavy deps guarded with
  `importorskip`; a fake NLP module keeps the model tests checkpoint-free.
- Full suite passes except 3 pre-existing `TestBatchIndependence` cases that
  fail only on CUDA (batch-size-dependent reduction nondeterminism in the
  default rasterized path; unrelated to this change — they pass on CPU).

## Validating on real data

```
cd Model
python -m data_parsing.osm_sd_map.visualize --lat 48.9930 --lon 8.4037 --heading 0.0  --download-nlp --run-encoder --out osm_map_vis.png
```


Fetches real OSM, runs the full pipeline, renders the SD map, and runs the
encoder forward — for eyeballing geometry/ego-framing/tag decoding.

## Notes / follow-ups
- Confirm the L2D heading convention (`vehicle[1]`) against the visualization.
- Confirm `ox.graph_from_xml` filtering parity with `network_type="drive"` on
  your osmnx version (cosmetic for the tile).
- Architecture diagram in `Model/README.md` still predates this branch.
- Possible follow-ups: a `--from-l2d EPISODE FRAME` flag for the visualizer;
  token-level fusion variants; NLP-encoder pretraining scripts.
