### PR TITLE
feat(map_encoder): add deformable cross-attention map BEV fusion mode

### DIFF
--- a/Model/model_components/map_encoder/map_bev_fusion/__init__.py
+++ b/Model/model_components/map_encoder/map_bev_fusion/__init__.py
@@ -1,9 +1,11 @@
 from .residual_fusion import ResidualMapFusion
 from .cross_attention_fusion import MapCrossAttentionFusion
+from .deformable_cross_attention_fusion import MapDeformableCrossAttentionFusion
 
 MAP_FUSION_REGISTRY = {
     "residual": ResidualMapFusion,
     "cross_attn": MapCrossAttentionFusion,
+    "deformable": MapDeformableCrossAttentionFusion,
 }
 
 
@@ -11,7 +13,8 @@ def build_map_bev_fusion(fusion_mode: str, embed_dim: int = 256, **kwargs):
     """Construct a map BEV fusion module.
 
     Args:
-        fusion_mode: One of ``"residual"`` or ``"cross_attn"``.
+        fusion_mode: One of ``"residual"``, ``"cross_attn"``, or
+            ``"deformable"``.
         embed_dim: Channel dimension shared by image and map BEV features.
     """
     if fusion_mode not in MAP_FUSION_REGISTRY:

--- a/Model/model_components/map_encoder/map_bev_fusion/deformable_cross_attention_fusion.py
+++ b/Model/model_components/map_encoder/map_bev_fusion/deformable_cross_attention_fusion.py
@@ -1,0 +1,147 @@
+"""Deformable cross-attention map BEV fusion.
+
+Each spatial query in the image BEV attends to K learned-offset sample points
+in the map BEV instead of all H*W tokens. Sampling is done with
+``F.grid_sample`` (bilinear interpolation), so no custom CUDA kernels are
+needed. This drops the cost of fusion from O(N^2) to O(N*K), making it viable
+at production BEV grids (450x300 = 135K tokens) where dense cross-attention
+would OOM.
+
+The design follows the deformable spatial cross-attention introduced by
+BEVFormer: a query predicts K sampling offsets relative to its own reference
+position, samples features there, and aggregates them with per-head softmax
+weights. Unlike BEVFormer, the reference plane here is the map BEV itself, so
+the reference point of each query is simply its own pixel position.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class MapDeformableCrossAttentionFusion(nn.Module):
+    """Fuse image BEV and map BEV via deformable spatial cross-attention.
+
+    Instead of attending to all ``H*W`` map tokens, each query pixel predicts
+    K 2D offsets from its own position, samples the map BEV at those locations
+    (bilinearly), and aggregates the K samples with per-head softmax weights.
+
+    Args:
+        embed_dim: Channel dimension of both input feature maps.
+        num_sample_points: K -- number of offset sample points per query.
+        num_heads: Number of attention heads. Heads share the K sampling
+            locations but learn independent attention weights.
+        dropout: Dropout applied inside the FFN.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int = 256,
+        num_sample_points: int = 4,
+        num_heads: int = 8,
+        dropout: float = 0.1,
+    ) -> None:
+        super().__init__()
+
+        self.embed_dim = embed_dim
+        self.num_points = num_sample_points
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+
+        # Predict K 2D offsets (pixel displacements) from the query feature.
+        self.offset_proj = nn.Linear(embed_dim, num_sample_points * 2)
+
+        # Predict per-head attention weights over the K sample points.
+        self.attn_proj = nn.Linear(embed_dim, num_heads * num_sample_points)
+
+        # Pre-norm on queries, then output projection with residual.
+        self.norm_query = nn.LayerNorm(embed_dim)
+        self.out_proj = nn.Linear(embed_dim, embed_dim)
+
+        # FFN with residual, matching the other fusion modes.
+        self.ffn = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim * 2),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(embed_dim * 2, embed_dim),
+            nn.Dropout(dropout),
+        )
+        self.norm_ffn = nn.LayerNorm(embed_dim)
+
+    def forward(
+        self,
+        image_bev: torch.Tensor,
+        map_bev: torch.Tensor,
+    ) -> torch.Tensor:
+        """Fuse ``map_bev`` into ``image_bev``.
+
+        Args:
+            image_bev: (B, embed_dim, H, W) image BEV features -- queries.
+            map_bev: (B, embed_dim, H, W) map BEV features -- sampled values.
+                Must have the same spatial size as image_bev.
+
+        Returns:
+            (B, embed_dim, H, W) image BEV updated with map context.
+        """
+        B, C, H, W = image_bev.shape
+        N = H * W
+        K = self.num_points
+        nH = self.num_heads
+
+        # Reference grid: each query's own pixel position in grid_sample
+        # coordinates [-1, 1] (align_corners=True).
+        ys = torch.linspace(-1.0, 1.0, H, device=image_bev.device,
+                            dtype=image_bev.dtype)
+        xs = torch.linspace(-1.0, 1.0, W, device=image_bev.device,
+                            dtype=image_bev.dtype)
+        grid_y, grid_x = torch.meshgrid(ys, xs, indexing="ij")
+        ref_grid = torch.stack([grid_x, grid_y], dim=-1)  # (H, W, 2)
+        ref_grid = ref_grid.reshape(1, N, 1, 2)  # (1, N, 1, 2)
+
+        # Flatten spatial dims: (B, N, C)
+        q = image_bev.permute(0, 2, 3, 1).reshape(B, N, C)
+        q_norm = self.norm_query(q)
+
+        # Predict K offsets and per-head attention logits from the query.
+        offsets = self.offset_proj(q_norm).reshape(B, N, K, 2)
+        attn_logits = self.attn_proj(q_norm).reshape(B, N, nH, K)
+
+        # Offsets are pixel displacements; rescale to grid coordinates
+        # (a pixel step is 2/(size-1) with align_corners=True).
+        scale = torch.tensor(
+            [2.0 / (W - 1), 2.0 / (H - 1)],
+            device=image_bev.device,
+            dtype=image_bev.dtype,
+        )
+        offsets = offsets * scale.view(1, 1, 1, 2)
+
+        # Sampling positions = reference + offset. Out-of-map positions are
+        # clamped by grid_sample's padding_mode="border".
+        sample_grid = (ref_grid + offsets).reshape(B, N, K, 2)
+
+        # grid_sample with H_out=N, W_out=K: cell (i, j) holds sample point j
+        # of query i -> (B, C, N, K).
+        sampled = F.grid_sample(
+            map_bev,
+            sample_grid,
+            mode="bilinear",
+            padding_mode="border",
+            align_corners=True,
+        )
+        sampled = sampled.permute(0, 2, 3, 1)  # (B, N, K, C)
+
+        # Split channels per head, weight by softmax over K, and sum.
+        sampled = sampled.reshape(B, N, K, nH, self.head_dim)
+        sampled = sampled.permute(0, 1, 3, 2, 4)  # (B, N, nH, K, head_dim)
+        attn_weights = F.softmax(attn_logits, dim=-1)  # (B, N, nH, K)
+        attn_out = (sampled * attn_weights.unsqueeze(-1)).sum(dim=3)
+        attn_out = attn_out.reshape(B, N, C)  # (B, N, C)
+
+        # Output projection with residual, then FFN with residual.
+        q = q + self.out_proj(attn_out)
+        q = q + self.ffn(self.norm_ffn(q))
+
+        # Reshape back to spatial: (B, C, H, W)
+        return q.reshape(B, H, W, C).permute(0, 3, 1, 2).contiguous()

--- a/Model/tests/test_map_encoder.py
+++ b/Model/tests/test_map_encoder.py
@@ -4,6 +4,8 @@ Covers:
   - RasterizedMapEncoder: output shape, channel layout, gradient flow
   - ResidualMapFusion: zero-alpha init, output shape, alpha learns, gradient flow
   - MapCrossAttentionFusion: output shape, map influences output, gradient flow
+  - MapDeformableCrossAttentionFusion: output shape, map influences output,
+    gradient flow, configurable sample points
   - MAP_ENCODER_REGISTRY and MAP_FUSION_REGISTRY
   - AutoE2E navigation integration: validity-gated map/route inputs are encoded
     only by the Reactive branch, and NavigationEncoder / MapBEVFusion
@@ -24,6 +26,9 @@ from model_components.map_encoder import (
 )
 from model_components.map_encoder.map_bev_fusion.residual_fusion import ResidualMapFusion
 from model_components.map_encoder.map_bev_fusion.cross_attention_fusion import MapCrossAttentionFusion
+from model_components.map_encoder.map_bev_fusion.deformable_cross_attention_fusion import (
+    MapDeformableCrossAttentionFusion,
+)
 
 
 _MAP_H = 256
@@ -196,6 +201,68 @@ class TestMapCrossAttentionFusion:
                 f"Expected (1, 32, {h}, {w}), got {tuple(out.shape)}"
 
 
+class TestMapDeformableCrossAttentionFusion:
+    def test_output_shape(self, device):
+        fusion = MapDeformableCrossAttentionFusion(embed_dim=256).to(device)
+        image_bev, map_bev = _make_bev_pair(2, 256, 8, device)
+        out = fusion(image_bev, map_bev)
+        assert out.shape == (2, 256, 8, 8)
+
+    def test_map_influences_output(self, device):
+        fusion = MapDeformableCrossAttentionFusion(embed_dim=256).to(device)
+        fusion.eval()
+        image_bev = torch.randn(1, 256, 8, 8, device=device)
+        map_a = torch.randn(1, 256, 8, 8, device=device)
+        map_b = torch.randn(1, 256, 8, 8, device=device)
+        out_a = fusion(image_bev, map_a)
+        out_b = fusion(image_bev, map_b)
+        assert not torch.allclose(out_a, out_b, atol=1e-5), \
+            "Different map inputs produced identical output — deformable attention has no effect"
+
+    def test_gradient_flows_through_fusion(self, device):
+        fusion = MapDeformableCrossAttentionFusion(embed_dim=64).to(device)
+        image_bev = torch.randn(1, 64, 4, 4, device=device, requires_grad=True)
+        map_bev = torch.randn(1, 64, 4, 4, device=device, requires_grad=True)
+        fusion(image_bev, map_bev).sum().backward()
+        assert image_bev.grad is not None and image_bev.grad.abs().max() > 0
+        assert map_bev.grad is not None and map_bev.grad.abs().max() > 0
+
+    def test_all_parameters_receive_gradients(self, device):
+        fusion = MapDeformableCrossAttentionFusion(embed_dim=64).to(device)
+        image_bev = torch.randn(1, 64, 4, 4, device=device)
+        map_bev = torch.randn(1, 64, 4, 4, device=device)
+        fusion(image_bev, map_bev).sum().backward()
+        no_grad = [n for n, p in fusion.named_parameters()
+                   if p.requires_grad and p.grad is None]
+        assert not no_grad, f"Parameters without grad: {no_grad}"
+
+    def test_no_nan_with_zero_inputs(self, device):
+        fusion = MapDeformableCrossAttentionFusion(embed_dim=64).to(device)
+        out = fusion(
+            torch.zeros(1, 64, 4, 4, device=device),
+            torch.zeros(1, 64, 4, 4, device=device),
+        )
+        assert torch.isfinite(out).all()
+
+    def test_output_matches_input_spatial_size(self, device):
+        for h, w in [(4, 4), (8, 8), (7, 7), (4, 8)]:
+            fusion = MapDeformableCrossAttentionFusion(embed_dim=32).to(device)
+            image_bev = torch.randn(1, 32, h, w, device=device)
+            map_bev = torch.randn(1, 32, h, w, device=device)
+            out = fusion(image_bev, map_bev)
+            assert out.shape == (1, 32, h, w), \
+                f"Expected (1, 32, {h}, {w}), got {tuple(out.shape)}"
+
+    def test_num_sample_points_is_configurable(self, device):
+        image_bev, map_bev = _make_bev_pair(1, 32, 8, device)
+        for k in (1, 4, 8):
+            fusion = MapDeformableCrossAttentionFusion(
+                embed_dim=32, num_sample_points=k
+            ).to(device)
+            out = fusion(image_bev, map_bev)
+            assert out.shape == (1, 32, 8, 8), \
+                f"K={k} produced {tuple(out.shape)}"
+
 
 class TestMapRegistries:
     def test_rasterized_in_encoder_registry(self):
@@ -205,9 +272,10 @@ class TestMapRegistries:
         with pytest.raises(ValueError, match="Unknown map_type"):
             build_map_encoder("vectorized")
 
-    def test_residual_and_cross_attn_in_fusion_registry(self):
+    def test_all_fusion_modes_in_registry(self):
         assert "residual" in MAP_FUSION_REGISTRY
         assert "cross_attn" in MAP_FUSION_REGISTRY
+        assert "deformable" in MAP_FUSION_REGISTRY
 
     def test_unknown_fusion_mode_raises(self):
         with pytest.raises(ValueError, match="Unknown map_fusion_mode"):
@@ -224,6 +292,10 @@ class TestMapRegistries:
     def test_build_map_bev_fusion_cross_attn(self, device):
         fusion = build_map_bev_fusion("cross_attn", embed_dim=64).to(device)
         assert isinstance(fusion, MapCrossAttentionFusion)
+
+    def test_build_map_bev_fusion_deformable(self, device):
+        fusion = build_map_bev_fusion("deformable", embed_dim=64).to(device)
+        assert isinstance(fusion, MapDeformableCrossAttentionFusion)
 
 
 class TestAutoE2EMapIntegration:
@@ -341,6 +413,33 @@ class TestAutoE2EMapIntegration:
         traj = model(visual, map_input, vis_hist, ego, mode="infer")
         assert traj.shape == (2, 128)
         assert torch.isfinite(traj).all()
+
+    def test_deformable_fusion_mode_forward_succeeds(self, build_mock_model, device):
+        model = self._make_model(build_mock_model, device, map_fusion_mode="deformable")
+        visual = torch.randn(2, 7, 3, 256, 256, device=device)
+        map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
+        vis_hist = torch.randn(2, 896, device=device)
+        ego = torch.randn(2, 256, device=device)
+        traj = model(visual, map_input, vis_hist, ego, mode="infer")
+        assert traj.shape == (2, 128)
+        assert torch.isfinite(traj).all()
+
+    def test_deformable_fusion_parameters_receive_gradients(self, build_mock_model, device):
+        model = self._make_model(build_mock_model, device, map_fusion_mode="deformable")
+        model.train()
+
+        visual = torch.randn(2, 7, 3, 256, 256, device=device)
+        map_input = torch.randn(2, 3, _MAP_H, _MAP_W, device=device)
+        vis_hist = torch.randn(2, 896, device=device)
+        ego = torch.randn(2, 256, device=device)
+
+        traj = model(visual, map_input, vis_hist, ego, mode="train")
+        traj.pow(2).mean().backward()
+
+        no_grad = [n for n, p in model.Reactive_E2E.MapBEVFusion.named_parameters()
+                   if p.requires_grad and p.grad is None]
+        assert not no_grad, \
+            f"MapBEVFusion params without grad: {no_grad}"
 
     def test_map_encoder_attribute_exists(self, build_mock_model, device):
         model = self._make_model(build_mock_model, device)


### PR DESCRIPTION
## feat(map_encoder): add deformable cross-attention as a production-viable map BEV fusion mode

### Motivation & Architectural Context

Map BEV fusion currently offers two modes (introduced in #55):

- `residual`: `image_bev + alpha * map_bev` with a per-channel gate initialized
  to zero. Cheap and stable at any BEV resolution, but spatially rigid -- every
  pixel only ever sees its own map cell.
- `cross_attn`: dense spatial cross-attention where each image BEV query attends
  to every map BEV token. Spatially adaptive, but O(N^2): at the production BEV
  grid (450x300 = 135K tokens) the score matrix is ~10^11 elements and OOMs,
  which is why the module currently raises a guard above 4096 tokens.

This PR adds a third mode, `deformable`, that gives attention-based map fusion
the spatial adaptivity of cross-attention at linear cost: each query attends to
only K learned-offset sample points in the map BEV (K=4 by default), dropping
the complexity from O(N^2) to O(N*K) and making it viable at production
resolution.

The design follows the deformable spatial cross-attention from BEVFormer
(Li et al., 2022): a query predicts sampling offsets relative to its own
reference position, features are sampled at those locations, and the K samples
are aggregated with per-head softmax weights. Since the reference plane here is
the map BEV itself, each query's reference point is simply its own pixel
position, and sampling uses `F.grid_sample` (bilinear, border padding) -- no
custom CUDA kernels required.

### Summary of Changes

#### 1. New fusion module: `MapDeformableCrossAttentionFusion`

**`model_components/map_encoder/map_bev_fusion/deformable_cross_attention_fusion.py`**

```python
class MapDeformableCrossAttentionFusion(nn.Module):
    def __init__(self, embed_dim=256, num_sample_points=4, num_heads=8, dropout=0.1): ...
```

- `offset_proj` predicts K 2D pixel displacements from the query feature;
  `attn_proj` predicts per-head softmax weights over the K sample points.
- Reference grid is each query's own position in grid_sample coordinates;
  sampling positions are reference + offset, with out-of-map positions clamped
  by `padding_mode="border"`.
- `F.grid_sample` yields `(B, C, N, K)`; the channel dim is split per head and
  the K samples are aggregated by weighted sum, followed by a pre-norm output
  projection with residual, then the same FFN + residual block used by the
  cross-attention fusion.
- Interface is identical to the other modes: `forward(image_bev, map_bev)`
  with `(B, C, H, W)` tensors in and out.

#### Why this avoids OOM

Standard attention materializes an attention score matrix of shape
`(B, num_heads, N, N)` -> `(1, 8, 135000, 135000)` at the production grid,
which is ~145.8B elements -- roughly 583 GB in float32 -- and exactly why the
dense `cross_attn` mode carries the >4096-token guard.

Deformable attention never builds that matrix. Its largest intermediate tensor
is the sampled per-head features, `(B, N, num_heads, K, head_dim)` ->
`(1, 135000, 8, 4, 32)` (~138M elements), which is only ~553 MB in float32
(~276 MB under fp16 autocast) -- a ~1000x reduction that fits comfortably on a
12 GB GPU at production resolution.

#### 2. Registry wiring

**`model_components/map_encoder/map_bev_fusion/__init__.py`** registers the new
mode so it can be selected end-to-end via `map_fusion_mode="deformable"`
(AutoE2E -> ReactiveE2E -> `build_map_bev_fusion`):

```python
MAP_FUSION_REGISTRY = {
    "residual": ResidualMapFusion,
    "cross_attn": MapCrossAttentionFusion,
    "deformable": MapDeformableCrossAttentionFusion,
}
```

Constructor options such as `num_sample_points` are forwarded through the
existing `map_fusion_kwargs` plumbing, so no model changes are required.

#### 3. Unit and integration tests

**`tests/test_map_encoder.py`** adds:

- `TestMapDeformableCrossAttentionFusion`: output shape, map influence on
  output, gradient flow, all-parameters-receive-gradients, NaN safety with zero
  inputs, non-square grids, and configurable K.
- Registry tests for the `"deformable"` key via `build_map_bev_fusion`.
- AutoE2E integration tests: `map_fusion_mode="deformable"` forward pass and
  gradient flow through `MapBEVFusion` (mock-backbone harness).

---

### Verification

- All 50 tests in `tests/test_map_encoder.py` pass, including the new
  deformable unit and integration cases.
- `ruff check` and `mypy` are clean for the touched code.
- Full CI unit suite (`pytest Model/tests`) passes.
- Forward pass at the production BEV grid 450x300 (135K tokens) with K=4
  completes without OOM -- the exact failure mode that motivates this mode.

Training sanity check on a small subset of KITScenes tar files (loss goes
down over the first ~6-12 steps):

| Metric   | Start (step 0) | Best (step ~6-12) |
| -------- | -------------- | ----------------- |
| Val loss | 1.012          | 0.083             |
| ADE      | 36.3 m         | 11.2 m            |
| FDE      | 70.9 m         | 28.2 m            |
