### PR TITLE
feat(training): expose map_fusion_mode as a train_il parameter

### DIFF
--- a/Model/tests/test_map_fusion_selection.py
+++ b/Model/tests/test_map_fusion_selection.py
@@ -1,0 +1,94 @@
+"""``map_fusion_mode`` must reach the model and survive into the checkpoint.
+
+The failure this guards against is silent: before #168, ``train_il`` accepted no
+fusion argument and ``AutoE2E`` defaulted to ``residual``, so a run intended as
+an attention-fusion experiment trained residual and logged nothing to say so.
+A regression here would not raise — it would quietly produce the wrong model.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+pytest.importorskip("flytekit")
+
+from model_components.map_encoder.map_bev_fusion import MAP_FUSION_REGISTRY
+from Platform.pipelines import workflows
+
+
+def _train_il_source() -> ast.Module:
+    return ast.parse(inspect.getsource(workflows.train_il.task_function))
+
+
+def _autoe2e_call(tree: ast.Module) -> ast.Call:
+    """The AutoE2E(...) construction inside train_il."""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "AutoE2E"
+        ):
+            return node
+    raise AssertionError("train_il no longer constructs AutoE2E directly")
+
+
+class TestEnum:
+    def test_every_value_is_a_registry_key(self):
+        """A selectable value that the registry rejects fails at model build."""
+        assert {m.value for m in workflows.MapFusion} == set(MAP_FUSION_REGISTRY)
+
+    def test_default_is_residual(self):
+        params = inspect.signature(workflows.train_il.task_function).parameters
+        assert params["map_fusion_mode"].default is workflows.MapFusion.RESIDUAL
+
+
+class TestReachesTheModel:
+    def test_train_il_forwards_it_to_autoe2e(self):
+        call = _autoe2e_call(_train_il_source())
+        assert "map_fusion_mode" in {kw.arg for kw in call.keywords}, (
+            "train_il builds AutoE2E without map_fusion_mode, so every run "
+            "silently trains the constructor default"
+        )
+
+    def test_workflow_passes_it_through(self):
+        params = inspect.signature(workflows.wf_train_il).parameters
+        assert "map_fusion_mode" in params
+        source = inspect.getsource(workflows.wf_train_il)
+        assert "map_fusion_mode=map_fusion_mode" in source
+
+
+class TestSurvivesTheCheckpoint:
+    def test_checkpoint_config_records_it(self):
+        """Evaluation rebuilds from this dict; a missing key loads mismatched weights."""
+        source = inspect.getsource(workflows.train_il.task_function)
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if "checkpoint_config" not in targets:
+                continue
+            assert isinstance(node.value, ast.Dict)
+            keys = [k.value for k in node.value.keys if isinstance(k, ast.Constant)]
+            assert "map_fusion_mode" in keys
+            return
+        raise AssertionError("train_il no longer builds a checkpoint_config dict")
+
+    @pytest.mark.parametrize("mode", sorted(MAP_FUSION_REGISTRY))
+    def test_model_kwargs_preserves_it(self, mode):
+        config = {
+            "backbone": "swin_v2_tiny",
+            "map_fusion_mode": mode,
+            "embed_dim": 256,
+            "num_views": 6,
+            "is_pretrained": False,
+            # A key the current constructor no longer takes; _model_kwargs must
+            # drop it without taking map_fusion_mode with it.
+            "fusion_mode": "bev",
+        }
+        kwargs = workflows._model_kwargs(config)
+        assert kwargs["map_fusion_mode"] == mode
+        assert "fusion_mode" not in kwargs

--- a/Platform/pipelines/workflows.py
+++ b/Platform/pipelines/workflows.py
@@ -184,6 +184,19 @@ class Backbone(enum.Enum):
     RESNET_50 = "res_net_50"
 
 
+# Map-BEV fusion is selectable in the model (MAP_FUSION_REGISTRY) and accepted by
+# AutoE2E.__init__, but train_il never forwarded it, so every run trained the
+# constructor default regardless of intent (#168).
+#
+# CROSS_ATTN is dense O(N^2) attention: MapCrossAttentionFusion refuses above
+# 4096 BEV tokens and the KITScenes contract grid is 256x256 = 65536, so
+# DEFORMABLE is the attention-based option at that resolution.
+class MapFusion(enum.Enum):
+    RESIDUAL = "residual"
+    CROSS_ATTN = "cross_attn"
+    DEFORMABLE = "deformable"
+
+
 def _row_decode_worker_count(dataset: Dataset, row_count: int) -> int:
     """Bound row decoders by each parser's per-process memory footprint."""
     # Each KITScenes child reparses the scene's Lanelet2 map and calibration.
@@ -3050,6 +3063,9 @@ def train_il(
     shards: List[FlyteDirectory],
     dataset: Dataset = Dataset.L2D,
     backbone: Backbone = Backbone.SWIN_V2_TINY,
+    # Defaults to the previously hardcoded value, so a run that does not pass it
+    # is unchanged.
+    map_fusion_mode: MapFusion = MapFusion.RESIDUAL,
     epochs: int = 3,
     batch_size: int = 4,
     # Effective batch size = batch_size * grad_accum_steps. The World-Model
@@ -3278,6 +3294,7 @@ def train_il(
         ctx.execution_id.name if ctx.execution_id else "local"
     )
     bb, fm = backbone.value, FUSION_LABEL
+    mfm = map_fusion_mode.value
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     training_policy = training_policy_for_dataset(
         dataset.value,
@@ -3288,6 +3305,7 @@ def train_il(
     )
 
     print(f"Training: backbone={bb} fusion={fm} epochs={epochs} bs={batch_size} device={device}")
+    print(f"Map BEV fusion: {mfm}")
 
     # MERGED DataLoader over ALL provided shard dirs. Each dataset keeps its own
     # geometry/num_views; batches are same-dataset (uniform), interleaved across
@@ -3902,6 +3920,7 @@ def train_il(
         map_context_channels=map_context_channels,
         route_channels=route_channels,
         enable_route_conditioning=enable_route_conditioning,
+        map_fusion_mode=mfm,
         enable_reasoning=enable_reasoning, reasoning_mode=reasoning_mode,
         enable_world_model=enable_world_model,
     ).to(device)
@@ -4016,6 +4035,11 @@ def train_il(
     scaler = torch.amp.GradScaler(enabled=amp)
     checkpoint_config = {
         "backbone": bb,
+        # Carried in the checkpoint so evaluation rebuilds the SAME architecture:
+        # _model_kwargs feeds this dict into AutoE2E(**config), so without the key
+        # a non-default run would be reconstructed with the constructor default
+        # and load mismatched weights.
+        "map_fusion_mode": mfm,
         "embed_dim": 256,
         "num_views": num_views,
         "view_fusion_kwargs": view_fusion_kwargs,
@@ -4384,6 +4408,7 @@ def train_il(
                 ),
                 "model/backbone": bb,
                 "model/fusion_mode": fm,
+                "model/map_fusion_mode": mfm,
                 "model/num_views": num_views,
                 "model/navigation_geometry_id": (
                     navigation_geometry_id or "legacy"
@@ -8675,6 +8700,7 @@ def wf_train_il(
     shards: List[FlyteDirectory],
     dataset: Dataset = Dataset.L2D,
     backbone: Backbone = Backbone.SWIN_V2_TINY,
+    map_fusion_mode: MapFusion = MapFusion.RESIDUAL,
     epochs: int = 3,
     batch_size: int = 4,
     grad_accum_steps: int = 1,
@@ -8718,6 +8744,7 @@ def wf_train_il(
     — the dominant per-epoch cost once episodes scale up.
     """
     out = train_il(shards=shards, dataset=dataset, backbone=backbone,
+                   map_fusion_mode=map_fusion_mode,
                    epochs=epochs, batch_size=batch_size,
                    grad_accum_steps=grad_accum_steps, lr=lr,
                    training_seed=training_seed, amp=amp,


### PR DESCRIPTION
## Problem

`AutoE2E.__init__` has accepted `map_fusion_mode` since #94, and
`MAP_FUSION_REGISTRY` offers `residual` / `cross_attn` / `deformable`. But
`train_il` never forwarded it, so **every run trained the constructor default —
`residual` — regardless of intent**, and nothing in the run log said so.

That makes the *"Map Feature Fusion: Residual, Attention"* axis of #168
unreachable through the sanctioned path. A contributor comparing the two either
compared residual against residual, or left `train_il` for a custom script and
lost comparability with everyone else. It is a silent failure: the run looks
healthy and produces a plausible number.

## What this adds

- `MapFusion` enum beside the existing `Backbone` enum
- `map_fusion_mode` on `train_il` and `wf_train_il`
- the value in `checkpoint_config`, so evaluation rebuilds the **same**
  architecture — `_model_kwargs` feeds that dict into `AutoE2E(**config)`, so
  without the key a non-default run is reconstructed with the constructor default
  and loads mismatched weights
- `model/map_fusion_mode` to MLflow, so runs are distinguishable after the fact

The default reproduces the previous behaviour exactly. A run that does not pass
the argument is unchanged.

## Deliberately not included

**`planner_mode` is left to #172**, which already adds it to `train_il` along
with the `compute_planner_loss` wiring. Only the map-fusion half is unique to
this PR, so it stays narrow rather than fixing planner_mode as well.

**BEV grid size is left to #188** (`camera_bev_size`), which touches the same
`train_il` signature block. This PR adds one parameter next to `backbone` and
should rebase cleanly either way; happy to rebase behind whichever lands first.

## Tests

`Model/tests/test_map_fusion_selection.py` — a new file rather than an addition
to `test_workflow_training_lifecycle.py`, which both #172 and #188 modify. Could also integrate into `test_workflow_training_lifecycle.py` if prefered.

Covers: the pass-through into `AutoE2E`, the workflow wiring, the checkpoint
round-trip through `_model_kwargs`, and that every enum value is a registry key.
Verified to fail without the change (5 of 8 fail).

> **Note on CI:** `Model/tests` currently has 40 pre-existing failures on `main`
> (reasoning, planner, projection, `auto_e2e`), unrelated to this PR — the counts
> are identical with and without it. Nothing in `Platform/pipelines` fails.

## `cross_attn` is a trap at the contract resolution

Worth knowing before anyone selects it: `MapCrossAttentionFusion.forward` raises
above 4096 BEV tokens, and the KITScenes contract grid is 256×256 = 65,536. So
`deformable` is the attention-based option at that resolution. The enum exposes
`cross_attn` anyway because it is valid at smaller grids, and the guard fails
loudly rather than silently.

