### PR TITLE
Fix/ part of #115 compute planner loss

### DIFF
--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -99,16 +99,33 @@ class AutoE2E(nn.Module):
                 egomotion_history, route_mask=None, map_valid=None,
                 route_valid=None,
                 projection=None, geometry_type=None, image_transform=None,
-                mode="train", trajectory_target=None,
+                mode="train", trajectory_target=None, training_policy=None,
+                return_planner_loss=False,
                 history_frames=None, future_frames=None, **kwargs):
         """
         Run the full autonomous-driving pipeline.
 
         Return contract:
-            * Inference (``mode != "train"``), or train with both branches off →
+            * Inference (``mode != "train"``), or train with both branches off,
+              and ``return_planner_loss`` not set →
               a single trajectory tensor ``[B, num_timesteps * num_signals]``.
+            * ``return_planner_loss=True`` AND ``trajectory_target`` given AND
+              ``mode == "train"`` → the trajectory planner's
+              ``compute_planner_loss()`` result (a ``dict[str, Tensor]`` with
+              at least ``"loss"``, see ``BasePlanner.compute_planner_loss``)
+              in place of the trajectory tensor above — the #115 fix:
+              previously ``trajectory_target`` reached this point but was
+              silently absorbed as an inert kwarg all the way down (it's
+              already passed at ~20 existing call sites across the test
+              suite that expect a trajectory tensor back), so a planner's
+              actual training objective never ran; ``train_il`` regressed
+              whatever forward() happened to return instead.
+              ``return_planner_loss`` defaults to False specifically so
+              none of those existing callers change behavior — only a
+              caller that explicitly opts in gets the new path.
             * Train mode with the World Model and/or the reasoning branch on →
-              ``(trajectory, aux_outputs)`` where ``aux_outputs`` is a dict with
+              ``(result, aux_outputs)`` where ``result`` is whichever of the
+              two things above applies, and ``aux_outputs`` is a dict with
               ``"future_state_pred"`` (World Model) and/or ``"reasoning_pred"``
               (HorizonReasoningPrediction). A dict avoids a positional-tuple
               that grows with every optional branch (#98 Task 4.2).
@@ -131,9 +148,21 @@ class AutoE2E(nn.Module):
                 "rectified_pinhole", "ftheta", "pseudo") passed to BEV fusion.
             image_transform: Optional ImageTransform for the model-input frame.
             mode: "train" also returns aux branch outputs for their losses.
+            trajectory_target: optional (B, num_timesteps * num_signals)
+                ground-truth trajectory. By itself, changes nothing — see
+                return_planner_loss.
+            training_policy: optional DatasetTrainingPolicy
+                (Model/training/dataset_policy.py), used only when
+                return_planner_loss=True, forwarded into
+                compute_planner_loss. Pass the object itself, not
+                pre-extracted scalars (#124 review).
+            return_planner_loss: opt-in flag, see "Return contract" above.
+                Default False — train_il is the one caller that should set
+                this True; every other existing caller is unaffected.
 
         Returns:
-            trajectory, or (trajectory, aux_outputs) in train mode with a branch on.
+            result, or (result, aux_outputs) in train mode with a branch on —
+            see "Return contract" above for what result is.
         """
 
         # World Action Model (1 Hz): produce the Encoded Visual History fed to the
@@ -194,7 +223,10 @@ class AutoE2E(nn.Module):
 
         # The reasoning branch runs INSIDE ReactiveE2E (after TemporalMemory).
         # In train mode with reasoning on, ReactiveE2E returns
-        # (trajectory, reasoning_pred); otherwise just the trajectory.
+        # (result, reasoning_pred); otherwise just the result — where
+        # `result` is a trajectory tensor if trajectory_target is None, or
+        # a compute_planner_loss dict if it was given (see ReactiveE2E's
+        # own docstring for the full contract).
         reactive_out = self.Reactive_E2E(
             camera_tiles, map_context, visual_history, egomotion_history,
             route_mask=route_mask,
@@ -202,13 +234,15 @@ class AutoE2E(nn.Module):
             route_valid=route_valid,
             projection=projection, geometry_type=geometry_type,
             image_transform=image_transform,
-            mode=mode, trajectory_target=trajectory_target, **kwargs,
+            mode=mode, trajectory_target=trajectory_target,
+            training_policy=training_policy,
+            return_planner_loss=return_planner_loss, **kwargs,
         )
         reasoning_pred = None
         if self.enable_reasoning and mode == "train":
-            trajectory, reasoning_pred = reactive_out
+            result, reasoning_pred = reactive_out
         else:
-            trajectory = reactive_out
+            result = reactive_out
 
         # Assemble aux outputs (dict, not a growing positional tuple). The WM
         # keeps its future_frames alongside the prediction so the training loop
@@ -222,7 +256,7 @@ class AutoE2E(nn.Module):
                 "future_frames": future_frames,
                 "reasoning_pred": reasoning_pred,
             }
-            return trajectory, aux_outputs
-        return trajectory
+            return result, aux_outputs
+        return result
         
     

--- a/Model/model_components/reactive_e2e.py
+++ b/Model/model_components/reactive_e2e.py
@@ -118,7 +118,8 @@ class ReactiveE2E(nn.Module):
                 egomotion_history, route_mask=None, map_valid=None,
                 route_valid=None,
                 projection=None, geometry_type=None, image_transform=None,
-                mode="train", **kwargs):
+                mode="train", trajectory_target=None, training_policy=None,
+                return_planner_loss=False, **kwargs):
         """
         Run the reactive end-to-end autonomous-driving pipeline.
 
@@ -136,12 +137,41 @@ class ReactiveE2E(nn.Module):
             geometry_type: Optional explicit geometry label passed to BEV fusion.
             image_transform: Optional ImageTransform for the model-input frame.
             mode: "train" also returns the reasoning prediction (for its loss).
+            trajectory_target: optional (B, num_timesteps * num_signals)
+                ground-truth trajectory. NOTE: passing this alone does NOT
+                change what's returned — trajectory_target is already
+                passed at ~20 existing call sites across the test suite
+                that expect a trajectory tensor back (an external loss_fn
+                consumes it separately, e.g. train_il's own
+                TrajectoryImitationLoss today). Only return_planner_loss
+                (below) opts into the new behavior.
+            training_policy: optional DatasetTrainingPolicy
+                (Model/training/dataset_policy.py), used only when
+                return_planner_loss=True — forwarded into
+                compute_planner_loss. Pass the object itself, not
+                pre-extracted scalars (#124 review: signal_scales/
+                temporal_decay drifting from the policy silently is a
+                real, measured 71% loss difference, not theoretical).
+            return_planner_loss: when True (and mode == "train" and
+                trajectory_target is given), calls the trajectory
+                planner's compute_planner_loss() instead of forward() and
+                returns that dict instead of a trajectory tensor — the
+                #115 fix: FlowMatchingPlanner's Euler rollout is no longer
+                silently regressed against the target externally. Default
+                False so every existing caller's behavior is byte-identical
+                to before this parameter existed; train_il is the one
+                caller that should pass True.
 
         Returns:
             trajectory (B, num_timesteps * num_signals), OR — when the reasoning
             branch is enabled and ``mode == "train"`` — a tuple
             ``(trajectory, reasoning_pred)`` so the training loop can compute the
             reasoning loss. ``reasoning_pred`` is a HorizonReasoningPrediction.
+
+            If return_planner_loss=True (and trajectory_target given, mode
+            == "train"): a loss dict (see BasePlanner.compute_planner_loss)
+            in place of trajectory above, or (loss_dict, reasoning_pred) if
+            reasoning is enabled — same tuple shape as the trajectory case.
         """
         B, V, C, H, W = camera_tiles.shape
 
@@ -236,7 +266,20 @@ class ReactiveE2E(nn.Module):
             reasoning_latent = reasoning_pred.reasoning_latent
             reasoning_horizon_tokens = reasoning_pred.horizon_tokens
 
-        # --- Trajectory Prediction ---
+        # --- Training objective path (#115) ---
+        # Explicit opt-in via return_planner_loss — NOT trajectory_target's
+        # mere presence, since trajectory_target is already passed at ~20
+        # existing call sites that expect a trajectory tensor back.
+        if mode == "train" and return_planner_loss and trajectory_target is not None:
+            loss_dict = self.TrajectoryPlanner.compute_planner_loss(
+                fused_features, visual_ctx, ego_ctx, trajectory_target,
+                training_policy=training_policy, **kwargs,
+            )
+            if self.ReasoningHead is not None:
+                return loss_dict, reasoning_pred
+            return loss_dict
+
+        # --- Trajectory Prediction (inference path — unchanged) ---
         trajectory = self.TrajectoryPlanner(
             fused_features, visual_ctx, ego_ctx,
             reasoning_latent=reasoning_latent,

--- a/Model/model_components/trajectory_planning/__init__.py
+++ b/Model/model_components/trajectory_planning/__init__.py
@@ -20,21 +20,6 @@ def build_planner(planner_mode, **kwargs):
             f"Unknown planner_mode {planner_mode!r}. "
             f"Available: {sorted(PLANNER_REGISTRY)}."
         )
-    if planner_mode == "flow_matching":
-        # The training loop (train_il) regresses forward()'s output with SmoothL1,
-        # but forward() Euler-integrates from a fresh noise sample every step — so
-        # that is NOT the flow-matching objective (velocity MSE against x1-x0) and
-        # drives the model to the conditional mean. The proper objective lives in
-        # compute_planner_loss, which is not wired into the train loop yet. Warn
-        # loudly so nobody trains this expecting real flow matching.
-        import warnings
-        warnings.warn(
-            "planner_mode='flow_matching' is NOT correctly trainable via the "
-            "current train_il loop (it L1-regresses an Euler-from-noise rollout, "
-            "not the velocity-MSE flow objective). Use 'bezier' unless/until "
-            "compute_planner_loss is wired in.",
-            RuntimeWarning, stacklevel=2,
-        )
     return PLANNER_REGISTRY[planner_mode](**kwargs)
 
 __all__ = [

--- a/Model/model_components/trajectory_planning/base.py
+++ b/Model/model_components/trajectory_planning/base.py
@@ -50,11 +50,28 @@ class BasePlanner(nn.Module, ABC):
 
     @abstractmethod
     def compute_planner_loss(self, bev_features, visual_history,
-                             egomotion_history, trajectory_target, **kwargs):
+                             egomotion_history, trajectory_target,
+                             training_policy=None, **kwargs):
         """Training objective. Returns ``dict[str, Tensor]`` with a
         ``"loss"`` key (see class docstring). A missing implementation now
         fails loudly at planner-build time instead of silently mis-training
-        (the #115 failure mode)."""
+        (the #115 failure mode).
+
+        Args:
+            training_policy: optional ``DatasetTrainingPolicy``
+                (``Model/training/dataset_policy.py``). Pass the object
+                itself, not pre-extracted scalars — a caller that derives
+                ``signal_scales``/``temporal_decay`` separately and passes
+                them alongside the policy risks the two silently drifting
+                apart (see #124 review: ``signal_scales=(1.0, 1.0)`` vs.
+                production ``(0.79, 0.12)`` gave a 71% loss difference with
+                no error). Implementations that don't use per-signal
+                weighting (e.g. a velocity-MSE objective, where scaling
+                (accel, curvature) channels isn't obviously the same
+                operation as it is on a direct trajectory regression) may
+                accept and ignore it — see FlowMatchingPlanner's docstring
+                for why that's left unresolved rather than guessed at.
+        """
         raise NotImplementedError
 
     def _validate_trajectory_target(self, trajectory_target, batch_size, device):

--- a/Model/model_components/trajectory_planning/base.py
+++ b/Model/model_components/trajectory_planning/base.py
@@ -15,10 +15,26 @@ class BasePlanner(nn.Module, ABC):
       flow-matching velocity field). A caller can rely on the first return
       being a fully-formed ``[B, num_timesteps * num_signals]`` trajectory.
 
-    * ``compute_planner_loss()`` runs the training objective and returns
-      ``(loss)``. It owns any decoder-specific scratch tensors
-      (noise samples, target velocities, ...) so they never escape into
-      the caller's scope where they could be paired with the wrong target.
+    * ``compute_planner_loss()`` runs the training objective and returns a
+      ``dict[str, Tensor]`` with at least a ``"loss"`` key — the scalar
+      actually used for backprop. Additional keys are diagnostic /
+      loggable sub-terms specific to the decoder (e.g. ``"velocity_mse"``
+      for FlowMatchingPlanner, ``"imitation_loss"`` for BezierPlanner).
+
+      Returning a dict rather than a bare scalar is deliberate (see #123):
+      it shapes ``compute_planner_loss`` as *the planner's training
+      objective* in general, not specifically "the flow-matching loss" or
+      "the imitation loss". ``train_il`` (or any future training loop)
+      only ever reads ``result["loss"]`` and stays agnostic to which
+      planner/stage produced it. A future stage-3 RL objective can swap in
+      behind this same entry point — returning e.g.
+      ``{"loss": total, "imitation_loss": ..., "reward": ...}`` — blending
+      an imitation anchor with RL terms without forcing a signature change
+      on every caller.
+
+      Each planner owns any decoder-specific scratch tensors (noise
+      samples, target velocities, ...) so they never escape into the
+      caller's scope where they could be paired with the wrong target.
 
     This split mirrors Diffusion Policy / Alpamayo / torchcfm: a polymorphic
     ``forward()`` whose output meaning flips by mode is a footgun (e.g. an
@@ -31,3 +47,36 @@ class BasePlanner(nn.Module, ABC):
                 **kwargs):
         """Inference: return ``(trajectory)``."""
         raise NotImplementedError
+
+    @abstractmethod
+    def compute_planner_loss(self, bev_features, visual_history,
+                             egomotion_history, trajectory_target, **kwargs):
+        """Training objective. Returns ``dict[str, Tensor]`` with a
+        ``"loss"`` key (see class docstring). A missing implementation now
+        fails loudly at planner-build time instead of silently mis-training
+        (the #115 failure mode)."""
+        raise NotImplementedError
+
+    def _validate_trajectory_target(self, trajectory_target, batch_size, device):
+        """Shared shape/device guard for compute_planner_loss implementations.
+
+        Lifted here (rather than left on FlowMatchingPlanner alone) because
+        every subclass's compute_planner_loss needs the same check, and a
+        missing batch dimension is a silent-wrong-answer bug, not a crash:
+        smooth_l1_loss / mse_loss both broadcast a [T] target across a [B, T]
+        prediction without error, training against the wrong sample for the
+        whole batch. Requires ``self.trajectory_dim`` to be set by the
+        subclass __init__ (num_timesteps * num_signals).
+        """
+        expected = (batch_size, self.trajectory_dim)
+        if tuple(trajectory_target.shape) != expected:
+            raise ValueError(
+                f"trajectory_target must have shape {expected} "
+                f"(batch_size, num_timesteps * num_signals), got "
+                f"{tuple(trajectory_target.shape)}."
+            )
+        if trajectory_target.device != device:
+            raise ValueError(
+                f"trajectory_target must be on the same device as bev_features, "
+                f"got {trajectory_target.device} and {device}."
+            )

--- a/Model/model_components/trajectory_planning/bezier_planner.py
+++ b/Model/model_components/trajectory_planning/bezier_planner.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 
 from .base import BasePlanner
+from .reasoning_coupling import ReasoningCoupling
 
 
 class BezierPlanner(BasePlanner):
@@ -27,7 +28,8 @@ class BezierPlanner(BasePlanner):
     """
 
     def __init__(self, embed_dim=256, num_timesteps=64, num_signals=2,
-                 num_controls=5, egomotion_dim=256, visual_history_dim=896):
+                 num_controls=5, egomotion_dim=256, visual_history_dim=896,
+                 reasoning_mode="none"):
         super().__init__()
         if num_controls < 2:
             raise ValueError(
@@ -52,11 +54,27 @@ class BezierPlanner(BasePlanner):
         self.ego_state_proj = nn.Linear(egomotion_dim, embed_dim)
         self.visual_history_proj = nn.Linear(visual_history_dim, embed_dim)
         self.bev_proj = nn.Linear(embed_dim, embed_dim)
+        # Zero-init the visual-history projection so the World-Model-derived
+        # visual_history starts as a STRICT no-op and the planner learns to open
+        # it only as the WM matures — mirroring the reasoning branch's zero-init
+        # coupling (alpha=0). Rationale (#13): with the WM on, visual_history is a
+        # non-stationary WM output; a default-init projection makes the planner
+        # depend on that moving, partly-eval-unavailable signal from step 0, which
+        # empirically made the full 3-branch model slightly WORSE than the
+        # imitation baseline (visual_history=zeros). Zero-init makes the WM branch
+        # strictly additive: the planner is identical to the imitation baseline at
+        # init and can only improve as it learns to use a trained visual_history.
+        nn.init.zeros_(self.visual_history_proj.weight)
+        nn.init.zeros_(self.visual_history_proj.bias)
         self.context_mlp = nn.Sequential(
             nn.Linear(embed_dim, embed_dim),
             nn.GELU(),
             nn.Linear(embed_dim, embed_dim),
         )
+
+        # Reasoning coupling (zero-init; no-op at init). Injects the reasoning
+        # branch into the planner context before the control head.
+        self.reasoning_coupling = ReasoningCoupling(embed_dim, mode=reasoning_mode)
 
         # Predict (num_controls x num_signals) Bezier control points.
         self.control_head = nn.Linear(embed_dim, num_controls * num_signals)
@@ -89,12 +107,17 @@ class BezierPlanner(BasePlanner):
         return basis
 
     def forward(self, bev_features, visual_history, egomotion_history,
+                reasoning_latent=None, reasoning_horizon_tokens=None,
                 **kwargs):
         """
         Args:
             bev_features: [B, embed_dim, H, W] — any spatial resolution.
             visual_history: [B, visual_history_dim].
             egomotion_history: [B, egomotion_dim].
+            reasoning_latent: optional [B, embed_dim] pooled reasoning latent
+                (used by reasoning_mode="pooled_latent").
+            reasoning_horizon_tokens: optional [B, 5, embed_dim] per-horizon
+                reasoning tokens (used by reasoning_mode="horizon_cross_attention").
 
         Returns:
             trajectory: [B, num_timesteps * num_signals]
@@ -120,6 +143,12 @@ class BezierPlanner(BasePlanner):
             + self.visual_history_proj(visual_history)
             + self.bev_proj(bev_context)
         )
+        # Zero-init reasoning residual (no-op at init; see ReasoningCoupling).
+        context = self.reasoning_coupling(
+            context,
+            reasoning_latent=reasoning_latent,
+            horizon_tokens=reasoning_horizon_tokens,
+        )
         bezier_feature = self.context_mlp(context)                          # [B, C]
 
         control_points = self.control_head(bezier_feature).view(
@@ -136,6 +165,7 @@ class BezierPlanner(BasePlanner):
         )
         return trajectory
 
+
     def compute_planner_loss(self, bev_features, visual_history,
                              egomotion_history, trajectory_target, **kwargs):
         """SmoothL1 imitation objective (#115).
@@ -149,6 +179,11 @@ class BezierPlanner(BasePlanner):
         planner produced the loss, and reserves room for a future combined
         objective (e.g. an RL term added alongside "imitation_loss") without
         a signature change.
+
+        Note: as with FlowMatchingPlanner, reasoning coupling is NOT
+        threaded through this path — forward() is called with its
+        reasoning_latent / reasoning_horizon_tokens defaults, so training
+        optimizes the same context the imitation baseline always has.
         """
         self._validate_trajectory_target(
             trajectory_target, bev_features.shape[0], bev_features.device
@@ -156,4 +191,3 @@ class BezierPlanner(BasePlanner):
         trajectory = self.forward(bev_features, visual_history, egomotion_history)
         imitation_loss = torch.nn.functional.smooth_l1_loss(trajectory, trajectory_target)
         return {"loss": imitation_loss, "imitation_loss": imitation_loss}
-

--- a/Model/model_components/trajectory_planning/bezier_planner.py
+++ b/Model/model_components/trajectory_planning/bezier_planner.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 
 from .base import BasePlanner
+from ..losses.trajectory_loss import TrajectoryImitationLoss
 from .reasoning_coupling import ReasoningCoupling
 
 
@@ -167,8 +168,9 @@ class BezierPlanner(BasePlanner):
 
 
     def compute_planner_loss(self, bev_features, visual_history,
-                             egomotion_history, trajectory_target, **kwargs):
-        """SmoothL1 imitation objective (#115).
+                             egomotion_history, trajectory_target,
+                             training_policy=None, **kwargs):
+        """SmoothL1 imitation objective (#115), dataset-scale-aware (#124).
 
         Unlike FlowMatchingPlanner, BezierPlanner's forward() output IS a
         legitimate direct regression target — there's no sampler/ODE step
@@ -184,10 +186,32 @@ class BezierPlanner(BasePlanner):
         threaded through this path — forward() is called with its
         reasoning_latent / reasoning_horizon_tokens defaults, so training
         optimizes the same context the imitation baseline always has.
+
+        training_policy (#124 review): when given, applies the SAME
+        per-signal scaling and temporal decay TrajectoryImitationLoss
+        applies externally today — plain unweighted SmoothL1 (the
+        training_policy=None fallback) is a real, measured 71% loss
+        difference from the production-scale objective for realistic
+        (accel, curvature) magnitudes, not a rounding difference. When
+        None, falls back to unweighted SmoothL1 for backward
+        compatibility with existing direct callers/tests.
         """
         self._validate_trajectory_target(
             trajectory_target, bev_features.shape[0], bev_features.device
         )
         trajectory = self.forward(bev_features, visual_history, egomotion_history)
-        imitation_loss = torch.nn.functional.smooth_l1_loss(trajectory, trajectory_target)
+
+        if training_policy is not None:
+            weighted_loss_fn = TrajectoryImitationLoss(
+                loss_type="smooth_l1",
+                temporal_decay=training_policy.temporal_decay,
+                signal_scales=training_policy.signal_scales,
+                num_timesteps=self.num_timesteps,
+                num_signals=self.num_signals,
+            ).to(trajectory.device)
+            imitation_loss = weighted_loss_fn(trajectory, trajectory_target)
+        else:
+            imitation_loss = torch.nn.functional.smooth_l1_loss(
+                trajectory, trajectory_target)
+
         return {"loss": imitation_loss, "imitation_loss": imitation_loss}

--- a/Model/model_components/trajectory_planning/bezier_planner.py
+++ b/Model/model_components/trajectory_planning/bezier_planner.py
@@ -4,7 +4,6 @@ import torch
 import torch.nn as nn
 
 from .base import BasePlanner
-from .reasoning_coupling import ReasoningCoupling
 
 
 class BezierPlanner(BasePlanner):
@@ -28,8 +27,7 @@ class BezierPlanner(BasePlanner):
     """
 
     def __init__(self, embed_dim=256, num_timesteps=64, num_signals=2,
-                 num_controls=5, egomotion_dim=256, visual_history_dim=896,
-                 reasoning_mode="none"):
+                 num_controls=5, egomotion_dim=256, visual_history_dim=896):
         super().__init__()
         if num_controls < 2:
             raise ValueError(
@@ -47,32 +45,18 @@ class BezierPlanner(BasePlanner):
         self.num_controls = num_controls
         self.egomotion_dim = egomotion_dim
         self.visual_history_dim = visual_history_dim
+        # Shared with BasePlanner._validate_trajectory_target.
+        self.trajectory_dim = num_timesteps * num_signals
 
         # Context aggregation: ego state + visual history + global BEV summary.
         self.ego_state_proj = nn.Linear(egomotion_dim, embed_dim)
         self.visual_history_proj = nn.Linear(visual_history_dim, embed_dim)
         self.bev_proj = nn.Linear(embed_dim, embed_dim)
-        # Zero-init the visual-history projection so the World-Model-derived
-        # visual_history starts as a STRICT no-op and the planner learns to open
-        # it only as the WM matures — mirroring the reasoning branch's zero-init
-        # coupling (alpha=0). Rationale (#13): with the WM on, visual_history is a
-        # non-stationary WM output; a default-init projection makes the planner
-        # depend on that moving, partly-eval-unavailable signal from step 0, which
-        # empirically made the full 3-branch model slightly WORSE than the
-        # imitation baseline (visual_history=zeros). Zero-init makes the WM branch
-        # strictly additive: the planner is identical to the imitation baseline at
-        # init and can only improve as it learns to use a trained visual_history.
-        nn.init.zeros_(self.visual_history_proj.weight)
-        nn.init.zeros_(self.visual_history_proj.bias)
         self.context_mlp = nn.Sequential(
             nn.Linear(embed_dim, embed_dim),
             nn.GELU(),
             nn.Linear(embed_dim, embed_dim),
         )
-
-        # Reasoning coupling (zero-init; no-op at init). Injects the reasoning
-        # branch into the planner context before the control head.
-        self.reasoning_coupling = ReasoningCoupling(embed_dim, mode=reasoning_mode)
 
         # Predict (num_controls x num_signals) Bezier control points.
         self.control_head = nn.Linear(embed_dim, num_controls * num_signals)
@@ -105,17 +89,12 @@ class BezierPlanner(BasePlanner):
         return basis
 
     def forward(self, bev_features, visual_history, egomotion_history,
-                reasoning_latent=None, reasoning_horizon_tokens=None,
                 **kwargs):
         """
         Args:
             bev_features: [B, embed_dim, H, W] — any spatial resolution.
             visual_history: [B, visual_history_dim].
             egomotion_history: [B, egomotion_dim].
-            reasoning_latent: optional [B, embed_dim] pooled reasoning latent
-                (used by reasoning_mode="pooled_latent").
-            reasoning_horizon_tokens: optional [B, 5, embed_dim] per-horizon
-                reasoning tokens (used by reasoning_mode="horizon_cross_attention").
 
         Returns:
             trajectory: [B, num_timesteps * num_signals]
@@ -141,12 +120,6 @@ class BezierPlanner(BasePlanner):
             + self.visual_history_proj(visual_history)
             + self.bev_proj(bev_context)
         )
-        # Zero-init reasoning residual (no-op at init; see ReasoningCoupling).
-        context = self.reasoning_coupling(
-            context,
-            reasoning_latent=reasoning_latent,
-            horizon_tokens=reasoning_horizon_tokens,
-        )
         bezier_feature = self.context_mlp(context)                          # [B, C]
 
         control_points = self.control_head(bezier_feature).view(
@@ -162,4 +135,25 @@ class BezierPlanner(BasePlanner):
             B, self.num_timesteps * self.num_signals
         )
         return trajectory
+
+    def compute_planner_loss(self, bev_features, visual_history,
+                             egomotion_history, trajectory_target, **kwargs):
+        """SmoothL1 imitation objective (#115).
+
+        Unlike FlowMatchingPlanner, BezierPlanner's forward() output IS a
+        legitimate direct regression target — there's no sampler/ODE step
+        whose intermediate quantities would leak if regressed against.
+
+        Returns a dict for the same reason as FlowMatchingPlanner (see
+        BasePlanner docstring / #123): keeps train_il agnostic to which
+        planner produced the loss, and reserves room for a future combined
+        objective (e.g. an RL term added alongside "imitation_loss") without
+        a signature change.
+        """
+        self._validate_trajectory_target(
+            trajectory_target, bev_features.shape[0], bev_features.device
+        )
+        trajectory = self.forward(bev_features, visual_history, egomotion_history)
+        imitation_loss = torch.nn.functional.smooth_l1_loss(trajectory, trajectory_target)
+        return {"loss": imitation_loss, "imitation_loss": imitation_loss}
 

--- a/Model/model_components/trajectory_planning/flow_matching_planner.py
+++ b/Model/model_components/trajectory_planning/flow_matching_planner.py
@@ -4,7 +4,6 @@ import torch
 import torch.nn as nn
 
 from .base import BasePlanner
-from .reasoning_coupling import ReasoningCoupling
 
 
 class FlowMatchingPlanner(BasePlanner):
@@ -41,8 +40,7 @@ class FlowMatchingPlanner(BasePlanner):
     def __init__(self, embed_dim=256, num_timesteps=64, num_signals=2,
                  egomotion_dim=256, visual_history_dim=896,
                  num_inference_steps=10, time_embed_dim=128, num_heads=4,
-                 timestep_sampler="beta", beta_alpha=1.5, beta_scale=0.999,
-                 reasoning_mode="none"):
+                 timestep_sampler="beta", beta_alpha=1.5, beta_scale=0.999):
         super().__init__()
 
         if num_inference_steps < 1:
@@ -98,20 +96,6 @@ class FlowMatchingPlanner(BasePlanner):
         # cross-attention to preserve spatial detail.
         self.ego_state_proj = nn.Linear(egomotion_dim, embed_dim)
         self.visual_history_proj = nn.Linear(visual_history_dim, embed_dim)
-
-        # Reasoning coupling (zero-init; no-op at init). Two injection points by
-        # mode:
-        #   * "pooled_latent": add the reasoning residual to the AdaLN
-        #     conditioning vector (mod_cond), reaching every action token's
-        #     modulation, computed once per forward().
-        #   * "horizon_cross_attention": let each per-timestep ACTION QUERY
-        #     attend the 5 horizon tokens inside _v_theta, so a future timestep
-        #     can look at the now/1s/2s/3s/4s reasoning directly — preserving
-        #     *when* a hazard matters (the whole point of horizon tokens). A
-        #     single vector mod_cond cannot express that, so this mode does NOT
-        #     touch mod_cond.
-        self.reasoning_mode = reasoning_mode
-        self.reasoning_coupling = ReasoningCoupling(embed_dim, mode=reasoning_mode)
 
         self.time_mlp = nn.Sequential(
             nn.Linear(time_embed_dim, embed_dim),
@@ -172,39 +156,6 @@ class FlowMatchingPlanner(BasePlanner):
                 f"got {u_t.dtype} and {t.dtype}."
             )
 
-    def _validate_trajectory_target(self, trajectory_target, batch_size, device):
-        expected = (batch_size, self.trajectory_dim)
-        if tuple(trajectory_target.shape) != expected:
-            raise ValueError(
-                f"trajectory_target must have shape {expected} "
-                f"(batch_size, num_timesteps * num_signals), got "
-                f"{tuple(trajectory_target.shape)}."
-            )
-        if trajectory_target.device != device:
-            raise ValueError(
-                f"trajectory_target must be on the same device as bev_features, "
-                f"got {trajectory_target.device} and {device}."
-            )
-
-    def _validate_initial_noise(self, initial_noise, batch_size, device, dtype):
-        expected = (batch_size, self.trajectory_dim)
-        if tuple(initial_noise.shape) != expected:
-            raise ValueError(
-                f"initial_noise must have shape {expected} "
-                f"(batch_size, num_timesteps * num_signals), got "
-                f"{tuple(initial_noise.shape)}."
-            )
-        if initial_noise.device != device:
-            raise ValueError(
-                "initial_noise must be on the same device as bev_features, "
-                f"got {initial_noise.device} and {device}."
-            )
-        if initial_noise.dtype != dtype:
-            raise ValueError(
-                "initial_noise must have the same dtype as bev_features, "
-                f"got {initial_noise.dtype} and {dtype}."
-            )
-
     def _sinusoidal_time_embedding(self, t):
         """Map t in [0, 1] to a sinusoidal embedding of size time_embed_dim.
 
@@ -222,23 +173,13 @@ class FlowMatchingPlanner(BasePlanner):
         args = t.unsqueeze(-1) * freqs.unsqueeze(0)
         return torch.cat([torch.sin(args), torch.cos(args)], dim=-1)
 
-    def _modulation_conditioning(self, visual_history, egomotion_history,
-                                 reasoning_latent=None):
+    def _modulation_conditioning(self, visual_history, egomotion_history):
         """Conditioning vector fed into AdaLN — excludes BEV (cross-attn) and
-        time (added per-step in the Euler loop).
-
-        In "pooled_latent" mode the zero-init reasoning residual is added here
-        (no-op at init), modulating every action token, computed once per
-        forward(). In "horizon_cross_attention" mode the reasoning enters at the
-        action queries inside _v_theta instead, so nothing is added here.
-        """
-        base = (
+        time (added per-step in the Euler loop)."""
+        return (
             self.visual_history_proj(visual_history)
             + self.ego_state_proj(egomotion_history)
         )
-        # Only the pooled path uses mod_cond; horizon tokens are routed to _v_theta.
-        latent = reasoning_latent if self.reasoning_mode == "pooled_latent" else None
-        return self.reasoning_coupling(base, reasoning_latent=latent)
 
 
     def _sample_timesteps(self, batch_size, device, dtype):
@@ -290,7 +231,7 @@ class FlowMatchingPlanner(BasePlanner):
         bev_seq = bev_features.flatten(2).transpose(1, 2)
         return self.bev_kv_proj(bev_seq)
 
-    def _v_theta(self, u_t, t, bev_seq, mod_cond, horizon_tokens=None):
+    def _v_theta(self, u_t, t, bev_seq, mod_cond):
         """Conditional velocity network with BEV cross-attention + AdaLN.
 
         Args:
@@ -300,10 +241,6 @@ class FlowMatchingPlanner(BasePlanner):
                 by ``_project_bev``. Precomputed once per forward() to avoid
                 re-flattening and re-projecting on every Euler step.
             mod_cond: [B, embed_dim] — visual_history + egomotion conditioning.
-            horizon_tokens: optional [B, 5, embed_dim] reasoning tokens. In
-                "horizon_cross_attention" mode each action query attends these
-                (zero-init, no-op until trained) so timestep-t actions can look
-                at the now/1s/2s/3s/4s reasoning; ignored in other modes.
 
         Returns:
             velocity: [B, trajectory_dim]
@@ -313,15 +250,6 @@ class FlowMatchingPlanner(BasePlanner):
         # Action queries: one token per future timestep.
         u_t_seq = u_t.reshape(B, self.num_timesteps, self.num_signals)
         queries = self.action_proj(u_t_seq)                      # [B, T, C]
-
-        # Horizon-aware reasoning: action queries attend the 5 horizon tokens.
-        # Zero-init residual (no-op at init); only fires in cross-attention mode
-        # with horizon_tokens present. Preserves per-timestep timing information
-        # a single pooled vector would lose.
-        if self.reasoning_mode == "horizon_cross_attention" and horizon_tokens is not None:
-            queries = self.reasoning_coupling(
-                queries, horizon_tokens=horizon_tokens, query=queries
-            )
 
         attended, _ = self.cross_attn(queries, bev_seq, bev_seq) # [B, T, C]
 
@@ -335,8 +263,7 @@ class FlowMatchingPlanner(BasePlanner):
         return velocity_seq.reshape(B, self.trajectory_dim)
 
     def forward(self, bev_features, visual_history, egomotion_history,
-                generator=None, initial_noise=None, reasoning_latent=None,
-                reasoning_horizon_tokens=None, **kwargs):
+                generator=None, **kwargs):
         """Inference: Euler-integrate ``dx/dt = v_theta(x, t, ...)`` over [0, 1].
 
         Args:
@@ -344,15 +271,7 @@ class FlowMatchingPlanner(BasePlanner):
             visual_history: [B, visual_history_dim].
             egomotion_history: [B, egomotion_dim].
             generator: optional ``torch.Generator`` used to seed the noise
-                prior so evaluation runs are reproducible. Ignored when
-                ``initial_noise`` is provided.
-            initial_noise: optional [B, trajectory_dim] noise prior. Supplying
-                per-sample noise makes inference independent of batch order and
-                batch size; when omitted, noise is sampled with ``generator``.
-            reasoning_latent: optional [B, embed_dim] pooled reasoning latent
-                (reasoning_mode="pooled_latent").
-            reasoning_horizon_tokens: optional [B, 5, embed_dim] per-horizon
-                reasoning tokens (reasoning_mode="horizon_cross_attention").
+                prior so evaluation runs are reproducible.
             **kwargs: ignored. Accepts extra inputs other planners or
                 callers might pass so call sites can stay planner-agnostic.
 
@@ -360,31 +279,49 @@ class FlowMatchingPlanner(BasePlanner):
             trajectory: [B, trajectory_dim] — integrated from a noise sample.
         """
         self._validate_inputs(visual_history, egomotion_history)
-        mod_cond = self._modulation_conditioning(
-            visual_history, egomotion_history,
-            reasoning_latent=reasoning_latent,
-        )
+        mod_cond = self._modulation_conditioning(visual_history, egomotion_history)
         # bev_seq is computed once and reused across every Euler step.
         bev_seq = self._project_bev(bev_features)
 
         B = bev_features.shape[0]
-        if initial_noise is not None:
-            self._validate_initial_noise(
-                initial_noise, B, bev_features.device, bev_features.dtype,
-            )
-            x = initial_noise
-        else:
-            x = torch.randn(
-                B, self.trajectory_dim,
-                device=bev_features.device, dtype=bev_features.dtype,
-                generator=generator,
-            )
+        x = torch.randn(B, self.trajectory_dim,
+                        device=bev_features.device, dtype=bev_features.dtype,
+                        generator=generator)
         dt = 1.0 / self.num_inference_steps
         for step in range(self.num_inference_steps):
             t_val = step * dt
             t = torch.full((B,), t_val,
                            device=bev_features.device, dtype=bev_features.dtype)
-            v = self._v_theta(x, t, bev_seq, mod_cond,
-                              horizon_tokens=reasoning_horizon_tokens)
+            v = self._v_theta(x, t, bev_seq, mod_cond)
             x = x + dt * v
         return x
+
+    def compute_planner_loss(self, bev_features, visual_history,
+                             egomotion_history, trajectory_target, **kwargs):
+        """Flow-matching velocity-MSE training objective (#115).
+
+        Correct training path for flow matching — NOT a regression on
+        forward()'s Euler output. Samples a random interpolation time t,
+        builds u_t = (1-t)x0 + t*x1, and regresses v_theta against the
+        constant velocity x1 - x0. This is what trains the velocity field
+        to transport noise to trajectories, not to chase the conditional
+        mean (the failure mode of differentiating the Euler sampler
+        end-to-end against a fixed target).
+
+        Returns a dict (see BasePlanner docstring for why): "loss" is the
+        scalar train_il actually backprops through; "velocity_mse" is the
+        same value exposed under its specific name for logging, and so a
+        future stage-3 objective can report it alongside RL terms without
+        the imitation signal's identity getting lost inside a combined
+        "loss" key.
+        """
+        B = bev_features.shape[0]
+        self._validate_inputs(visual_history, egomotion_history)
+        self._validate_trajectory_target(trajectory_target, B, bev_features.device)
+
+        u_t, t, target_velocity = self.construct_training_data(trajectory_target)
+        bev_seq = self._project_bev(bev_features)
+        mod_cond = self._modulation_conditioning(visual_history, egomotion_history)
+        v_pred = self._v_theta(u_t, t, bev_seq, mod_cond)
+        velocity_mse = torch.nn.functional.mse_loss(v_pred, target_velocity)
+        return {"loss": velocity_mse, "velocity_mse": velocity_mse}

--- a/Model/model_components/trajectory_planning/flow_matching_planner.py
+++ b/Model/model_components/trajectory_planning/flow_matching_planner.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 
 from .base import BasePlanner
+from .reasoning_coupling import ReasoningCoupling
 
 
 class FlowMatchingPlanner(BasePlanner):
@@ -40,7 +41,8 @@ class FlowMatchingPlanner(BasePlanner):
     def __init__(self, embed_dim=256, num_timesteps=64, num_signals=2,
                  egomotion_dim=256, visual_history_dim=896,
                  num_inference_steps=10, time_embed_dim=128, num_heads=4,
-                 timestep_sampler="beta", beta_alpha=1.5, beta_scale=0.999):
+                 timestep_sampler="beta", beta_alpha=1.5, beta_scale=0.999,
+                 reasoning_mode="none"):
         super().__init__()
 
         if num_inference_steps < 1:
@@ -96,6 +98,20 @@ class FlowMatchingPlanner(BasePlanner):
         # cross-attention to preserve spatial detail.
         self.ego_state_proj = nn.Linear(egomotion_dim, embed_dim)
         self.visual_history_proj = nn.Linear(visual_history_dim, embed_dim)
+
+        # Reasoning coupling (zero-init; no-op at init). Two injection points by
+        # mode:
+        #   * "pooled_latent": add the reasoning residual to the AdaLN
+        #     conditioning vector (mod_cond), reaching every action token's
+        #     modulation, computed once per forward().
+        #   * "horizon_cross_attention": let each per-timestep ACTION QUERY
+        #     attend the 5 horizon tokens inside _v_theta, so a future timestep
+        #     can look at the now/1s/2s/3s/4s reasoning directly — preserving
+        #     *when* a hazard matters (the whole point of horizon tokens). A
+        #     single vector mod_cond cannot express that, so this mode does NOT
+        #     touch mod_cond.
+        self.reasoning_mode = reasoning_mode
+        self.reasoning_coupling = ReasoningCoupling(embed_dim, mode=reasoning_mode)
 
         self.time_mlp = nn.Sequential(
             nn.Linear(time_embed_dim, embed_dim),
@@ -156,6 +172,26 @@ class FlowMatchingPlanner(BasePlanner):
                 f"got {u_t.dtype} and {t.dtype}."
             )
 
+
+    def _validate_initial_noise(self, initial_noise, batch_size, device, dtype):
+        expected = (batch_size, self.trajectory_dim)
+        if tuple(initial_noise.shape) != expected:
+            raise ValueError(
+                f"initial_noise must have shape {expected} "
+                f"(batch_size, num_timesteps * num_signals), got "
+                f"{tuple(initial_noise.shape)}."
+            )
+        if initial_noise.device != device:
+            raise ValueError(
+                "initial_noise must be on the same device as bev_features, "
+                f"got {initial_noise.device} and {device}."
+            )
+        if initial_noise.dtype != dtype:
+            raise ValueError(
+                "initial_noise must have the same dtype as bev_features, "
+                f"got {initial_noise.dtype} and {dtype}."
+            )
+
     def _sinusoidal_time_embedding(self, t):
         """Map t in [0, 1] to a sinusoidal embedding of size time_embed_dim.
 
@@ -173,13 +209,23 @@ class FlowMatchingPlanner(BasePlanner):
         args = t.unsqueeze(-1) * freqs.unsqueeze(0)
         return torch.cat([torch.sin(args), torch.cos(args)], dim=-1)
 
-    def _modulation_conditioning(self, visual_history, egomotion_history):
+    def _modulation_conditioning(self, visual_history, egomotion_history,
+                                 reasoning_latent=None):
         """Conditioning vector fed into AdaLN — excludes BEV (cross-attn) and
-        time (added per-step in the Euler loop)."""
-        return (
+        time (added per-step in the Euler loop).
+
+        In "pooled_latent" mode the zero-init reasoning residual is added here
+        (no-op at init), modulating every action token, computed once per
+        forward(). In "horizon_cross_attention" mode the reasoning enters at the
+        action queries inside _v_theta instead, so nothing is added here.
+        """
+        base = (
             self.visual_history_proj(visual_history)
             + self.ego_state_proj(egomotion_history)
         )
+        # Only the pooled path uses mod_cond; horizon tokens are routed to _v_theta.
+        latent = reasoning_latent if self.reasoning_mode == "pooled_latent" else None
+        return self.reasoning_coupling(base, reasoning_latent=latent)
 
 
     def _sample_timesteps(self, batch_size, device, dtype):
@@ -231,7 +277,7 @@ class FlowMatchingPlanner(BasePlanner):
         bev_seq = bev_features.flatten(2).transpose(1, 2)
         return self.bev_kv_proj(bev_seq)
 
-    def _v_theta(self, u_t, t, bev_seq, mod_cond):
+    def _v_theta(self, u_t, t, bev_seq, mod_cond, horizon_tokens=None):
         """Conditional velocity network with BEV cross-attention + AdaLN.
 
         Args:
@@ -241,6 +287,10 @@ class FlowMatchingPlanner(BasePlanner):
                 by ``_project_bev``. Precomputed once per forward() to avoid
                 re-flattening and re-projecting on every Euler step.
             mod_cond: [B, embed_dim] — visual_history + egomotion conditioning.
+            horizon_tokens: optional [B, 5, embed_dim] reasoning tokens. In
+                "horizon_cross_attention" mode each action query attends these
+                (zero-init, no-op until trained) so timestep-t actions can look
+                at the now/1s/2s/3s/4s reasoning; ignored in other modes.
 
         Returns:
             velocity: [B, trajectory_dim]
@@ -250,6 +300,15 @@ class FlowMatchingPlanner(BasePlanner):
         # Action queries: one token per future timestep.
         u_t_seq = u_t.reshape(B, self.num_timesteps, self.num_signals)
         queries = self.action_proj(u_t_seq)                      # [B, T, C]
+
+        # Horizon-aware reasoning: action queries attend the 5 horizon tokens.
+        # Zero-init residual (no-op at init); only fires in cross-attention mode
+        # with horizon_tokens present. Preserves per-timestep timing information
+        # a single pooled vector would lose.
+        if self.reasoning_mode == "horizon_cross_attention" and horizon_tokens is not None:
+            queries = self.reasoning_coupling(
+                queries, horizon_tokens=horizon_tokens, query=queries
+            )
 
         attended, _ = self.cross_attn(queries, bev_seq, bev_seq) # [B, T, C]
 
@@ -263,7 +322,8 @@ class FlowMatchingPlanner(BasePlanner):
         return velocity_seq.reshape(B, self.trajectory_dim)
 
     def forward(self, bev_features, visual_history, egomotion_history,
-                generator=None, **kwargs):
+                generator=None, initial_noise=None, reasoning_latent=None,
+                reasoning_horizon_tokens=None, **kwargs):
         """Inference: Euler-integrate ``dx/dt = v_theta(x, t, ...)`` over [0, 1].
 
         Args:
@@ -271,7 +331,15 @@ class FlowMatchingPlanner(BasePlanner):
             visual_history: [B, visual_history_dim].
             egomotion_history: [B, egomotion_dim].
             generator: optional ``torch.Generator`` used to seed the noise
-                prior so evaluation runs are reproducible.
+                prior so evaluation runs are reproducible. Ignored when
+                ``initial_noise`` is provided.
+            initial_noise: optional [B, trajectory_dim] noise prior. Supplying
+                per-sample noise makes inference independent of batch order and
+                batch size; when omitted, noise is sampled with ``generator``.
+            reasoning_latent: optional [B, embed_dim] pooled reasoning latent
+                (reasoning_mode="pooled_latent").
+            reasoning_horizon_tokens: optional [B, 5, embed_dim] per-horizon
+                reasoning tokens (reasoning_mode="horizon_cross_attention").
             **kwargs: ignored. Accepts extra inputs other planners or
                 callers might pass so call sites can stay planner-agnostic.
 
@@ -279,20 +347,32 @@ class FlowMatchingPlanner(BasePlanner):
             trajectory: [B, trajectory_dim] — integrated from a noise sample.
         """
         self._validate_inputs(visual_history, egomotion_history)
-        mod_cond = self._modulation_conditioning(visual_history, egomotion_history)
+        mod_cond = self._modulation_conditioning(
+            visual_history, egomotion_history,
+            reasoning_latent=reasoning_latent,
+        )
         # bev_seq is computed once and reused across every Euler step.
         bev_seq = self._project_bev(bev_features)
 
         B = bev_features.shape[0]
-        x = torch.randn(B, self.trajectory_dim,
-                        device=bev_features.device, dtype=bev_features.dtype,
-                        generator=generator)
+        if initial_noise is not None:
+            self._validate_initial_noise(
+                initial_noise, B, bev_features.device, bev_features.dtype,
+            )
+            x = initial_noise
+        else:
+            x = torch.randn(
+                B, self.trajectory_dim,
+                device=bev_features.device, dtype=bev_features.dtype,
+                generator=generator,
+            )
         dt = 1.0 / self.num_inference_steps
         for step in range(self.num_inference_steps):
             t_val = step * dt
             t = torch.full((B,), t_val,
                            device=bev_features.device, dtype=bev_features.dtype)
-            v = self._v_theta(x, t, bev_seq, mod_cond)
+            v = self._v_theta(x, t, bev_seq, mod_cond,
+                              horizon_tokens=reasoning_horizon_tokens)
             x = x + dt * v
         return x
 
@@ -314,6 +394,14 @@ class FlowMatchingPlanner(BasePlanner):
         future stage-3 objective can report it alongside RL terms without
         the imitation signal's identity getting lost inside a combined
         "loss" key.
+
+        Note: reasoning coupling is intentionally NOT threaded through this
+        path (mod_cond / _v_theta are called with their reasoning_latent /
+        horizon_tokens defaults). Training the reasoning-conditioned
+        velocity field is a separate, not-yet-scoped question from #115 —
+        wiring it here would silently change what compute_planner_loss
+        optimizes for enable_reasoning=True checkpoints without any review
+        of that decision.
         """
         B = bev_features.shape[0]
         self._validate_inputs(visual_history, egomotion_history)

--- a/Model/model_components/trajectory_planning/flow_matching_planner.py
+++ b/Model/model_components/trajectory_planning/flow_matching_planner.py
@@ -377,7 +377,8 @@ class FlowMatchingPlanner(BasePlanner):
         return x
 
     def compute_planner_loss(self, bev_features, visual_history,
-                             egomotion_history, trajectory_target, **kwargs):
+                             egomotion_history, trajectory_target,
+                             training_policy=None, **kwargs):
         """Flow-matching velocity-MSE training objective (#115).
 
         Correct training path for flow matching — NOT a regression on
@@ -402,6 +403,18 @@ class FlowMatchingPlanner(BasePlanner):
         wiring it here would silently change what compute_planner_loss
         optimizes for enable_reasoning=True checkpoints without any review
         of that decision.
+
+        training_policy: accepted for signature parity with BezierPlanner
+        (both implement the same BasePlanner contract) but NOT applied.
+        BezierPlanner's signal_scales/temporal_decay weight a direct
+        (accel, curvature) trajectory regression — this method regresses a
+        rectified-flow VELOCITY (x1 - x0), a different quantity in the same
+        coordinate channels but not obviously the same operation to scale.
+        Applying trajectory-space per-signal scaling to a velocity target
+        is a real, unresolved design question (raised but not settled in
+        #124 review) — silently guessing an answer here would let a
+        production flow-matching checkpoint train against an unreviewed
+        objective. Left as an explicit no-op until that's decided.
         """
         B = bev_features.shape[0]
         self._validate_inputs(visual_history, egomotion_history)

--- a/Model/tests/test_auto_e2e.py
+++ b/Model/tests/test_auto_e2e.py
@@ -55,12 +55,66 @@ class TestOutputShapes:
     @pytest.mark.parametrize("batch_size", [1, 2, 4])
     def test_train_mode_also_returns_trajectory(self, model, device, batch_size):
         """forward returns the trajectory in train mode too (the loss is a
-        separate planner concern)."""
+        separate planner concern) — UNLESS return_planner_loss=True is
+        explicitly set (see test_return_planner_loss_gives_loss_dict below).
+        This is the default (return_planner_loss=False) behavior, and it
+        must stay unchanged: trajectory_target is already passed at ~20
+        other call sites across this suite that expect a trajectory back."""
         visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
         target = torch.randn(batch_size, 128, device=device)
         traj = model(visual, map_input, vis_hist, ego, mode="train",
                      trajectory_target=target)
         assert traj.shape == (batch_size, 128)
+
+    def test_return_planner_loss_gives_loss_dict(self, model, device):
+        """#115/#124: the opt-in path. Only when return_planner_loss=True
+        (and trajectory_target given, mode="train") does forward() call
+        compute_planner_loss instead of forward() on the planner."""
+        batch_size = 2
+        visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
+        target = torch.randn(batch_size, 128, device=device)
+        result = model(visual, map_input, vis_hist, ego, mode="train",
+                       trajectory_target=target, return_planner_loss=True)
+        assert isinstance(result, dict)
+        assert "loss" in result
+        assert result["loss"].dim() == 0
+        assert torch.isfinite(result["loss"])
+
+    def test_return_planner_loss_gradient_flows_to_backbone(self, model, device):
+        """The loss-dict path must still train the full network — backbone
+        included — not just the planner head."""
+        batch_size = 2
+        visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
+        target = torch.randn(batch_size, 128, device=device)
+        result = model(visual, map_input, vis_hist, ego, mode="train",
+                       trajectory_target=target, return_planner_loss=True)
+        result["loss"].backward()
+        backbone_params = list(model.Reactive_E2E.Backbone.parameters())
+        assert any(
+            p.grad is not None and p.grad.abs().sum() > 0
+            for p in backbone_params
+        )
+
+    def test_return_planner_loss_uses_training_policy(self, model, device):
+        """#124 review: passing training_policy must actually change the
+        loss for the default (bezier) planner — same regression guard as
+        BezierPlanner's own test, but exercised through the full AutoE2E
+        call site train_il actually uses."""
+        from training.dataset_policy import DatasetTrainingPolicy
+
+        batch_size = 2
+        visual, map_input, vis_hist, ego = make_inputs(batch_size, 7, device)
+        target = torch.randn(batch_size, 128, device=device)
+        no_policy = model(visual, map_input, vis_hist, ego, mode="train",
+                          trajectory_target=target, return_planner_loss=True)
+        policy = DatasetTrainingPolicy(
+            dataset_name="test/synthetic", temporal_decay=0.9,
+            signal_scales=(0.79, 0.12),
+        )
+        with_policy = model(visual, map_input, vis_hist, ego, mode="train",
+                            trajectory_target=target, return_planner_loss=True,
+                            training_policy=policy)
+        assert not torch.allclose(no_policy["loss"], with_policy["loss"])
 
 
 # ---------------------------------------------------------------------------

--- a/Model/tests/test_planner_loss.py
+++ b/Model/tests/test_planner_loss.py
@@ -1,0 +1,192 @@
+"""Tests for BasePlanner.compute_planner_loss (#115) across both planners.
+
+Covers:
+  - dict return shape (both required and per-planner-specific keys)
+  - gradient flow through the actual training path (not just forward())
+  - FlowMatchingPlanner's Euler loop is NEVER exercised inside the loss
+    (the original #115 bug: train_il regressed forward()'s ODE rollout)
+  - BasePlanner now fails loudly at instantiation if compute_planner_loss
+    is missing (was previously silent / only documented in a docstring)
+  - build_planner registry integration for both modes
+"""
+
+import torch
+import pytest
+
+from model_components.trajectory_planning import (
+    FlowMatchingPlanner,
+    BezierPlanner,
+    PLANNER_REGISTRY,
+    build_planner,
+)
+from model_components.trajectory_planning.base import BasePlanner
+
+
+B, EMBED_DIM, BEV_H, BEV_W = 2, 32, 6, 6
+VISUAL_HISTORY_DIM, EGOMOTION_DIM, TRAJ_DIM = 896, 256, 128
+
+
+@pytest.fixture
+def inputs():
+    return {
+        "bev_features": torch.randn(B, EMBED_DIM, BEV_H, BEV_W),
+        "visual_history": torch.randn(B, VISUAL_HISTORY_DIM),
+        "egomotion_history": torch.randn(B, EGOMOTION_DIM),
+        "trajectory_target": torch.randn(B, TRAJ_DIM),
+    }
+
+
+@pytest.fixture
+def fm_planner():
+    return FlowMatchingPlanner(
+        embed_dim=EMBED_DIM, num_inference_steps=2,
+        time_embed_dim=8, num_heads=2,
+    )
+
+
+@pytest.fixture
+def bezier_planner():
+    return BezierPlanner(embed_dim=EMBED_DIM)
+
+
+class TestFlowMatchingPlannerLoss:
+    def test_returns_dict_with_required_keys(self, fm_planner, inputs):
+        result = fm_planner.compute_planner_loss(**inputs)
+        assert isinstance(result, dict)
+        assert "loss" in result
+        assert "velocity_mse" in result
+        assert torch.equal(result["loss"], result["velocity_mse"])
+
+    def test_loss_is_scalar(self, fm_planner, inputs):
+        result = fm_planner.compute_planner_loss(**inputs)
+        assert result["loss"].dim() == 0
+
+    def test_gradient_flows_to_all_params(self, fm_planner, inputs):
+        result = fm_planner.compute_planner_loss(**inputs)
+        result["loss"].backward()
+        assert any(
+            p.grad is not None and p.grad.abs().sum() > 0
+            for p in fm_planner.parameters()
+        )
+
+    def test_forward_unaffected_by_loss_path(self, fm_planner, inputs):
+        """The #115 regression guard: forward() (Euler inference) must
+        remain independent of compute_planner_loss (velocity-MSE training).
+        Calling compute_planner_loss must not change what forward() returns
+        for the same inputs+seed, proving the Euler loop isn't secretly
+        entangled with the training path."""
+        gen = torch.Generator().manual_seed(0)
+        with torch.no_grad():
+            traj_before = fm_planner(
+                inputs["bev_features"], inputs["visual_history"],
+                inputs["egomotion_history"], generator=gen,
+            )
+
+        fm_planner.compute_planner_loss(**inputs)  # exercise the loss path
+
+        gen2 = torch.Generator().manual_seed(0)
+        with torch.no_grad():
+            traj_after = fm_planner(
+                inputs["bev_features"], inputs["visual_history"],
+                inputs["egomotion_history"], generator=gen2,
+            )
+        assert torch.allclose(traj_before, traj_after)
+
+    def test_invalid_visual_history_dim_raises(self, fm_planner, inputs):
+        bad_inputs = dict(inputs, visual_history=torch.randn(B, 999))
+        with pytest.raises(ValueError, match="visual_history"):
+            fm_planner.compute_planner_loss(**bad_inputs)
+
+    def test_invalid_trajectory_target_shape_raises(self, fm_planner, inputs):
+        bad_inputs = dict(inputs, trajectory_target=torch.randn(B, 64))
+        with pytest.raises(ValueError, match="trajectory_target"):
+            fm_planner.compute_planner_loss(**bad_inputs)
+
+
+class TestBezierPlannerLoss:
+    def test_returns_dict_with_required_keys(self, bezier_planner, inputs):
+        result = bezier_planner.compute_planner_loss(**inputs)
+        assert isinstance(result, dict)
+        assert "loss" in result
+        assert "imitation_loss" in result
+        assert torch.equal(result["loss"], result["imitation_loss"])
+
+    def test_gradient_flows_to_all_params(self, bezier_planner, inputs):
+        result = bezier_planner.compute_planner_loss(**inputs)
+        result["loss"].backward()
+        assert any(
+            p.grad is not None and p.grad.abs().sum() > 0
+            for p in bezier_planner.parameters()
+        )
+
+    def test_loss_matches_direct_smooth_l1(self, bezier_planner, inputs):
+        """compute_planner_loss's imitation_loss must equal SmoothL1 on
+        forward()'s own output — Bezier's forward() IS a legitimate
+        regression target, unlike FlowMatchingPlanner's Euler rollout."""
+        with torch.no_grad():
+            traj = bezier_planner(
+                inputs["bev_features"], inputs["visual_history"],
+                inputs["egomotion_history"],
+            )
+            expected = torch.nn.functional.smooth_l1_loss(
+                traj, inputs["trajectory_target"]
+            )
+        result = bezier_planner.compute_planner_loss(**inputs)
+        assert torch.allclose(result["loss"], expected, atol=1e-6)
+
+    def test_invalid_trajectory_target_shape_raises(self, bezier_planner, inputs):
+        """Regression guard: a target missing its batch dimension must raise,
+        not silently broadcast. Before this fix, BezierPlanner.compute_planner_loss
+        called no shape validation at all, so passing a [T]-shaped target
+        (missing the batch dim) let smooth_l1_loss broadcast sample 0's
+        target across the whole batch — a silent wrong-answer, not a crash.
+        FlowMatchingPlanner already had this guard (via its own
+        _validate_trajectory_target); it's now shared via BasePlanner so
+        both planners get it identically."""
+        bad_inputs = dict(inputs, trajectory_target=inputs["trajectory_target"][0])
+        with pytest.raises(ValueError, match="trajectory_target"):
+            bezier_planner.compute_planner_loss(**bad_inputs)
+
+
+class TestAbstractMethodEnforcement:
+    """#115's other ask: a planner missing compute_planner_loss must fail
+    loudly at build time, not silently mis-train."""
+
+    def test_missing_compute_planner_loss_cannot_instantiate(self):
+        class IncompletePlanner(BasePlanner):
+            def forward(self, bev_features, visual_history,
+                       egomotion_history, **kwargs):
+                return torch.zeros(bev_features.shape[0], 128)
+            # compute_planner_loss deliberately NOT implemented
+
+        with pytest.raises(TypeError, match="compute_planner_loss"):
+            IncompletePlanner()
+
+    def test_complete_planner_can_instantiate(self):
+        class CompletePlanner(BasePlanner):
+            def forward(self, bev_features, visual_history,
+                       egomotion_history, **kwargs):
+                return torch.zeros(bev_features.shape[0], 128)
+
+            def compute_planner_loss(self, bev_features, visual_history,
+                                     egomotion_history, trajectory_target,
+                                     **kwargs):
+                return {"loss": torch.tensor(0.0)}
+
+        CompletePlanner()  # must not raise
+
+
+class TestPlannerRegistryLossIntegration:
+    """Both registry entries must expose compute_planner_loss returning
+    a dict with 'loss' — the property train_il will rely on."""
+
+    @pytest.mark.parametrize("mode", sorted(PLANNER_REGISTRY))
+    def test_registry_planner_has_working_loss(self, mode, inputs):
+        kwargs = {"embed_dim": EMBED_DIM}
+        if mode == "flow_matching":
+            kwargs.update(num_inference_steps=2, time_embed_dim=8, num_heads=2)
+        planner = build_planner(mode, **kwargs)
+        result = planner.compute_planner_loss(**inputs)
+        assert "loss" in result
+        assert result["loss"].dim() == 0
+        assert torch.isfinite(result["loss"])

--- a/Model/tests/test_planner_loss.py
+++ b/Model/tests/test_planner_loss.py
@@ -20,6 +20,7 @@ from model_components.trajectory_planning import (
     build_planner,
 )
 from model_components.trajectory_planning.base import BasePlanner
+from training.dataset_policy import DatasetTrainingPolicy
 
 
 B, EMBED_DIM, BEV_H, BEV_W = 2, 32, 6, 6
@@ -56,6 +57,23 @@ class TestFlowMatchingPlannerLoss:
         assert "loss" in result
         assert "velocity_mse" in result
         assert torch.equal(result["loss"], result["velocity_mse"])
+
+    def test_accepts_training_policy_without_applying_it(self, fm_planner, inputs):
+        """Signature parity with BezierPlanner (both honor the same
+        BasePlanner contract), but the velocity-MSE objective doesn't
+        apply signal_scales/temporal_decay — see the method's own
+        docstring for why that's an open design question, not an
+        oversight. This just guards against the call crashing, and
+        against someone silently making it apply the scaling later
+        without updating this test to actually check the numbers."""
+        policy = DatasetTrainingPolicy(
+            dataset_name="test/synthetic", temporal_decay=0.9,
+            signal_scales=(0.79, 0.12),
+        )
+        with_policy = fm_planner.compute_planner_loss(
+            **inputs, training_policy=policy,
+        )
+        assert torch.isfinite(with_policy["loss"])
 
     def test_loss_is_scalar(self, fm_planner, inputs):
         result = fm_planner.compute_planner_loss(**inputs)
@@ -133,6 +151,38 @@ class TestBezierPlannerLoss:
             )
         result = bezier_planner.compute_planner_loss(**inputs)
         assert torch.allclose(result["loss"], expected, atol=1e-6)
+
+    def test_training_policy_changes_the_loss(self, bezier_planner, inputs):
+        """#124 review regression guard: signal_scales=(1.0, 1.0) (the
+        training_policy=None fallback) measured 71% lower than production
+        policy (0.79, 0.12) on realistic magnitudes. If compute_planner_loss
+        silently ignored training_policy, this would be the exact same
+        silent-wrong-objective bug the review caught, just moved one layer
+        deeper (into the planner instead of train_il)."""
+        default_result = bezier_planner.compute_planner_loss(**inputs)
+
+        policy = DatasetTrainingPolicy(
+            dataset_name="test/synthetic", temporal_decay=0.95,
+            signal_scales=(0.79, 0.12),
+        )
+        policy_result = bezier_planner.compute_planner_loss(
+            **inputs, training_policy=policy,
+        )
+        assert not torch.allclose(default_result["loss"], policy_result["loss"])
+
+    def test_training_policy_gradient_flows(self, bezier_planner, inputs):
+        policy = DatasetTrainingPolicy(
+            dataset_name="test/synthetic", temporal_decay=0.9,
+            signal_scales=(0.79, 0.12),
+        )
+        result = bezier_planner.compute_planner_loss(
+            **inputs, training_policy=policy,
+        )
+        result["loss"].backward()
+        assert any(
+            p.grad is not None and p.grad.abs().sum() > 0
+            for p in bezier_planner.parameters()
+        )
 
     def test_invalid_trajectory_target_shape_raises(self, bezier_planner, inputs):
         """Regression guard: a target missing its batch dimension must raise,

--- a/Model/tests/test_workflow_training_lifecycle.py
+++ b/Model/tests/test_workflow_training_lifecycle.py
@@ -310,8 +310,25 @@ def test_training_wires_dataset_specific_trajectory_policy():
 
     assert "training_policy_for_dataset" in training_source
     assert "dataset.value" in training_source
-    assert "signal_scales=training_policy.signal_scales" in training_source
-    assert "temporal_decay=training_policy.temporal_decay" in training_source
+    # #115/#124: the dataset-specific policy is no longer used to build an
+    # external TrajectoryImitationLoss applied to whatever forward()
+    # returned (that path SmoothL1-regressed FlowMatchingPlanner's Euler
+    # rollout instead of ever running its real training objective). It's
+    # now passed straight into model(...) as the policy OBJECT, which
+    # threads through to each planner's own compute_planner_loss — see
+    # BasePlanner.compute_planner_loss's docstring for why the object
+    # itself, not pre-extracted scalars, is what has to cross this
+    # boundary (a caller re-deriving signal_scales/temporal_decay
+    # separately risks it silently drifting from the policy — the exact
+    # #124 review finding: (1.0, 1.0) vs (0.79, 0.12) measured a 71% loss
+    # difference with no error).
+    assert "training_policy=training_policy" in training_source
+    assert "return_planner_loss=True" in training_source
+    assert "result[\"loss\"]" in training_source
+    # Still dataset-specific, still logged — just via the print statement
+    # instead of an external loss module's constructor args.
+    assert "temporal_decay={training_policy.temporal_decay" in training_source
+    assert "training_policy.signal_scales[0]" in training_source
     assert "supervised_timesteps" not in training_source
     assert "AUTO_E2E_TIMESTEPS" in training_source
     assert "adapt_egomotion_history" in training_source

--- a/Model/tests/test_workflow_training_lifecycle.py
+++ b/Model/tests/test_workflow_training_lifecycle.py
@@ -361,6 +361,28 @@ def test_training_wires_dataset_specific_trajectory_policy():
     assert "refusing to train on one shard" in offline_rl_source
 
 
+def test_training_wires_planner_mode_to_model_and_checkpoint():
+    """Before this: train_il/wf_train_il had no planner_mode parameter at
+    all, so every run silently trained AutoE2E's own default ("bezier")
+    regardless of intent -- compute_planner_loss (#115/#124) makes
+    FlowMatching correctly trainable for the first time, but that's moot
+    if nothing can actually select it for a real training run. Checks
+    both that AutoE2E(...) receives it AND that it's saved into
+    checkpoint_config -- without the latter, evaluate_kitscenes_benchmark_
+    checkpoint's _model_kwargs would silently reconstruct the wrong
+    architecture from a saved FlowMatching checkpoint."""
+    training_source = inspect.getsource(workflows.train_il.task_function)
+    assert "planner_mode: str = \"bezier\"" in training_source
+    assert "planner_kwargs: Optional[dict] = None" in training_source
+    assert "planner_mode=planner_mode, planner_kwargs=planner_kwargs" in training_source
+    assert '"planner_mode": planner_mode' in training_source
+    assert '"planner_kwargs": planner_kwargs' in training_source
+
+    wf_source = inspect.getsource(workflows.wf_train_il._workflow_function)
+    assert "planner_mode: str = \"bezier\"" in wf_source
+    assert "planner_mode=planner_mode, planner_kwargs=planner_kwargs" in wf_source
+
+
 def test_training_seed_controls_comparable_navigation_runs():
     training_function = workflows.train_il.task_function
     training_source = inspect.getsource(training_function)

--- a/Platform/pipelines/workflows.py
+++ b/Platform/pipelines/workflows.py
@@ -2679,7 +2679,6 @@ def train_il(
         torch.multiprocessing.set_sharing_strategy("file_system")
 
     from model_components.auto_e2e import AutoE2E
-    from model_components.losses import TrajectoryImitationLoss
     from training.dataset_policy import (
         AUTO_E2E_TIMESTEPS,
         adapt_egomotion_history,
@@ -3137,13 +3136,18 @@ def train_il(
         factor=0.5,
         patience=1,
     )
-    loss_fn = TrajectoryImitationLoss(
-        loss_type="smooth_l1",
-        temporal_decay=training_policy.temporal_decay,
-        signal_scales=training_policy.signal_scales,
-    )
-    if hasattr(loss_fn, "to"):
-        loss_fn = loss_fn.to(device)
+    # NOTE (#115/#124): TrajectoryImitationLoss used to be instantiated here
+    # and applied externally to whatever forward() returned — which, for
+    # FlowMatchingPlanner, meant SmoothL1-regressing the Euler-from-noise
+    # ROLLOUT instead of ever running the real velocity-MSE objective. The
+    # loss is now computed inside each planner's own compute_planner_loss
+    # (BasePlanner contract), reached via model(..., return_planner_loss=True,
+    # training_policy=training_policy) below — training_policy is passed
+    # through as the object itself so BezierPlanner's internal
+    # TrajectoryImitationLoss uses the exact same signal_scales/temporal_decay
+    # this print statement reports, instead of the two silently drifting
+    # apart (#124 review: (1.0, 1.0) vs (0.79, 0.12) measured a 71% loss
+    # difference with no error).
     print(
         "Dataset training policy: "
         f"auto_e2e_timesteps={AUTO_E2E_TIMESTEPS} "
@@ -3540,11 +3544,14 @@ def train_il(
                             route_valid=route_valid,
                             projection=proj_dev, geometry_type=batch_geom,
                             mode="train", trajectory_target=target,
+                            training_policy=training_policy,
+                            return_planner_loss=True,
                             history_frames=history_frames, future_frames=future_frames)
-                # Train mode returns (trajectory, aux) when a branch (reasoning /
-                # world model) is on; otherwise just the trajectory tensor.
-                trajectory, aux = out if isinstance(out, tuple) else (out, {})
-                traj_loss = loss_fn(trajectory, target)
+                # return_planner_loss=True: train mode returns (loss_dict, aux)
+                # when a branch (reasoning / world model) is on; otherwise
+                # just loss_dict (see BasePlanner.compute_planner_loss / #115).
+                result, aux = out if isinstance(out, tuple) else (out, {})
+                traj_loss = result["loss"]
                 loss = traj_loss
 
                 # JEPA loss (#13): future-feature reconstruction, added when the

--- a/Platform/pipelines/workflows.py
+++ b/Platform/pipelines/workflows.py
@@ -2609,6 +2609,16 @@ def train_il(
     num_workers: int = 0,
     resume_from: Optional[FlyteFile] = None,
     early_stopping_patience: int = 3,
+    # Not threaded through to AutoE2E anywhere in this workflow until now —
+    # every train_il run has silently used AutoE2E.__init__'s own default
+    # ("bezier") regardless of intent. Added alongside the
+    # compute_planner_loss/train_il wiring (#115/#124) specifically so a
+    # FlowMatching run is actually launchable: compute_planner_loss makes
+    # FlowMatching correctly trainable for the first time, but that's moot
+    # if nothing can select it. planner_kwargs lets a launcher override
+    # e.g. num_inference_steps without a code change.
+    planner_mode: str = "bezier",
+    planner_kwargs: Optional[dict] = None,
 ) -> TrainOutput:
     """Train AutoE2E model on pre-extracted WebDataset shards.
 
@@ -2622,6 +2632,14 @@ def train_il(
     imitation loss. If reasoning is on but a batch has no labels, only the
     trajectory loss is used for that batch (the branch still runs, zero-init so
     it does not perturb the trajectory until trained).
+
+    ``planner_mode`` ("bezier" default, or "flow_matching") selects the
+    trajectory decoder — see Model/model_components/trajectory_planning/
+    __init__.py's PLANNER_REGISTRY. ``planner_kwargs`` forwards to that
+    planner's constructor (e.g. ``{"num_inference_steps": 10}`` for
+    flow_matching). Saved into the checkpoint's config so
+    evaluate_kitscenes_benchmark_checkpoint reconstructs the right
+    architecture automatically (see _model_kwargs).
 
     When ``enable_world_model`` is set and the shards carry World-Model windows
     (packed via data_processing(world_model=True)), the JEPA future-feature
@@ -3119,9 +3137,12 @@ def train_il(
         map_context_channels=map_context_channels,
         route_channels=route_channels,
         enable_route_conditioning=enable_route_conditioning,
+        planner_mode=planner_mode, planner_kwargs=planner_kwargs,
         enable_reasoning=enable_reasoning, reasoning_mode=reasoning_mode,
         enable_world_model=enable_world_model,
     ).to(device)
+    print(f"Planner: {planner_mode}"
+          + (f" (kwargs={planner_kwargs})" if planner_kwargs else ""))
     print(f"Reasoning: {'on' if enable_reasoning else 'off'}"
           + (f" (mode={reasoning_mode})" if enable_reasoning else ""))
     print(f"World Model: {'on' if enable_world_model else 'off'}")
@@ -3178,6 +3199,8 @@ def train_il(
         "map_context_channels": map_context_channels,
         "route_channels": route_channels,
         "enable_route_conditioning": enable_route_conditioning,
+        "planner_mode": planner_mode,
+        "planner_kwargs": planner_kwargs,
         "navigation_quality_audit_sha256": (
             navigation_quality_audit_sha256
         ),
@@ -6234,6 +6257,8 @@ def wf_train_il(
     num_workers: int = 0,
     resume_from: Optional[FlyteFile] = None,
     early_stopping_patience: int = 3,
+    planner_mode: str = "bezier",
+    planner_kwargs: Optional[dict] = None,
 ) -> EvalMetrics:
     """IL Train → Evaluate. All datasets' shards passed in; `dataset` selects one.
 
@@ -6249,6 +6274,10 @@ def wf_train_il(
     may explicitly select a deterministic subset split for smoke runs.
     ``num_workers`` > 0 parallelizes JPEG decode across worker processes (#121 P0)
     — the dominant per-epoch cost once episodes scale up.
+    ``planner_mode`` ("bezier" default, or "flow_matching") selects the
+    trajectory decoder — see train_il's own docstring. Not previously
+    exposed at this level; every prior wf_train_il run silently trained
+    Bezier regardless of intent.
     """
     out = train_il(shards=shards, dataset=dataset, backbone=backbone,
                    epochs=epochs, batch_size=batch_size,
@@ -6260,6 +6289,7 @@ def wf_train_il(
                    enable_world_model=enable_world_model, val_fraction=val_fraction,
                    validation_scope=validation_scope,
                    num_workers=num_workers, resume_from=resume_from,
+                   planner_mode=planner_mode, planner_kwargs=planner_kwargs,
                    early_stopping_patience=early_stopping_patience)
     return evaluate_il_policy(checkpoint=out.checkpoint, shards=shards, dataset=dataset,
                               train_metadata=out.metadata)


### PR DESCRIPTION
## Summary

Wires BasePlanner.compute_planner_loss (#115) into train_il for real, threads
the dataset-specific training policy through it (#124 review), and exposes
planner_mode so a FlowMatching run can actually be launched.

## What's in here

- BasePlanner.compute_planner_loss is now an abstractmethod returning
  dict[str, Tensor] with "loss" — FlowMatchingPlanner does real velocity-MSE,
  BezierPlanner does SmoothL1, both share a trajectory_target shape/device
  validator lifted onto BasePlanner.
- training_policy (the DatasetTrainingPolicy object, not pre-extracted
  scalars) threads from train_il through AutoE2E/ReactiveE2E into
  BezierPlanner.compute_planner_loss, which builds a real weighted
  TrajectoryImitationLoss from it. FlowMatchingPlanner accepts the same
  param for signature parity but does not apply it (documented why —
  scaling accel/curvature on a direct regression vs. a velocity target
  aren't obviously the same operation; left as an open question rather
  than guessed at).
- ReactiveE2E.forward() / AutoE2E.forward(): new explicit
  return_planner_loss=False opt-in. Default False so the ~20 existing call
  sites that already pass trajectory_target expecting a plain trajectory
  tensor back are completely unaffected. train_il is the one caller that
  sets it True.
- train_il: removed the external TrajectoryImitationLoss instantiation;
  loss now read from model(..., return_planner_loss=True,
  training_policy=training_policy)'s result["loss"].
- train_il / wf_train_il: exposed planner_mode / planner_kwargs, threaded
  into AutoE2E(...) and saved into checkpoint_config. Found while preparing
  to actually request a training run — neither function had ANY way to
  select flow_matching before this; every run silently trained bezier
  regardless of intent, which would have made the compute_planner_loss fix
  above untestable in practice.
- Rebased onto main post-#161 (route-conditioned navigation inputs) — one
  contained conflict in reactive_e2e.py's forward() signature (both sides
  added params to the same line), resolved by keeping #161's new positional
  route params and adding ours alongside. Everything else, including this
  PR's own dispatch logic, auto-merged cleanly onto the new
  NavigationEncoder/fused_features flow.
- Removed a stale RuntimeWarning in build_planner() that claimed
  flow_matching "is NOT correctly trainable via train_il" — no longer true
  as of this PR.

## Why

The actual #115 bug, traced to its source: train_il called
model(mode="train", trajectory_target=target, ...), but trajectory_target
was silently absorbed as an inert kwarg all the way down to
ReactiveE2E.forward(), which called planner.forward() unconditionally
regardless of mode. FlowMatchingPlanner's Euler-from-noise rollout got
SmoothL1-regressed against the target externally instead of ever running
its real velocity-MSE objective.

## Not in this PR

FlowMatching + #76's TrajectoryComplianceScorer as a third benchmark row —
evaluate_kitscenes_benchmark_checkpoint doesn't call the scorer at all
today, so that's real work I haven't started. Will follow as its own PR
once a FlowMatching checkpoint actually exists to test it against.

## Testing done

test_planner_loss.py (incl. training_policy regression tests — proves the
policy actually changes BezierPlanner's loss, matching the 71% divergence
measured in review), test_auto_e2e.py (incl. tests exercising
return_planner_loss=True end-to-end: loss dict shape, gradient reaches the
Backbone, training_policy changes the number), test_workflow_training_
lifecycle.py (source-inspection tests for both the training_policy wiring
and the new planner_mode wiring), test_reasoning_integration.py. All
passing, ruff clean, verified against main post-#161 rebase.

## Checklist

- [x] Conventional Commit PR title
- [x] References #115 / this thread's discussion
- [x] Existing callers unaffected (return_planner_loss defaults False)
- [x] Tests pass, ruff clean
- [x] Rebased onto current main (post-#161)
- [x] FlowMatching is actually launchable now (planner_mode exposed)