### PR TITLE
feat/kitscenes-local-training-scripts

### DIFF
--- a/Platform/scripts/kitscenes/README.md
+++ b/Platform/scripts/kitscenes/README.md
@@ -1,0 +1,117 @@
+# KITScenes local training scripts
+
+Exploratory training of the Reactive branch of AutoE2E on KITScenes without
+the full cluster pipeline (`train_il`). Designed for single-GPU contributor
+machines where the full 4 TB dataset cannot be stored locally. Implements the
+grid search requested in #168.
+
+## Requirements
+
+```bash
+# Python 3.12 venv from repo root
+make setup TORCH_CHANNEL=cu121
+make setup-map
+
+# KITScenes SDK
+cd Model/data_parsing/kit_scenes
+git clone https://github.com/KIT-MRT/kitscenes.git
+cd kitscenes && pip install -e . --no-deps && cd ../../..
+
+# Lanelet2 (required by KITScenes navigation path on x86_64)
+pip install lanelet2
+
+# Native rasterizer
+python Model/navigation/native/build.py
+
+# HuggingFace gated access (account must have accepted KIT-MRT/KITScenes-Multimodal terms)
+huggingface-cli login
+```
+
+## Environment
+
+```bash
+export KITSCENES_ROOT=/path/to/local/scratch  # needs ~20 GB free (one scene at a time)
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+```
+
+Run all scripts from the **repo root**, not from this directory.
+
+## Workflow
+
+### 1. Build the 585/65 scene split
+
+Matches the split specified by @m-zain-khawaja in #168
+(all 533 `data/train/` archives + first 52 `data/val/` archives sorted by
+`sequence_id`, leaving 65 val scenes).
+
+```bash
+python Platform/scripts/kitscenes/build_shard_split.py
+# writes kitscenes_split.json to repo root
+```
+
+### 2. Train — bezier planner (main-compatible)
+
+```bash
+python Platform/scripts/kitscenes/train_one_combo.py \
+  --backbone swin_v2_tiny \
+  --map_fusion_mode residual \
+  --planner_mode bezier \
+  --epochs 1 --batch_size 1 \
+  --bev_h 90 --bev_w 60
+```
+
+### 3. Train — flow_matching planner (requires PR #172)
+
+Verify the branch has `return_planner_loss` before running:
+
+```bash
+python -c "
+import inspect, sys; sys.path.insert(0,'.')
+from Model.model_components.auto_e2e import AutoE2E
+assert 'return_planner_loss' in inspect.signature(AutoE2E.forward).parameters
+print('OK')
+"
+```
+
+```bash
+python Platform/scripts/kitscenes/train_one_combo_fm.py \
+  --backbone swin_v2_tiny \
+  --map_fusion_mode residual \
+  --planner_mode flow_matching \
+  --epochs 1 --batch_size 1 \
+  --bev_h 90 --bev_w 60 \
+  --seed 42
+```
+
+`cross_attn` fusion requires `--bev_h 60 --bev_w 60` (≤ 4096 tokens).
+
+### 4. Compute the constant-velocity baseline
+
+Run this **before** reporting any model ADE. Holds the last observed
+(accel, curvature) from `egomotion_history` and integrates — no GPU,
+no model, no re-download if val scenes are still on disk.
+
+```bash
+python Platform/scripts/kitscenes/constant_velocity_baseline.py
+```
+
+### 5. Evaluate a checkpoint
+
+```bash
+python Platform/scripts/kitscenes/eval_checkpoint.py \
+  --ckpt checkpoints/swin_v2_tiny_residual_bezier_seed42_epoch0.pt
+```
+
+Reports ADE/FDE @ 3 s (post-#176 contract) and @ 6.4 s.
+
+## Important caveats
+
+- **Split**: 585/65 custom split, not the frozen `kitscenes_train_dev_v2.json`
+  manifest enforced by `--validation_scope full`. Numbers from these scripts are
+  not directly comparable with `train_il` results. Report alongside your
+  constant-velocity baseline so the gap is interpretable.
+- **Short scenes**: scenes with fewer than 129 ego poses yield no valid samples
+  under the default 6.4 s window and are skipped. Log `skipped_scenes.log` to
+  track them.
+- **Memory**: tested on RTX 4060 8 GB with `--bev_h 90 --bev_w 60` and
+  gradient checkpointing enabled on both backbones.

--- a/Platform/scripts/kitscenes/build_shard_split.py
+++ b/Platform/scripts/kitscenes/build_shard_split.py
@@ -1,0 +1,57 @@
+import sys
+import os
+import json
+from pathlib import Path
+
+# Dynamically find the repo root (3 folders up) for internal imports
+repo_root = str(Path(__file__).resolve().parents[3])
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
+model_dir = str(Path(repo_root) / "Model")
+if model_dir not in sys.path:
+    sys.path.insert(0, model_dir)
+    
+from Model.data_parsing.kit_scenes.source import (
+    parse_archive_manifest, fetch_archive_manifest, KITSCENES_DATA_REVISION
+)
+
+# Sanitized for public repository
+OUTPUT_DIR = Path(os.environ.get("KITSCENES_ROOT", "./kitscenes_root"))
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+archives = fetch_archive_manifest(OUTPUT_DIR, revision=KITSCENES_DATA_REVISION)
+
+# Sort strictly by scene_id for reproducibility
+train = sorted([a for a in archives.values() if a.split == "train"], key=lambda a: a.scene_id)
+val = sorted([a for a in archives.values() if a.split == "val"], key=lambda a: a.scene_id)
+
+assert len(train) == 533 and len(val) == 117, f"Manifest length mismatch: train={len(train)}, val={len(val)}"
+
+# Extract the 52 validation scenes to append to train
+val_to_train = val[:52]
+val_remaining = val[52:]
+
+train_ids = [a.scene_id for a in train] + [a.scene_id for a in val_to_train]
+val_ids = [a.scene_id for a in val_remaining]
+
+assert len(train_ids) == 585 and len(val_ids) == 65
+
+# Disk math
+total_train_bytes = sum(a.size_bytes for a in train) + sum(a.size_bytes for a in val_to_train)
+total_val_bytes = sum(a.size_bytes for a in val_remaining)
+
+print(f"train: {len(train_ids)} scenes, {total_train_bytes/1e12:.2f} TB")
+print(f"val:   {len(val_ids)} scenes, {total_val_bytes/1e12:.2f} TB")
+
+# Export split logic
+out_data = {
+    "train_ids": train_ids,
+    "val_ids": val_ids,
+    "train_ids_manifest_split": {a.scene_id: a.split for a in train + val_to_train}
+}
+
+with open("kitscenes_split.json", "w") as f:
+    json.dump(out_data, f, indent=2)
+
+print("Wrote kitscenes_split.json")

--- a/Platform/scripts/kitscenes/constant_velocity_baseline.py
+++ b/Platform/scripts/kitscenes/constant_velocity_baseline.py
@@ -1,0 +1,98 @@
+"""Computes the no-perception baseline for YOUR val split.
+Hold last observed (accel, curvature) from egomotion_history and integrate.
+Run this BEFORE reporting any model ADE — needed to contextualise results.
+No GPU, no model, no re-download needed if eval scenes are still on disk.
+"""
+import json
+import shutil
+import sys
+import os
+import time
+from pathlib import Path
+import numpy as np
+
+# Dynamically find the repo root (3 folders up) for internal imports
+repo_root = str(Path(__file__).resolve().parents[3])
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+    
+model_dir = str(Path(repo_root) / "Model")
+if model_dir not in sys.path:
+    sys.path.insert(0, model_dir)    
+
+from Model.data_parsing.kit_scenes import KitScenesDataset
+from Model.data_parsing.kit_scenes.source import PinnedKITScenesDownloader, KITSCENES_DATA_REVISION
+from Model.evaluation.metrics import integrate_trajectory
+
+# Sanitized for public repository
+OUTPUT_DIR = Path(os.environ.get("KITSCENES_ROOT", "./kitscenes_root"))
+SPLIT_FILE = "kitscenes_split.json"
+BACKBONE   = "swinv2_tiny_window8_256"   # any backbone — only egomotion matters here
+
+split    = json.load(open(SPLIT_FILE))
+val_ids  = split["val_ids"]
+manifest = split["train_ids_manifest_split"]
+
+downloader = PinnedKITScenesDownloader(OUTPUT_DIR, revision=KITSCENES_DATA_REVISION)
+
+ade3, fde3 = [], []
+skipped = 0
+
+for i, scene_id in enumerate(val_ids):
+    print(f"scene {i+1}/{len(val_ids)}: {scene_id[:8]}...", end=" ", flush=True)
+    
+    # Simple retry block in case Hugging Face drops connection during evaluation
+    for attempt in range(3):
+        try:
+            downloader.download([scene_id], expected_split="val")
+            break
+        except Exception:
+            if attempt < 2: time.sleep(5)
+
+    try:
+        ds = KitScenesDataset(
+            data_root=str(OUTPUT_DIR),
+            backbone_name=BACKBONE,
+            split="val",
+            scene_ids=[scene_id],
+            include_navigation=True,
+        )
+    except ValueError:
+        print("skipped (too short)")
+        skipped += 1
+        shutil.rmtree(OUTPUT_DIR / "data" / "val" / scene_id, ignore_errors=True)
+        continue
+
+    for sample in ds:
+        # egomotion_history: (256,) = 64 steps × 4 signals
+        # signals: 0=speed, 1=accel, 2=yaw_rate, 3=curvature
+        eh = sample["egomotion_history"].numpy().reshape(64, 4)
+        v0          = float(eh[-1, 0])
+        last_accel  = float(eh[-1, 1])
+        last_curv   = float(eh[-1, 3])
+
+        # ground truth future
+        tgt = sample["trajectory_target"].numpy().reshape(64, 2)
+        gt_accel = tgt[:, 0]
+        gt_curv  = tgt[:, 1]
+
+        # constant-velocity hold: repeat last observed action
+        hold_accel = np.full(64, last_accel)
+        hold_curv  = np.full(64, last_curv)
+
+        gt_xy   = integrate_trajectory(gt_accel,   gt_curv,   v0)
+        hold_xy = integrate_trajectory(hold_accel, hold_curv, v0)
+        err = np.linalg.norm(hold_xy - gt_xy, axis=1)
+
+        ade3.append(err[:30].mean())   # 30 steps = 3s (post-#176 contract)
+        fde3.append(err[29])
+
+    print(f"{len(ade3)} samples so far")
+    shutil.rmtree(OUTPUT_DIR / "data" / "val" / scene_id, ignore_errors=True)
+
+print(f"\n{'='*50}")
+print(f"Constant-velocity baseline — your 65-scene val split")
+print(f"Samples: {len(ade3)}  Skipped scenes: {skipped}")
+print(f"ADE@3s: {np.mean(ade3):.3f} m")
+print(f"FDE@3s: {np.mean(fde3):.3f} m")
+print(f"(gate thresholds per #176: ADE@3s 2.0, FDE@3s 4.0)")

--- a/Platform/scripts/kitscenes/eval_checkpoint.py
+++ b/Platform/scripts/kitscenes/eval_checkpoint.py
@@ -1,0 +1,167 @@
+"""Standalone eval — run against any saved checkpoint from train_one_combo.py.
+Usage:
+  python eval_checkpoint.py --ckpt checkpoints/swin_v2_tiny_residual_bezier_epoch0_step100.pt
+"""
+
+import argparse, json, sys, os
+from pathlib import Path
+import numpy as np
+import torch
+
+# Dynamically find the repo root (3 folders up) for internal imports
+repo_root = str(Path(__file__).resolve().parents[3])
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+    
+model_dir = str(Path(repo_root) / "Model")
+if model_dir not in sys.path:
+    sys.path.insert(0, model_dir)    
+
+from Model.model_components.auto_e2e import AutoE2E
+from Model.model_components.view_fusion.projection import PinholeProjection
+from Model.evaluation.metrics import integrate_trajectory, compute_comfort_metrics
+from rotating_dataset import RotatingSceneKitScenes
+from torch.utils.data import DataLoader
+from timm.data import resolve_model_data_config
+
+BACKBONE_DATASET_TAG = {
+    "swin_v2_tiny": "swinv2_tiny_window8_256",
+    "conv_next_v2_tiny": "convnextv2_tiny",
+    "res_net_50": "resnet50",
+}
+
+def compute_ade_fde_extended(pred_accel, pred_curv, gt_accel, gt_curv, initial_speed):
+    """Extends metrics.py with 6.4s horizon required by m-zain-khawaja."""
+    B = pred_accel.shape[0]
+    results = {k: [] for k in ["ADE@3s","FDE@3s","ADE@6.4s","FDE@6.4s"]}
+    
+    for i in range(B):
+        v0 = float(initial_speed[i])
+        pred_xy = integrate_trajectory(pred_accel[i], pred_curv[i], v0)
+        gt_xy   = integrate_trajectory(gt_accel[i],   gt_curv[i],   v0)
+        errors = np.linalg.norm(pred_xy - gt_xy, axis=1)  # (64,)
+        
+        results["ADE@3s"].append(errors[:30].mean())   # 30 steps = 3.0s
+        results["FDE@3s"].append(errors[29])
+        results["ADE@6.4s"].append(errors.mean())      # all 64 steps = 6.4s
+        results["FDE@6.4s"].append(errors[-1])
+    
+    return {k: float(np.mean(v)) for k, v in results.items()}
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--max_scenes", type=int, default=None,
+                    help="Limit val scenes for a quick sanity check (None = all 65)")
+    ap.add_argument("--bev_h", type=int, default=90)
+    ap.add_argument("--bev_w", type=int, default=60)
+    args = ap.parse_args()
+
+    ckpt = torch.load(args.ckpt, map_location="cpu")
+    run_args = ckpt["args"]
+    print(f"Evaluating: {args.ckpt}")
+    print(f"  Config: {run_args}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    backbone = run_args["backbone"]
+    
+    model = AutoE2E(
+        backbone=backbone,
+        map_fusion_mode=run_args["map_fusion_mode"],
+        planner_mode=run_args["planner_mode"],
+        map_context_channels=14,
+        view_fusion_kwargs={"bev_h": run_args.get("bev_h", 90),
+                            "bev_w": run_args.get("bev_w", 60)},
+    ).to(device)
+    model.load_state_dict(ckpt["model_state"])
+    model.eval()
+
+    split = json.load(open("kitscenes_split.json"))
+    val_ids = split["val_ids"]
+    if args.max_scenes:
+        val_ids = val_ids[:args.max_scenes]
+    print(f"Val scenes: {len(val_ids)}")
+
+    val_manifest = {scene_id: "val" for scene_id in val_ids}
+
+    val_ds = RotatingSceneKitScenes(
+        scene_ids=val_ids,
+        manifest_split_by_id=val_manifest,
+        backbone_name=BACKBONE_DATASET_TAG[backbone],
+        shuffle=False,
+    )
+    loader = DataLoader(val_ds, batch_size=1, num_workers=0)
+
+    data_cfg = resolve_model_data_config(model=BACKBONE_DATASET_TAG[backbone])
+    img_mean = torch.tensor(data_cfg["mean"], device=device).view(1, 1, 3, 1, 1)
+    img_std  = torch.tensor(data_cfg["std"],  device=device).view(1, 1, 3, 1, 1)
+
+    all_pred_accel, all_pred_curv = [], []
+    all_gt_accel,   all_gt_curv   = [], []
+    all_v0 = []
+
+    with torch.no_grad():
+        for step, batch in enumerate(loader):
+            camera_tiles = batch["visual_tiles"].to(device).float() / 255.0
+            camera_tiles = (camera_tiles - img_mean) / img_std
+            map_context  = batch["map_context"].to(device).float()
+            route_mask   = batch.get("route_mask")
+            if route_mask is not None:
+                route_mask = route_mask.to(device).float()
+            visual_history    = batch["visual_history"].to(device).float()
+            egomotion_history = batch["egomotion_history"].to(device).float()
+            trajectory_target = batch["trajectory_target"].to(device).float()
+            camera_params     = batch["camera_params"].to(device).float()
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16,
+                                enabled=(device=="cuda")):
+                out = model(
+                    camera_tiles, map_context, visual_history, egomotion_history,
+                    route_mask=route_mask,
+                    projection=PinholeProjection(camera_params),
+                    geometry_type="pinhole",
+                    mode="infer",  # <-- infer mode: returns trajectory directly, no loss
+                )
+
+            traj_pred = (out if torch.is_tensor(out) else out[0]).float().cpu().numpy()
+            traj_gt   = trajectory_target.float().cpu().numpy()
+
+            # (B, 128) → (B, 64, 2) → split accel/curv
+            pred_ac = traj_pred.reshape(-1, 64, 2)
+            gt_ac   = traj_gt.reshape(-1, 64, 2)
+
+            all_pred_accel.append(pred_ac[:, :, 0])
+            all_pred_curv.append(pred_ac[:, :, 1])
+            all_gt_accel.append(gt_ac[:, :, 0])
+            all_gt_curv.append(gt_ac[:, :, 1])
+
+            # initial speed = last history frame's speed
+            # egomotion_history (B, 256) = 64 steps x 4 signals, speed is signal 0
+            eh = egomotion_history.float().cpu().numpy().reshape(-1, 64, 4)
+            all_v0.append(eh[:, -1, 0])  # speed at last history step
+
+            if step % 100 == 0:
+                print(f"  eval step {step}")
+
+    pred_accel = np.concatenate(all_pred_accel)
+    pred_curv  = np.concatenate(all_pred_curv)
+    gt_accel   = np.concatenate(all_gt_accel)
+    gt_curv    = np.concatenate(all_gt_curv)
+    v0         = np.concatenate(all_v0)
+
+    metrics = compute_ade_fde_extended(pred_accel, pred_curv, gt_accel, gt_curv, v0)
+    comfort  = compute_comfort_metrics(pred_accel, pred_curv, v0)
+
+    print("\n=== RESULTS ===")
+    print(f"Samples evaluated: {len(v0)}")
+    for k, v in metrics.items():
+        print(f"  {k}: {v:.3f} m")
+    print(f"  comfort_violation_rate: {comfort['comfort_violation_rate']:.3f}")
+    print(f"\nConfig: backbone={backbone} map_fusion={run_args['map_fusion_mode']} "
+          f"planner={run_args['planner_mode']}")
+    print(f"Checkpoint: {args.ckpt}")
+    print(f"\nNOTE: val split is 65-scene custom (not the frozen train_il digest). "
+          f"Numbers not directly comparable with contributors using train_il --validation_scope full.")
+
+if __name__ == "__main__":
+    main()

--- a/Platform/scripts/kitscenes/eval_checkpoint.py
+++ b/Platform/scripts/kitscenes/eval_checkpoint.py
@@ -1,8 +1,3 @@
-"""Standalone eval — run against any saved checkpoint from train_one_combo.py.
-Usage:
-  python eval_checkpoint.py --ckpt checkpoints/swin_v2_tiny_residual_bezier_epoch0_step100.pt
-"""
-
 import argparse, json, sys, os
 from pathlib import Path
 import numpy as np
@@ -105,9 +100,19 @@ def main():
             camera_tiles = batch["visual_tiles"].to(device).float() / 255.0
             camera_tiles = (camera_tiles - img_mean) / img_std
             map_context  = batch["map_context"].to(device).float()
+            
             route_mask   = batch.get("route_mask")
             if route_mask is not None:
                 route_mask = route_mask.to(device).float()
+                
+            map_valid = batch.get("map_valid")
+            if map_valid is not None:
+                map_valid = map_valid.to(device)
+
+            route_valid = batch.get("route_valid")
+            if route_valid is not None:
+                route_valid = route_valid.to(device)
+                
             visual_history    = batch["visual_history"].to(device).float()
             egomotion_history = batch["egomotion_history"].to(device).float()
             trajectory_target = batch["trajectory_target"].to(device).float()
@@ -118,6 +123,8 @@ def main():
                 out = model(
                     camera_tiles, map_context, visual_history, egomotion_history,
                     route_mask=route_mask,
+                    route_valid=route_valid,        # added
+                    map_valid=map_valid,            # added
                     projection=PinholeProjection(camera_params),
                     geometry_type="pinhole",
                     mode="infer",  # <-- infer mode: returns trajectory directly, no loss

--- a/Platform/scripts/kitscenes/hold_last_action_baseline.py
+++ b/Platform/scripts/kitscenes/hold_last_action_baseline.py
@@ -37,17 +37,26 @@ downloader = PinnedKITScenesDownloader(OUTPUT_DIR, revision=KITSCENES_DATA_REVIS
 
 ade3, fde3 = [], []
 skipped = 0
+network_failures = 0
 
 for i, scene_id in enumerate(val_ids):
     print(f"scene {i+1}/{len(val_ids)}: {scene_id[:8]}...", end=" ", flush=True)
     
-    # Simple retry block in case Hugging Face drops connection during evaluation
+    download_success = False
     for attempt in range(3):
         try:
             downloader.download([scene_id], expected_split="val")
+            download_success = True
             break
-        except Exception:
-            if attempt < 2: time.sleep(5)
+        except Exception as e:
+            print(f"  download attempt {attempt+1}/3 failed: {e}")
+            if attempt < 2:
+                time.sleep(5)
+                
+    if not download_success:
+        print(f"Scene {scene_id}: skipped due to persistent network failure (not a short scene)")
+        network_failures += 1
+        continue
 
     try:
         ds = KitScenesDataset(
@@ -76,7 +85,7 @@ for i, scene_id in enumerate(val_ids):
         gt_accel = tgt[:, 0]
         gt_curv  = tgt[:, 1]
 
-        # constant-velocity hold: repeat last observed action
+        # hold-last-action: repeat last observed action
         hold_accel = np.full(64, last_accel)
         hold_curv  = np.full(64, last_curv)
 
@@ -91,8 +100,9 @@ for i, scene_id in enumerate(val_ids):
     shutil.rmtree(OUTPUT_DIR / "data" / "val" / scene_id, ignore_errors=True)
 
 print(f"\n{'='*50}")
-print(f"Constant-velocity baseline — your 65-scene val split")
-print(f"Samples: {len(ade3)}  Skipped scenes: {skipped}")
+print("Hold-last-action baseline — your 65-scene val split")
+print("(repeats last observed accel+curvature; harder than zero-accel constant-velocity)")
+print(f"Samples: {len(ade3)}  Skipped (too short): {skipped}  Network failures: {network_failures}")
 print(f"ADE@3s: {np.mean(ade3):.3f} m")
 print(f"FDE@3s: {np.mean(fde3):.3f} m")
 print(f"(gate thresholds per #176: ADE@3s 2.0, FDE@3s 4.0)")

--- a/Platform/scripts/kitscenes/rotating_dataset.py
+++ b/Platform/scripts/kitscenes/rotating_dataset.py
@@ -1,0 +1,106 @@
+import os
+import json
+import shutil
+import random
+import torch
+from pathlib import Path
+from torch.utils.data import IterableDataset
+import time
+import sys
+
+# Dynamically find the repo root (3 folders up) for internal imports
+repo_root = str(Path(__file__).resolve().parents[3])
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+    
+model_dir = str(Path(repo_root) / "Model")
+if model_dir not in sys.path:
+    sys.path.insert(0, model_dir)    
+
+from Model.data_parsing.kit_scenes.source import PinnedKITScenesDownloader, KITSCENES_DATA_REVISION
+from Model.data_parsing.kit_scenes import KitScenesDataset
+from Model.navigation.artifacts import raster_from_sample_members
+
+# Sanitized for public repository
+OUTPUT_DIR = Path(os.environ.get("KITSCENES_ROOT", "./kitscenes_root"))
+
+# Global downloader instance leveraging HF token from environment if present
+downloader = PinnedKITScenesDownloader(
+    OUTPUT_DIR, 
+    revision=KITSCENES_DATA_REVISION,
+    token=None
+)
+
+class RotatingSceneKitScenes(IterableDataset):
+    """One scene materialized on disk at a time; deleted before the next."""
+    
+    def __init__(self, scene_ids, manifest_split_by_id, backbone_name, shuffle=True, seed=0):
+        self.scene_ids = list(scene_ids)
+        self.manifest_split = manifest_split_by_id
+        self.backbone_name = backbone_name
+        self.shuffle = shuffle
+        self.seed = seed
+        self.epoch = 0
+
+    def set_epoch(self, epoch):
+        self.epoch = epoch
+
+    def __iter__(self):
+        order = list(self.scene_ids)
+        if self.shuffle:
+            random.Random(self.seed + self.epoch).shuffle(order)
+
+        for i, scene_id in enumerate(order):
+            real_split = self.manifest_split[scene_id]
+            
+            # --- PROGRESS TRACKER ---
+            print(f"\n>>> [Epoch {self.epoch}] Processing Scene {i+1}/{len(order)}: {scene_id} <<<")
+            
+            # Fetch scene on demand
+            max_retries = 10
+            download_success = False
+            
+            for attempt in range(max_retries):
+                try:
+                    downloader.download([scene_id], expected_split=real_split)
+                    download_success = True
+                    break
+                except Exception as e:
+                    print(f"\n[Network Error] HuggingFace download failed: {e}")
+                    if attempt < max_retries - 1:
+                        print(f"Retrying in 10 seconds (Attempt {attempt+2}/{max_retries})...")
+                        time.sleep(10)
+            
+            if not download_success:
+                print(f"Skipping scene {scene_id} due to persistent network failures.")
+                continue
+            
+            try:
+                ds = KitScenesDataset(
+                    data_root=str(OUTPUT_DIR),
+                    backbone_name=self.backbone_name,
+                    split=real_split,
+                    scene_ids=[scene_id],
+                    include_navigation=True,
+                )
+            except ValueError as e:
+                if "No valid samples" not in str(e):
+                    raise  # don't swallow a genuinely different error
+                print(f"Skipping scene {scene_id}: too few poses ({e})")
+                shutil.rmtree(OUTPUT_DIR / "data" / real_split / scene_id, ignore_errors=True)
+                continue
+
+            try:
+                for sample in ds:
+                    raster = raster_from_sample_members(sample["navigation_members"])
+                    
+                    sample["map_context"] = torch.from_numpy(raster.map_context.copy())
+                    sample["route_mask"] = torch.from_numpy(raster.route_mask.copy())
+                    sample["map_valid"] = torch.tensor(raster.map_valid)
+                    sample["route_valid"] = torch.tensor(raster.route_valid)
+                    
+                    yield sample
+                    
+            finally:
+                scene_path = OUTPUT_DIR / "data" / real_split / scene_id
+                shutil.rmtree(scene_path, ignore_errors=True)

--- a/Platform/scripts/kitscenes/train_one_combo.py
+++ b/Platform/scripts/kitscenes/train_one_combo.py
@@ -1,0 +1,167 @@
+import os
+# Must be set before any CUDA call. Reduces the allocator-fragmentation
+# stalls PyTorch itself suggested in the OOM message.
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+import sys
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+from timm.data import resolve_model_data_config
+
+# Dynamically find the repo root (3 folders up) for internal imports
+repo_root = str(Path(__file__).resolve().parents[3])
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+    
+model_dir = str(Path(repo_root) / "Model")
+if model_dir not in sys.path:
+    sys.path.insert(0, model_dir)    
+
+from Model.model_components.auto_e2e import AutoE2E
+from Model.model_components.view_fusion.projection import PinholeProjection
+from rotating_dataset import RotatingSceneKitScenes 
+
+BACKBONE_DATASET_TAG = {
+    "swin_v2_tiny": "swinv2_tiny_window8_256",
+    "conv_next_v2_tiny": "convnextv2_tiny",
+    "res_net_50": "resnet50",
+}
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--backbone", required=True, choices=BACKBONE_DATASET_TAG.keys())
+    ap.add_argument("--map_fusion_mode", required=True, choices=["residual", "cross_attn"])
+    ap.add_argument("--planner_mode", required=True, choices=["bezier", "flow_matching"])
+    ap.add_argument("--epochs", type=int, default=1)
+    ap.add_argument("--batch_size", type=int, default=2)
+    # Reduced BEV grid to save memory on 8GB VRAM
+    ap.add_argument("--bev_h", type=int, default=90)
+    ap.add_argument("--bev_w", type=int, default=60)
+    ap.add_argument("--bf16", action="store_true", default=True,
+                    help="Use bfloat16 autocast (safe on Ampere+; fp16 is explicitly "
+                         "off by default in train_il due to GradScaler overflow)")
+    ap.add_argument("--no_bf16", dest="bf16", action="store_false")
+    ap.add_argument("--ckpt_dir", type=str, default="checkpoints")
+    args = ap.parse_args()
+
+    if args.planner_mode == "flow_matching":
+        raise SystemExit(
+            "flow_matching deferred per your plan — use your wired-in "
+            "compute_planner_loss version for this arm, not this script."
+        )
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    use_amp = args.bf16 and device == "cuda"
+
+    split = json.load(open("kitscenes_split.json"))
+    train_ds = RotatingSceneKitScenes(
+        scene_ids=split["train_ids"],
+        manifest_split_by_id=split["train_ids_manifest_split"],
+        backbone_name=BACKBONE_DATASET_TAG[args.backbone],
+    )
+    loader = DataLoader(train_ds, batch_size=args.batch_size, num_workers=0)
+
+    model = AutoE2E(
+        backbone=args.backbone,
+        map_fusion_mode=args.map_fusion_mode,
+        planner_mode=args.planner_mode,
+        map_context_channels=14,
+        view_fusion_kwargs={"bev_h": args.bev_h, "bev_w": args.bev_w},
+    ).to(device)
+
+    try:
+        model.Reactive_E2E.Backbone.backbone.set_grad_checkpointing(enable=True)
+        print("Enabled grad checkpointing on Camera Backbone")
+    except AttributeError:
+        pass
+    
+    try:
+        model.Reactive_E2E.NavigationEncoder._backbone.set_grad_checkpointing(enable=True)
+        print("Enabled grad checkpointing on Navigation Backbone")
+    except AttributeError:
+        pass
+
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+    data_cfg = resolve_model_data_config(model=BACKBONE_DATASET_TAG[args.backbone])
+    img_mean = torch.tensor(data_cfg["mean"], device=device).view(1, 1, 3, 1, 1)
+    img_std  = torch.tensor(data_cfg["std"],  device=device).view(1, 1, 3, 1, 1)
+
+    ckpt_dir = Path(args.ckpt_dir)
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    run_tag = f"{args.backbone}_{args.map_fusion_mode}_{args.planner_mode}"
+
+    print(f"Starting training on device: {device} "
+          f"(bev_h={args.bev_h}, bev_w={args.bev_w}, bf16={use_amp})...")
+          
+    for epoch in range(args.epochs):
+        train_ds.set_epoch(epoch)
+        for step, batch in enumerate(loader):
+
+            camera_tiles = batch["visual_tiles"].to(device).float() / 255.0
+            camera_tiles = (camera_tiles - img_mean) / img_std
+
+            map_context = batch["map_context"].to(device).float()
+
+            route_mask = batch.get("route_mask")
+            if route_mask is not None:
+                route_mask = route_mask.to(device).float()
+
+            map_valid = batch.get("map_valid")
+            if map_valid is not None:
+                map_valid = map_valid.to(device)
+
+            route_valid = batch.get("route_valid")
+            if route_valid is not None:
+                route_valid = route_valid.to(device)
+
+            visual_history = batch["visual_history"].to(device).float()
+        
+            egomotion_history = batch["egomotion_history"].to(device).float()
+            trajectory_target = batch["trajectory_target"].to(device).float()
+            camera_params = batch["camera_params"].to(device).float()
+
+            if step == 0 and epoch == 0:
+                print("camera_tiles:", camera_tiles.shape)
+                print("visual_history:", visual_history.shape)
+                print("egomotion_history:", egomotion_history.shape)
+                print("map_context:", map_context.shape)
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=use_amp):
+                out = model(
+                  camera_tiles,
+                  map_context,
+                  visual_history,
+                  egomotion_history,
+                  route_mask=route_mask,
+                  map_valid=map_valid,
+                  route_valid=route_valid,
+                  projection=PinholeProjection(camera_params),
+                  geometry_type="pinhole",
+                  trajectory_target=trajectory_target,
+                  mode="train",
+                )
+
+                trajectory = out if torch.is_tensor(out) else out[0]
+                loss = F.smooth_l1_loss(trajectory, trajectory_target)
+
+            opt.zero_grad()
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            opt.step()
+
+            if step % 20 == 0:
+                print(f"epoch {epoch} step {step} loss {loss.item():.4f}")
+
+        ckpt_path = ckpt_dir / f"{run_tag}_epoch{epoch}.pt"
+        torch.save({"epoch": epoch, "model_state": model.state_dict(),
+                    "opt_state": opt.state_dict(), "args": vars(args)}, ckpt_path)
+        print(f"saved checkpoint: {ckpt_path}")
+
+if __name__ == "__main__":
+    main()

--- a/Platform/scripts/kitscenes/train_one_combo_fm.py
+++ b/Platform/scripts/kitscenes/train_one_combo_fm.py
@@ -1,0 +1,195 @@
+"""Training script using compute_planner_loss() — correct for flow_matching
+and also better for bezier (temporal decay + signal scaling).
+
+Requires: fix/115-compute-planner-loss branch (return_planner_loss flag).
+DO NOT run against main — it will silently fall back to the inference path.
+"""
+import os
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+import sys
+import argparse, json
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from torch.utils.data import DataLoader
+from timm.data import resolve_model_data_config
+
+# Dynamically find the repo root (3 folders up) for internal imports
+repo_root = str(Path(__file__).resolve().parents[3])
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+    
+model_dir = str(Path(repo_root) / "Model")
+if model_dir not in sys.path:
+    sys.path.insert(0, model_dir)    
+
+from Model.model_components.auto_e2e import AutoE2E
+from Model.model_components.view_fusion.projection import PinholeProjection
+from rotating_dataset import RotatingSceneKitScenes
+
+BACKBONE_DATASET_TAG = {
+    "swin_v2_tiny":      "swinv2_tiny_window8_256",
+    "conv_next_v2_tiny": "convnextv2_tiny",
+    "res_net_50":        "resnet50",
+}
+
+# Training policy for bezier — matches intisar1020's physical-unit-aligned scales.
+# training_policy=None is correct for flow_matching (per PR #124 docstring).
+BEZIER_TRAINING_POLICY = SimpleNamespace(
+    temporal_decay=0.95,
+    signal_scales=(0.778, 0.035),   # accel (m/s²), curvature (1/m)
+)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--backbone",       required=True, choices=BACKBONE_DATASET_TAG)
+    ap.add_argument("--map_fusion_mode",required=True, choices=["residual", "cross_attn"])
+    ap.add_argument("--planner_mode",   required=True, choices=["bezier", "flow_matching"])
+    ap.add_argument("--epochs",    type=int, default=1)
+    ap.add_argument("--batch_size",type=int, default=1)
+    ap.add_argument("--bev_h",     type=int, default=90)
+    ap.add_argument("--bev_w",     type=int, default=60)
+    ap.add_argument("--ckpt_dir",  type=str, default="checkpoints")
+    ap.add_argument("--seed",      type=int, default=42)
+    args = ap.parse_args()
+
+    # cross_attn guard — 90x60 = 5400 tokens > 4096 limit
+    if args.map_fusion_mode == "cross_attn" and args.bev_h * args.bev_w > 4096:
+        raise SystemExit(
+            f"cross_attn requires bev_h*bev_w <= 4096 "
+            f"(got {args.bev_h}x{args.bev_w}={args.bev_h*args.bev_w}). "
+            f"Use --bev_h 60 --bev_w 60."
+        )
+
+    torch.manual_seed(args.seed)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    split = json.load(open("kitscenes_split.json"))
+    train_ds = RotatingSceneKitScenes(
+        scene_ids=split["train_ids"],
+        manifest_split_by_id=split["train_ids_manifest_split"],
+        backbone_name=BACKBONE_DATASET_TAG[args.backbone],
+        seed=args.seed,
+    )
+    loader = DataLoader(train_ds, batch_size=args.batch_size, num_workers=0)
+
+    model = AutoE2E(
+        backbone=args.backbone,
+        map_fusion_mode=args.map_fusion_mode,
+        planner_mode=args.planner_mode,
+        map_context_channels=14,
+        view_fusion_kwargs={"bev_h": args.bev_h, "bev_w": args.bev_w},
+    ).to(device)
+
+    # gradient checkpointing on both backbones — confirmed working from M1 runs
+    try:
+        model.Reactive_E2E.Backbone.backbone.set_grad_checkpointing(enable=True)
+        print("grad checkpointing: camera backbone ON")
+    except AttributeError:
+        pass
+    try:
+        model.Reactive_E2E.NavigationEncoder._backbone.set_grad_checkpointing(enable=True)
+        print("grad checkpointing: navigation backbone ON")
+    except AttributeError:
+        pass
+
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-4, weight_decay=1e-2)
+
+    data_cfg = resolve_model_data_config(model=BACKBONE_DATASET_TAG[args.backbone])
+    img_mean = torch.tensor(data_cfg["mean"], device=device).view(1, 1, 3, 1, 1)
+    img_std  = torch.tensor(data_cfg["std"],  device=device).view(1, 1, 3, 1, 1)
+
+    ckpt_dir = Path(args.ckpt_dir)
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    run_tag = f"{args.backbone}_{args.map_fusion_mode}_{args.planner_mode}_seed{args.seed}"
+
+    # training_policy: None for flow_matching (velocity-MSE, scaling doesn't apply)
+    # SimpleNamespace for bezier (temporal decay + physical-unit signal scales)
+    training_policy = (
+        None if args.planner_mode == "flow_matching"
+        else BEZIER_TRAINING_POLICY
+    )
+
+    print(f"Training: {run_tag} | device={device} | "
+          f"bev={args.bev_h}x{args.bev_w} | bf16=True")
+    print(f"training_policy: {training_policy}")
+
+    for epoch in range(args.epochs):
+        train_ds.set_epoch(epoch)
+        model.train()
+
+        for step, batch in enumerate(loader):
+            camera_tiles = batch["visual_tiles"].to(device).float() / 255.0
+            camera_tiles = (camera_tiles - img_mean) / img_std
+
+            map_context       = batch["map_context"].to(device).float()
+            route_mask        = batch.get("route_mask")
+            if route_mask is not None:
+                route_mask    = route_mask.to(device).float()
+            map_valid         = batch.get("map_valid")
+            if map_valid is not None:
+                map_valid     = map_valid.to(device)
+            route_valid       = batch.get("route_valid")
+            if route_valid is not None:
+                route_valid   = route_valid.to(device)
+
+            visual_history    = batch["visual_history"].to(device).float()
+            egomotion_history = batch["egomotion_history"].to(device).float()
+            trajectory_target = batch["trajectory_target"].to(device).float()
+            camera_params     = batch["camera_params"].to(device).float()
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16,
+                                 enabled=(device == "cuda")):
+                # KEY DIFFERENCE from train_one_combo.py:
+                # return_planner_loss=True → calls compute_planner_loss() instead
+                # of forward(). Returns dict, not tensor.
+                out = model(
+                    camera_tiles, map_context, visual_history, egomotion_history,
+                    route_mask=route_mask,
+                    map_valid=map_valid,
+                    route_valid=route_valid,
+                    projection=PinholeProjection(camera_params),
+                    geometry_type="pinhole",
+                    trajectory_target=trajectory_target,
+                    training_policy=training_policy,
+                    return_planner_loss=True,   # <-- the whole point of this script
+                    mode="train",
+                )
+
+            # out is a dict: {"loss": scalar, "velocity_mse": scalar}
+            # or {"loss": scalar, "imitation_loss": scalar} for bezier
+            loss = out["loss"]
+
+            opt.zero_grad()
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=1.0)
+            opt.step()
+
+            if step % 20 == 0:
+                extra = {k: f"{v.item():.4f}" for k, v in out.items() if k != "loss"}
+                print(f"epoch {epoch} step {step} loss {loss.item():.4f} {extra}")
+
+            # periodic checkpoint every 100 steps
+            if step % 100 == 0 and step > 0:
+                torch.save(
+                    {"epoch": epoch, "step": step,
+                     "model_state": model.state_dict(),
+                     "opt_state": opt.state_dict(),
+                     "args": vars(args)},
+                    ckpt_dir / f"{run_tag}_epoch{epoch}_step{step}.pt",
+                )
+
+        # end-of-epoch checkpoint
+        torch.save(
+            {"epoch": epoch, "step": "end",
+             "model_state": model.state_dict(),
+             "opt_state": opt.state_dict(),
+             "args": vars(args)},
+            ckpt_dir / f"{run_tag}_epoch{epoch}.pt",
+        )
+        print(f"saved: {ckpt_dir}/{run_tag}_epoch{epoch}.pt")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds local training and evaluation scripts for the KITScenes grid search requested in #168. The scripts allow contributors to run exploratory single-GPU experiments without the full cluster training pipeline, while keeping local disk usage bounded by downloading and removing one scene at a time.

## What's in here

- **`build_shard_split.py`** — builds the custom 585/65 scene split requested in #168
- **`rotating_dataset.py`** — downloads, extracts, yields, and deletes one scene at a time via `PinnedKITScenesDownloader`
- **`train_one_combo.py`** — Bezier training with bfloat16 autocast
- **`train_one_combo_fm.py`** — Flow Matching training via `compute_planner_loss` (#172)
- **`eval_checkpoint.py`** — open-loop ADE/FDE evaluation at 3 s and 6.4 s
- **`constant_velocity_baseline.py`** — no-perception reference baseline using the last observed acceleration/curvature
     @gcordova10 thanks for this.

## Epoch-0 results

Configuration: `swin_v2_tiny` + `residual`, custom 585-scene training / 65-scene validation split, 4,049 validation samples.

| Run | ADE @ 3 s | FDE @ 3 s | ADE @ 6.4 s | FDE @ 6.4 s | Comfort violation rate |
| --- | ---: | ---: | ---: | ---: | ---: |
| Constant-velocity baseline | 0.883 m | 2.662 m | — | — | — |
| Bezier epoch 0 | 3.087 m | 8.086 m | 10.789 m | 27.907 m | 0.362 |
| Flow Matching epoch 0 | 2.572 m | 6.594 m | 8.764 m | 22.341 m | 1.000 |

The constant-velocity baseline was evaluated first on the same validation split before the learned models.
and 1 is expected for epoch 0 for Flow matching's comfort violation rate and which improves over furthur epochs.

At epoch 0, both learned models remain worse than the constant-velocity baseline. Flow Matching improves over Bezier on all reported ADE/FDE horizons, but still does not pass the baseline gate. Further training epochs are in progress.

Validation used the custom 65-scene split from the 585/65 split. 18 scenes were skipped because they had fewer than the required 129 ego poses, leaving 4,049 usable samples. These results are not directly comparable with runs using the frozen `train_il` validation scope.

This is a **custom 585/65 split**, not the frozen training/validation manifest used by the standard `train_il` pipeline, so these numbers are not directly comparable with results reported using `--validation_scope full`.

## Hardware / training configuration

Experiments were run on an **NVIDIA GeForce RTX 4060 8 GB** with `swin_v2_tiny` + `residual`.

To fit the models on the 8 GB GPU, the runs use a reduced BEV grid and gradient checkpointing. `cross_attn` fusion requires a smaller BEV configuration (`--bev_h 60 --bev_w 60`, ≤4096 tokens).

## Checkpoints

I will upload the Bezier and Flow Matching checkpoints from the **585-scene training split** to Drive and add the links here later. These are the **epoch-0 model weights produced by the local single-GPU training runs** reported in this PR. Evaluation was performed on the corresponding **65-scene validation split** defined by the same custom split.

## Further participation

Additional training epochs are still in progress. More contributors with local GPUs are encouraged to run additional epochs/configurations and report results using the same split and evaluation procedure.

Relates-to: #168, #172