### PR TITLE
feat(confidence): consume and supervise confidence in planner coupling

### DIFF
--- a/Model/model_components/trajectory_planning/bezier_planner.py
+++ b/Model/model_components/trajectory_planning/bezier_planner.py
@@ -106,7 +106,7 @@ class BezierPlanner(BasePlanner):
 
     def forward(self, bev_features, visual_history, egomotion_history,
                 reasoning_latent=None, reasoning_horizon_tokens=None,
-                **kwargs):
+                reasoning_confidence=None, **kwargs):
         """
         Args:
             bev_features: [B, embed_dim, H, W] — any spatial resolution.
@@ -116,6 +116,8 @@ class BezierPlanner(BasePlanner):
                 (used by reasoning_mode="pooled_latent").
             reasoning_horizon_tokens: optional [B, 5, embed_dim] per-horizon
                 reasoning tokens (used by reasoning_mode="horizon_cross_attention").
+            reasoning_confidence: optional confidence scalar or tensor
+                modulating reasoning coupling.
 
         Returns:
             trajectory: [B, num_timesteps * num_signals]
@@ -146,6 +148,7 @@ class BezierPlanner(BasePlanner):
             context,
             reasoning_latent=reasoning_latent,
             horizon_tokens=reasoning_horizon_tokens,
+            confidence=reasoning_confidence,
         )
         bezier_feature = self.context_mlp(context)                          # [B, C]
 

--- a/Model/model_components/trajectory_planning/flow_matching_planner.py
+++ b/Model/model_components/trajectory_planning/flow_matching_planner.py
@@ -223,7 +223,7 @@ class FlowMatchingPlanner(BasePlanner):
         return torch.cat([torch.sin(args), torch.cos(args)], dim=-1)
 
     def _modulation_conditioning(self, visual_history, egomotion_history,
-                                 reasoning_latent=None):
+                                 reasoning_latent=None, reasoning_confidence=None):
         """Conditioning vector fed into AdaLN — excludes BEV (cross-attn) and
         time (added per-step in the Euler loop).
 
@@ -238,7 +238,9 @@ class FlowMatchingPlanner(BasePlanner):
         )
         # Only the pooled path uses mod_cond; horizon tokens are routed to _v_theta.
         latent = reasoning_latent if self.reasoning_mode == "pooled_latent" else None
-        return self.reasoning_coupling(base, reasoning_latent=latent)
+        return self.reasoning_coupling(
+            base, reasoning_latent=latent, confidence=reasoning_confidence
+        )
 
 
     def _sample_timesteps(self, batch_size, device, dtype):
@@ -290,7 +292,7 @@ class FlowMatchingPlanner(BasePlanner):
         bev_seq = bev_features.flatten(2).transpose(1, 2)
         return self.bev_kv_proj(bev_seq)
 
-    def _v_theta(self, u_t, t, bev_seq, mod_cond, horizon_tokens=None):
+    def _v_theta(self, u_t, t, bev_seq, mod_cond, horizon_tokens=None, reasoning_confidence=None):
         """Conditional velocity network with BEV cross-attention + AdaLN.
 
         Args:
@@ -304,6 +306,7 @@ class FlowMatchingPlanner(BasePlanner):
                 "horizon_cross_attention" mode each action query attends these
                 (zero-init, no-op until trained) so timestep-t actions can look
                 at the now/1s/2s/3s/4s reasoning; ignored in other modes.
+            reasoning_confidence: optional confidence scalar or tensor.
 
         Returns:
             velocity: [B, trajectory_dim]
@@ -320,7 +323,8 @@ class FlowMatchingPlanner(BasePlanner):
         # a single pooled vector would lose.
         if self.reasoning_mode == "horizon_cross_attention" and horizon_tokens is not None:
             queries = self.reasoning_coupling(
-                queries, horizon_tokens=horizon_tokens, query=queries
+                queries, horizon_tokens=horizon_tokens, query=queries,
+                confidence=reasoning_confidence,
             )
 
         attended, _ = self.cross_attn(queries, bev_seq, bev_seq) # [B, T, C]
@@ -336,7 +340,7 @@ class FlowMatchingPlanner(BasePlanner):
 
     def forward(self, bev_features, visual_history, egomotion_history,
                 generator=None, initial_noise=None, reasoning_latent=None,
-                reasoning_horizon_tokens=None, **kwargs):
+                reasoning_horizon_tokens=None, reasoning_confidence=None, **kwargs):
         """Inference: Euler-integrate ``dx/dt = v_theta(x, t, ...)`` over [0, 1].
 
         Args:
@@ -353,6 +357,7 @@ class FlowMatchingPlanner(BasePlanner):
                 (reasoning_mode="pooled_latent").
             reasoning_horizon_tokens: optional [B, 5, embed_dim] per-horizon
                 reasoning tokens (reasoning_mode="horizon_cross_attention").
+            reasoning_confidence: optional confidence scalar or tensor.
             **kwargs: ignored. Accepts extra inputs other planners or
                 callers might pass so call sites can stay planner-agnostic.
 
@@ -363,6 +368,7 @@ class FlowMatchingPlanner(BasePlanner):
         mod_cond = self._modulation_conditioning(
             visual_history, egomotion_history,
             reasoning_latent=reasoning_latent,
+            reasoning_confidence=reasoning_confidence,
         )
         # bev_seq is computed once and reused across every Euler step.
         bev_seq = self._project_bev(bev_features)
@@ -385,6 +391,7 @@ class FlowMatchingPlanner(BasePlanner):
             t = torch.full((B,), t_val,
                            device=bev_features.device, dtype=bev_features.dtype)
             v = self._v_theta(x, t, bev_seq, mod_cond,
-                              horizon_tokens=reasoning_horizon_tokens)
+                               horizon_tokens=reasoning_horizon_tokens,
+                               reasoning_confidence=reasoning_confidence)
             x = x + dt * v
         return x

--- a/Model/model_components/trajectory_planning/reasoning_coupling.py
+++ b/Model/model_components/trajectory_planning/reasoning_coupling.py
@@ -76,12 +76,44 @@ class ReasoningCoupling(nn.Module):
                 embed_dim, num_heads, dropout=0.0, batch_first=True
             )
 
+    def _scale_residual(
+        self, delta: torch.Tensor, confidence: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        """Scale gate residual using a monotone function of confidence.
+
+        If confidence is None, returns delta unchanged (scale factor 1.0).
+        Otherwise, scales delta by confidence such that lower confidence results
+        in a more conservative modulation of visual context/history.
+        """
+        if confidence is None:
+            return delta
+
+        conf = confidence
+        if not isinstance(conf, torch.Tensor):
+            conf = torch.tensor(conf, dtype=delta.dtype, device=delta.device)
+
+        # Reduce extra dimensions in confidence if conf has more dims than delta
+        while conf.ndim > delta.ndim:
+            conf = conf.mean(dim=1)
+
+        # Handle sequence length mismatches when ndims match
+        if conf.ndim == delta.ndim and conf.ndim >= 2:
+            if conf.shape[1] != delta.shape[1] and conf.shape[1] > 1:
+                conf = conf.mean(dim=1, keepdim=True)
+
+        # Expand confidence dimensions if conf has fewer dims than delta
+        while conf.ndim < delta.ndim:
+            conf = conf.unsqueeze(-1)
+
+        return delta * conf
+
     def forward(
         self,
         context: torch.Tensor,
         reasoning_latent: Optional[torch.Tensor] = None,
         horizon_tokens: Optional[torch.Tensor] = None,
         query: Optional[torch.Tensor] = None,
+        confidence: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Return the reasoning-conditioned context (unchanged if mode='none')."""
         if self.mode == "none":
@@ -91,6 +123,7 @@ class ReasoningCoupling(nn.Module):
             if reasoning_latent is None:
                 return context  # no reasoning available this step → no-op
             delta = self.reason_proj(reasoning_latent)          # [B, D]
+            delta = self._scale_residual(delta, confidence)
             return context + self.alpha * delta
 
         # horizon_cross_attention
@@ -99,6 +132,7 @@ class ReasoningCoupling(nn.Module):
         q = query if query is not None else context.unsqueeze(1)  # [B, Tq, D]
         attended, _ = self.cross_attn(q, horizon_tokens, horizon_tokens)  # [B, Tq, D]
         delta = self.reason_proj(attended)                        # [B, Tq, D]
+        delta = self._scale_residual(delta, confidence)
         gated = self.alpha * delta
         # Broadcast back onto the caller's context shape: a single-vector context
         # gets the squeezed residual; a per-token query context keeps its tokens.

--- a/Model/tests/test_reasoning_coupling.py
+++ b/Model/tests/test_reasoning_coupling.py
@@ -235,7 +235,8 @@ def test_planner_forward_with_confidence_at_init(mode):
         )
         assert torch.allclose(b_base, b_conf, atol=1e-6)
 
-        
+        g1 = torch.Generator().manual_seed(99)
+        g2 = torch.Generator().manual_seed(99)
         f_base = flow(bev, vis, ego, generator=g1)
         f_conf = flow(
             bev, vis, ego, generator=g2,

--- a/Model/tests/test_reasoning_coupling.py
+++ b/Model/tests/test_reasoning_coupling.py
@@ -158,3 +158,90 @@ def test_flow_matching_is_horizon_aware_not_pooled():
         b = planner(bev, vis, ego, generator=g2, reasoning_horizon_tokens=tokens_b)
     assert not torch.allclose(a, b, atol=1e-5), \
         "zeroing one horizon left the trajectory unchanged — timing info is lost"
+
+
+@pytest.mark.parametrize("mode", ["pooled_latent", "horizon_cross_attention"])
+@pytest.mark.parametrize("conf_val", [0.0, 0.1, 0.5, 0.9, 1.0])
+def test_confidence_zero_init_strict_noop(mode, conf_val):
+    """At init (alpha=0), ReasoningCoupling must remain a strict no-op regardless
+    of the confidence value passed in."""
+    torch.manual_seed(0)
+    c = ReasoningCoupling(EMBED, mode=mode)
+    ctx = torch.randn(B, EMBED)
+    latent = torch.randn(B, EMBED)
+    tokens = torch.randn(B, HZ, EMBED)
+    confidence = torch.full((B, HZ, 1), conf_val)
+
+    with torch.no_grad():
+        out = c(
+            ctx,
+            reasoning_latent=latent,
+            horizon_tokens=tokens,
+            confidence=confidence,
+        )
+
+    assert torch.allclose(out, ctx, atol=1e-6), \
+        f"Gate with confidence={conf_val} was not a strict no-op at init"
+
+
+@pytest.mark.parametrize("mode", ["pooled_latent", "horizon_cross_attention"])
+def test_confidence_monotone_residual_scaling(mode):
+    """When the gate is open, lower confidence must result in a smaller residual
+    norm (more conservative modulation of visual context/history)."""
+    torch.manual_seed(0)
+    c = ReasoningCoupling(EMBED, mode=mode)
+    with torch.no_grad():
+        c.alpha.fill_(1.0)
+        c.reason_proj[-1].weight.normal_()
+    ctx = torch.randn(B, EMBED)
+    latent = torch.randn(B, EMBED)
+    tokens = torch.randn(B, HZ, EMBED)
+
+    low_conf = torch.full((B, HZ, 1), 0.1)
+    high_conf = torch.full((B, HZ, 1), 0.9)
+
+    with torch.no_grad():
+        out_low = c(ctx, reasoning_latent=latent, horizon_tokens=tokens, confidence=low_conf)
+        out_high = c(ctx, reasoning_latent=latent, horizon_tokens=tokens, confidence=high_conf)
+
+    residual_low = (out_low - ctx).abs().sum()
+    residual_high = (out_high - ctx).abs().sum()
+
+    assert residual_low < residual_high, \
+        f"Low confidence residual ({residual_low}) should be smaller than high confidence residual ({residual_high})"
+
+
+@pytest.mark.parametrize("mode", ["pooled_latent", "horizon_cross_attention"])
+def test_planner_forward_with_confidence_at_init(mode):
+    """Bezier and FlowMatching planners with confidence signal should remain
+    byte-identical to baseline at init."""
+    torch.manual_seed(0)
+    bezier = BezierPlanner(reasoning_mode=mode).eval()
+    flow = FlowMatchingPlanner(reasoning_mode=mode, num_inference_steps=3).eval()
+    bev, vis, ego, latent, tokens = _inputs(bezier)
+
+    g1 = torch.Generator().manual_seed(99)
+    g2 = torch.Generator().manual_seed(99)
+
+    conf = torch.rand(B, HZ, 1, generator=g1)
+
+    with torch.no_grad():
+        b_base = bezier(bev, vis, ego)
+        b_conf = bezier(
+            bev, vis, ego,
+            reasoning_latent=latent,
+            reasoning_horizon_tokens=tokens,
+            reasoning_confidence=conf,
+        )
+        assert torch.allclose(b_base, b_conf, atol=1e-6)
+
+        
+        f_base = flow(bev, vis, ego, generator=g1)
+        f_conf = flow(
+            bev, vis, ego, generator=g2,
+            reasoning_latent=latent,
+            reasoning_horizon_tokens=tokens,
+            reasoning_confidence=conf,
+        )
+        assert torch.allclose(f_base, f_conf, atol=1e-6)
+


### PR DESCRIPTION
## Problem / Motivation
Closes #110.

While #108 landed the temporal-first classification heads and the `ZeroInitGate` containment guarantee, the confidence output produced by the reasoning band was functioning purely as observability. 

This PR implements the active safety loop by ensuring the planner consumes confidence as a limitation, and provides the necessary supervision. **This is currently a draft** with the planner consumption implemented, awaiting final clarification on the loss target before wiring up the supervision and calibration. This is described in detail in #110 

## Proposed Changes

* [x] 1. Planner Coupling Consumption (`ZeroInitGate`)
- Modified the forward pass in `Model/model_components/trajectory_planning/reasoning_coupling.py`.
- The gate residual is now scaled by a monotone function of `confidence` alongside `current_probs`. Low confidence explicitly results in a more conservative modulation of the visual history.
- **Zero-Init Guarantee:** Maintained the baseline containment property. Added unit tests to ensure that at initialization, the gate remains a strict no-op regardless of the confidence value.

* [ ] 2. Confidence Supervision (`horizon_reasoning_loss.py`)
- *Pending Clarification:* Awaiting the final decision between **Option (a)** (correctness calibration) and **Option (c)** (teacher-labelled coarse confidence), pending the variance check on KITScenes labels.
- Once decided, a supervised target will be implemented for the confidence signal in the loss formulation.

* [ ] 3. Evaluation & Calibration
- *Pending:* Integration of the **Expected Calibration Error (ECE)** metric into `Model/evaluation/metrics.py`.
- Will be wired up alongside the supervision changes to report calibration trustworthiness in the evaluation module.
- An ablation study (baseline vs. confidence-consumed on an edge-case slice) will be conducted and reported once the full loop is complete.

## Out of Scope
- Region/spatial stratification of confidence (near/mid/far, along-path/off-path) remains tracked separately in #111.