### PR TITLE
refactor(model): align inference defaults and planner access

### DIFF
--- a/Model/README.md
+++ b/Model/README.md
@@ -1,37 +1,85 @@
-# AutoE2E Architecture
+# AutoE2E Model
 
-## Architecture Diagram
-> **Note:** The architecture diagram is outdated and does not reflect the current implementation (separate map encoder branch, BEV fusion as default, residual map fusion). It will be updated in a follow-up PR.
+## Runtime Composition
 
-<img src="../Media/auto_e2e_architecture.jpg" width="100%">
+`AutoE2E` is the public model. It composes:
 
-## Inputs and Predictions
-**AutoE2E consumes as input:**
-- 7 camera images at 256x256 resolution (providing a surround view of the vehicle)
-- Rendered map tile (indicating the high level road network layout and future route of the vehicle)
-- Egomotion history (speed, acceleration, yaw angle and yaw angle rate for the previous 6.4s at 10Hz sampling rate)
-- Visual history (`(896,)` = 64 frames × 14-dim compressed scene memory; provides frame-to-frame visual context, distinct from the planner GRU's intra-trajectory temporal coherence)
+- `ReactiveE2E`: the camera, map, temporal-memory, optional reasoning, and
+  trajectory-planning path.
+- `WorldActionModel`: an optional visual-history and JEPA branch that shares the
+  reactive camera backbone.
+- `RollingHistoryBuffer`: inference-time state used by the World Model when the
+  caller does not supply an explicit history window.
 
-**AutoE2E outputs a prediction of:**
-- Future driving trajectory (modelled as future acceleration and curvature values over a 6.4s future horizon at 10Hz sampling rate)
-- `ego_hidden` — 256-dim final GRU hidden state from `TrajectoryPlanner` summarising the planner's intent over the prediction horizon. Conditions `FutureState`; replaces the legacy compressed visual feature vector / rolling visual history buffer.
+The default model uses BEV camera fusion, residual map fusion, `NoMemory`, and
+`BezierPlanner`. The World Model and reasoning branch are disabled by default.
+The active planner is available through the read-only
+`model.trajectory_planner` property.
 
-**During training, and for purposes of model introspection, AutoE2E also predicts:**
-- Future visual features at 1.6s intervals for a 6.4s future horizon (what does the future feature representation of the scene look like, this is used for a feature reconstruction loss similar to JEPA)
+## Inputs
 
-**Forward signature:**
+`AutoE2E.forward` consumes:
+
+- `camera_tiles`: `[B, V, 3, H, W]` real camera images.
+- `map_input`: `[B, 3, H_map, W_map]` rasterized BEV navigation map.
+- `visual_history`: `[B, 896]` or `[B, T, 896]`.
+- `egomotion_history`: `[B, 256]` or `[B, T, 256]`.
+- `projection`: an optional `CameraProjectionModel` implementation such as
+  `PinholeProjection` or `FThetaProjection`.
+- `geometry_type`: the matching geometry label. With no calibrated projection,
+  use `"pseudo"` or omit the label.
+- `history_frames`: optional explicit World Model history
+  `[B, T, V, 3, H, W]`.
+
+The navigation map is a separate input branch. It is not counted as a camera
+view.
+
+## Inference
+
+Inference always returns one flattened control tensor:
+
 ```python
-trajectory, ego_hidden, future_visual_features = model(
-    visual_tiles,        # (B, V, 3, H, W) — 7 cameras
-    map_tile,            # (B, 3, H_map, W_map) — BEV nav-map image
-    visual_history,      # (B, 896) — frame-to-frame visual memory
-    egomotion_history,   # (B, 256)
-    camera_params=None,  # (B, V, 3, 4) optional, used by BEV fusion
-    mode="train",        # "train" returns future_visual_features; otherwise None
-)
+model.eval()
+with torch.inference_mode():
+    trajectory = model(
+        camera_tiles=camera_tiles,
+        map_input=map_input,
+        visual_history=visual_history,
+        egomotion_history=egomotion_history,
+        projection=projection,
+        geometry_type=geometry_type,
+        history_frames=history_frames,
+        mode="infer",
+    )
 ```
 
-**To learn the driving policy:**
-- Imitation Learning is used to penalize trajectory prediction as well as World Model Simulation based Reinforcement Learning
+`trajectory` has shape `[B, num_timesteps * num_signals]`, which is `[B, 128]`
+with the defaults. It represents 64 future `(acceleration, curvature)` control
+pairs, not Cartesian waypoints.
 
+`mode="infer"` selects the model's return contract. It does not switch PyTorch
+layers to evaluation behavior, so inference callers must also call
+`model.eval()`.
 
+When the World Model is enabled, supplying `history_frames` uses the stateless
+windowed path. Omitting it updates the model's rolling FIFO; call
+`model.reset_visual_history()` between independent sequences.
+
+## Training Return Contract
+
+With both optional branches disabled, training also returns only `trajectory`.
+When the World Model or reasoning branch is enabled, training returns:
+
+```python
+trajectory, aux_outputs = model(..., mode="train")
+```
+
+`aux_outputs` contains:
+
+- `future_state_pred`: predicted future backbone feature maps, or `None`.
+- `future_frames`: the caller-provided JEPA targets, or `None`.
+- `reasoning_pred`: `HorizonReasoningPrediction`, or `None`.
+
+Training is orchestrated through the Flyte tasks in
+`Platform/pipelines/workflows.py`; there is no standalone local training entry
+point.

--- a/Model/inference/run_forward_pass.py
+++ b/Model/inference/run_forward_pass.py
@@ -16,6 +16,7 @@ def run_forward_pass(backbone, planner_mode, device, embed_dim=256, batch_size=2
     # map_input branch, not a camera view.
     model = AutoE2E(backbone=backbone, num_views=num_views, embed_dim=embed_dim,
                     planner_mode=planner_mode).to(device)
+    model.eval()
 
     # Visual Scene Input: [batch, num_views, channels, height, width]
     camera_tiles = torch.randn(batch_size, num_views, 3, 256, 256).to(device)

--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -84,6 +84,11 @@ class AutoE2E(nn.Module):
             )
             self.visual_history_buffer = RollingHistoryBuffer(history_len=history_len)
 
+    @property
+    def trajectory_planner(self) -> nn.Module:
+        """Return the active planner through the public model interface."""
+        return self.Reactive_E2E.TrajectoryPlanner
+
     def reset_visual_history(self):
         """Clear the World Model's rolling buffer (call between sequences)."""
         if self.visual_history_buffer is not None:
@@ -212,4 +217,3 @@ class AutoE2E(nn.Module):
         return trajectory
         
     
-

--- a/Model/model_components/reactive_e2e.py
+++ b/Model/model_components/reactive_e2e.py
@@ -16,7 +16,7 @@ class ReactiveE2E(nn.Module):
                  map_type="rasterized", map_in_channels=3,
                  map_fusion_mode="residual", map_fusion_kwargs=None,
                  temporal_memory_mode="no_memory", temporal_memory_kwargs=None,
-                 planner_mode="gru", planner_kwargs=None,
+                 planner_mode="bezier", planner_kwargs=None,
                  enable_reasoning=False, reasoning_mode="none",
                  reasoning_kwargs=None):
         super(ReactiveE2E, self).__init__()

--- a/Model/tests/test_bezier_planner.py
+++ b/Model/tests/test_bezier_planner.py
@@ -151,7 +151,7 @@ def test_autoe2e_with_bezier_planner_end_to_end(device):
     from model_components.trajectory_planning import BezierPlanner
 
     model = _autoe2e_bezier(device)
-    assert isinstance(model.Reactive_E2E.TrajectoryPlanner, BezierPlanner)
+    assert isinstance(model.trajectory_planner, BezierPlanner)
 
     x = torch.randn(2, 8, 3, 256, 256, device=device)
     map_input = torch.randn(2, 3, 256, 256, device=device)
@@ -179,7 +179,7 @@ def test_autoe2e_with_bezier_planner_train_mode(device):
 
     (trajectory - target).pow(2).mean().backward()
     assert any(p.grad is not None
-               for p in model.Reactive_E2E.TrajectoryPlanner.parameters()), \
+               for p in model.trajectory_planner.parameters()), \
         "planner must receive gradient from a trajectory loss"
 
 
@@ -191,7 +191,25 @@ def test_autoe2e_default_planner_is_bezier(device):
     with patch("model_components.reactive_e2e.Backbone", _MockBackbone):
         model = AutoE2E(num_views=8,
                         view_fusion_kwargs={"bev_h": 8, "bev_w": 8}).to(device)
-    assert isinstance(model.Reactive_E2E.TrajectoryPlanner, BezierPlanner)
+    assert isinstance(model.trajectory_planner, BezierPlanner)
+    assert model.trajectory_planner is model.Reactive_E2E.TrajectoryPlanner
+    assert not any(
+        key.startswith("trajectory_planner.") for key in model.state_dict()
+    )
+
+
+def test_reactive_e2e_default_planner_is_bezier(device):
+    """ReactiveE2E is also valid when constructed without an outer AutoE2E."""
+    from unittest.mock import patch
+
+    from model_components.reactive_e2e import ReactiveE2E
+
+    with patch("model_components.reactive_e2e.Backbone", _MockBackbone):
+        model = ReactiveE2E(
+            num_views=8,
+            view_fusion_kwargs={"bev_h": 8, "bev_w": 8},
+        ).to(device)
+    assert isinstance(model.TrajectoryPlanner, BezierPlanner)
 
 
 def test_gradients_flow_to_all_parameters(device):

--- a/Model/tests/test_overlay_inference.py
+++ b/Model/tests/test_overlay_inference.py
@@ -50,16 +50,11 @@ class _FakePlanner:
     num_signals = 2
 
 
-class _FakeReactive:
-    TrajectoryPlanner = _FakePlanner()
-
-
 class _NoiseEchoPolicy(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.anchor = torch.nn.Parameter(torch.zeros(()))
         self.trajectory_planner = _FakePlanner()
-        self.Reactive_E2E = _FakeReactive()
         self.reset_count = 0
         self.last_egomotion_history = None
 

--- a/Model/tests/test_overlay_inference.py
+++ b/Model/tests/test_overlay_inference.py
@@ -58,6 +58,7 @@ class _NoiseEchoPolicy(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.anchor = torch.nn.Parameter(torch.zeros(()))
+        self.trajectory_planner = _FakePlanner()
         self.Reactive_E2E = _FakeReactive()
         self.reset_count = 0
         self.last_egomotion_history = None

--- a/Platform/pipelines/inference.py
+++ b/Platform/pipelines/inference.py
@@ -101,11 +101,9 @@ def noise_from(
 
 def _planner(model: torch.nn.Module) -> torch.nn.Module:
     try:
-        return model.Reactive_E2E.TrajectoryPlanner
+        return model.trajectory_planner
     except AttributeError as exc:
-        raise ValueError(
-            "model does not expose Reactive_E2E.TrajectoryPlanner"
-        ) from exc
+        raise ValueError("model does not expose trajectory_planner") from exc
 
 
 def predict_control(

--- a/Platform/pipelines/overlay_precompute.py
+++ b/Platform/pipelines/overlay_precompute.py
@@ -13,11 +13,9 @@ from Platform.pipelines.inference import predict_control
 def planner_is_deterministic(model: torch.nn.Module) -> bool:
     """Return whether the active trajectory planner ignores its noise prior."""
     try:
-        planner = model.Reactive_E2E.TrajectoryPlanner
+        planner = model.trajectory_planner
     except AttributeError as exc:
-        raise ValueError(
-            "model does not expose Reactive_E2E.TrajectoryPlanner"
-        ) from exc
+        raise ValueError("model does not expose trajectory_planner") from exc
     return planner.__class__.__name__.lower().startswith("bezier")
 
 

--- a/Platform/pipelines/overlay_tasks.py
+++ b/Platform/pipelines/overlay_tasks.py
@@ -1265,7 +1265,7 @@ def precompute_overlay_partition(
         "dataset_version": dataset_version,
     })
     deterministic_planner = planner_is_deterministic(model)
-    planner = model.Reactive_E2E.TrajectoryPlanner
+    planner = model.trajectory_planner
     num_inference_steps = int(
         getattr(planner, "num_inference_steps", 1)
     )


### PR DESCRIPTION
## Summary

- default direct `ReactiveE2E` construction to the registered Bezier planner
- expose the active planner through `AutoE2E.trajectory_planner` and migrate Platform inference and overlay callers away from nested model internals
- run the forward-pass demo in evaluation mode and document the current input, output, and optional-branch contracts

## Rationale

`ReactiveE2E` still defaulted to the removed `gru` planner even though `AutoE2E` and the planner registry use Bezier. Platform inference code also reached through `Reactive_E2E.TrajectoryPlanner`, coupling it to the model's internal composition. Separately, `mode="infer"` does not call `nn.Module.eval()`, and the model README described an obsolete three-value return contract.

This change keeps the existing state-dict keys and inference tensor contract while making the planner boundary explicit.

## Validation

- `python -m pytest Model/tests -q` on the configured EC2 GPU host: 614 passed, 7 skipped, 6 deselected
- `ruff check`
- `mypy model_components/auto_e2e.py model_components/reactive_e2e.py inference/run_forward_pass.py tests/test_bezier_planner.py tests/test_overlay_inference.py`

Full-repository `mypy .` continues to report two pre-existing `SeekVideoReader` argument-type errors in `Model/data_parsing/nvidia_physical_ai/camera.py`.
