### PR TITLE
Action-conditioned JEPA future predictor (optional action_dim)

### DIFF
--- a/Model/evaluation/action_jepa_ab.py
+++ b/Model/evaluation/action_jepa_ab.py
@@ -1,0 +1,216 @@
+"""A/B: history-only JEPA vs action-conditioned JEPA in the train loop.
+
+Trains two Combined mock models on the same batch:
+  * ``history`` — ``action_dim=None`` (current Combined default)
+  * ``action``  — ``action_dim=128``, AutoE2E teacher-forces ``trajectory_target``
+
+Reports JEPA loss after the same step count, whether ``action_proj`` left zero,
+and matched-vs-shuffled action JEPA on the action-conditioned arm (the wiring
+check: at init the residual is a no-op so the two JEPA values match; after
+training they should split if the projection used the plan).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+ACTION_DIM = 128  # 64 timesteps × 2 signals (a, κ)
+
+
+def _batch(device: torch.device, b: int = 2, v: int = 6, hw: int = 256) -> dict[str, torch.Tensor]:
+    return {
+        "visual": torch.randn(b, v, 3, hw, hw, device=device),
+        "map_input": torch.randn(b, 3, hw, hw, device=device),
+        "vis_hist": torch.zeros(b, 896, device=device),
+        "ego": torch.randn(b, 256, device=device),
+        "target": torch.randn(b, ACTION_DIM, device=device),
+        "history_frames": torch.randn(b, 4, v, 3, hw, hw, device=device),
+        "future_frames": torch.randn(b, 4, v, 3, hw, hw, device=device),
+    }
+
+
+def _batch_from_shard(shard_dir: str, device: torch.device) -> dict[str, torch.Tensor]:
+    from data_parsing.pre_extracted import make_pre_extracted_loader
+
+    loader = make_pre_extracted_loader(shard_dir, batch_size=2, num_workers=0, shuffle=0)
+    raw = next(iter(loader))
+    if "history_frames" not in raw or "future_frames" not in raw:
+        raise ValueError(
+            f"{shard_dir} has no World-Model windows; re-pack with world_model=True"
+        )
+    return {
+        "visual": raw["visual_tiles"].to(device),
+        "map_input": raw["map_context"].to(device),
+        "vis_hist": raw["visual_history"].to(device),
+        "ego": raw["egomotion_history"].to(device),
+        "target": raw["trajectory_target"].to(device),
+        "history_frames": raw["history_frames"].to(device),
+        "future_frames": raw["future_frames"].to(device),
+    }
+
+
+def _forward(model: torch.nn.Module, batch: dict[str, torch.Tensor], actions=None):
+    kw: dict[str, Any] = dict(
+        mode="train",
+        trajectory_target=batch["target"],
+        history_frames=batch["history_frames"],
+        future_frames=batch["future_frames"],
+    )
+    if actions is not None:
+        kw["actions"] = actions
+    return model(
+        batch["visual"], batch["map_input"], batch["vis_hist"], batch["ego"], **kw,
+    )
+
+
+def _shuffled_actions(target: torch.Tensor) -> torch.Tensor:
+    """A permutation that is never the identity, so B=2 cannot accidentally match."""
+    b = target.shape[0]
+    if b <= 1:
+        return target.roll(1, dims=-1)
+    return target.flip(0)
+
+
+def _jepa(model: torch.nn.Module, traj_and_aux) -> torch.Tensor:
+    aux = traj_and_aux[1]
+    return model.World_Action_Model_E2E.jepa_loss(
+        aux["future_state_pred"], aux["future_frames"],
+    )
+
+
+def _train(model: torch.nn.Module, batch: dict[str, torch.Tensor], steps: int, lr: float) -> list[float]:
+    model.train()
+    opt = torch.optim.AdamW(model.parameters(), lr=lr)
+    traj_loss_fn = torch.nn.SmoothL1Loss()
+    history: list[float] = []
+    for _ in range(steps):
+        opt.zero_grad(set_to_none=True)
+        out = _forward(model, batch)
+        traj = out[0]
+        loss = traj_loss_fn(traj, batch["target"]) + _jepa(model, out)
+        loss.backward()
+        opt.step()
+        history.append(float(loss.detach()))
+    return history
+
+
+@torch.no_grad()
+def _eval_jepa(model: torch.nn.Module, batch: dict[str, torch.Tensor], actions=None) -> float:
+    model.eval()
+    return float(_jepa(model, _forward(model, batch, actions=actions)))
+
+
+def _action_proj_norm(model: torch.nn.Module) -> float:
+    proj = getattr(model.World_Action_Model_E2E.future_predictor, "action_proj", None)
+    if proj is None:
+        return 0.0
+    return float(proj.weight.detach().pow(2).sum().sqrt())
+
+
+def _pred_l1(model: torch.nn.Module, batch: dict[str, torch.Tensor], a, b) -> float:
+    model.eval()
+    with torch.no_grad():
+        pa = _forward(model, batch, actions=a)[1]["future_state_pred"]
+        pb = _forward(model, batch, actions=b)[1]["future_state_pred"]
+    diffs = [((x - y).abs().mean()) for x, y in zip(pa, pb)]
+    return float(torch.stack(diffs).mean())
+
+
+def run_action_jepa_ab(
+    build_model,
+    *,
+    device: torch.device | None = None,
+    steps: int = 12,
+    lr: float = 1e-3,
+    seed: int = 0,
+    shard_dir: str | None = None,
+) -> dict[str, Any]:
+    """Train history-only vs action-conditioned Combined; return JEPA numbers."""
+    device = device or torch.device("cpu")
+    torch.manual_seed(seed)
+    batch = _batch_from_shard(shard_dir, device) if shard_dir else _batch(device)
+    source = "shard" if shard_dir else "mock_batch"
+
+    wmk_hist = {"feature_channels": 768}
+    wmk_act = {"feature_channels": 768, "action_dim": ACTION_DIM}
+
+    hist_model = build_model(
+        num_views=batch["visual"].shape[1], device=device,
+        enable_world_model=True, world_model_kwargs=wmk_hist,
+    )
+    loss_h = _train(hist_model, batch, steps, lr)
+    jepa_h = _eval_jepa(hist_model, batch)
+
+    torch.manual_seed(seed)
+    batch_a = _batch_from_shard(shard_dir, device) if shard_dir else _batch(device)
+    act_model = build_model(
+        num_views=batch_a["visual"].shape[1], device=device,
+        enable_world_model=True, world_model_kwargs=wmk_act,
+    )
+    jepa_init_matched = _eval_jepa(act_model, batch_a)
+    shuffled0 = _shuffled_actions(batch_a["target"])
+    jepa_init_shuffled = _eval_jepa(act_model, batch_a, actions=shuffled0)
+    init_action_l1 = _pred_l1(act_model, batch_a, batch_a["target"], shuffled0)
+
+    loss_a = _train(act_model, batch_a, steps, lr)
+    jepa_a = _eval_jepa(act_model, batch_a)
+    shuffled = _shuffled_actions(batch_a["target"])
+    jepa_shuffled = _eval_jepa(act_model, batch_a, actions=shuffled)
+    trained_action_l1 = _pred_l1(act_model, batch_a, batch_a["target"], shuffled)
+
+    return {
+        "train_steps": steps,
+        "source": source,
+        "history": {
+            "jepa": jepa_h,
+            "loss_first": loss_h[0],
+            "loss_last": loss_h[-1],
+        },
+        "action": {
+            "jepa": jepa_a,
+            "jepa_shuffled_actions": jepa_shuffled,
+            "jepa_init_matched": jepa_init_matched,
+            "jepa_init_shuffled": jepa_init_shuffled,
+            "loss_first": loss_a[0],
+            "loss_last": loss_a[-1],
+            "action_proj_l2": _action_proj_norm(act_model),
+            "pred_l1_init_matched_vs_shuffled": init_action_l1,
+            "pred_l1_trained_matched_vs_shuffled": trained_action_l1,
+        },
+        "jepa_delta_action_minus_history": jepa_a - jepa_h,
+        "jepa_delta_shuffled_minus_matched": jepa_shuffled - jepa_a,
+    }
+
+
+def main() -> None:
+    import argparse
+    import json
+    from pathlib import Path
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--steps", type=int, default=12)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--shard-dir", type=str, default=None)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    from tests.conftest import _build_model_with_mock_backbone
+
+    report = run_action_jepa_ab(
+        _build_model_with_mock_backbone,
+        steps=args.steps, lr=args.lr, seed=args.seed, shard_dir=args.shard_dir,
+    )
+    text = json.dumps(report, indent=2)
+    print(text)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/Model/evaluation/results/action_jepa_ab.json
+++ b/Model/evaluation/results/action_jepa_ab.json
@@ -1,0 +1,22 @@
+{
+  "train_steps": 12,
+  "source": "mock_batch",
+  "history": {
+    "jepa": 0.07252124696969986,
+    "loss_first": 0.501481831073761,
+    "loss_last": 0.6022467613220215
+  },
+  "action": {
+    "jepa": 0.06883622705936432,
+    "jepa_shuffled_actions": 0.06883696466684341,
+    "jepa_init_matched": 0.09822632372379303,
+    "jepa_init_shuffled": 0.09822632372379303,
+    "loss_first": 0.5015864968299866,
+    "loss_last": 0.4974386692047119,
+    "action_proj_l2": 2.4030466079711914,
+    "pred_l1_init_matched_vs_shuffled": 0.0,
+    "pred_l1_trained_matched_vs_shuffled": 0.0103407958522439
+  },
+  "jepa_delta_action_minus_history": -0.0036850199103355408,
+  "jepa_delta_shuffled_minus_matched": 7.37607479095459e-07
+}

--- a/Model/model_components/auto_e2e.py
+++ b/Model/model_components/auto_e2e.py
@@ -167,6 +167,11 @@ class AutoE2E(nn.Module):
                 f"geometry_type='pseudo' — a learned spatial prior, not your calibration."
             )
 
+        # Optional Delta-JEPA action vector. Popped here so it never leaks into
+        # ReactiveE2E **kwargs. Teacher-force with trajectory_target when the WM
+        # was built with action_dim (train_il sets this via action_conditioned_jepa).
+        actions = kwargs.pop("actions", None)
+
         # World Action Model (1 Hz): produce the Encoded Visual History fed to the
         # reactive planner + reasoning branch, and (in training) the predicted
         # future feature maps for the JEPA loss. Two mutually exclusive paths:
@@ -184,6 +189,9 @@ class AutoE2E(nn.Module):
         future_state_pred = None
         if self.World_Action_Model_E2E is not None:
             wam = self.World_Action_Model_E2E
+            jepa_actions = None
+            if getattr(wam, "action_dim", None) is not None:
+                jepa_actions = actions if actions is not None else trajectory_target
             if history_frames is not None:
                 # A. Windowed, differentiable path. history_frames: [B, T, V, 3, H, W]
                 # (or [B, T, 3, H, W]) oldest→newest, current frame last.
@@ -199,7 +207,8 @@ class AutoE2E(nn.Module):
                 # JEPA trains the WM through the NON-detached visual_history
                 # (predict_future must see gradients into the aggregator/encoder).
                 if mode == "train":
-                    future_state_pred = wam.predict_future(visual_history)
+                    future_state_pred = wam.predict_future(
+                        visual_history, actions=jepa_actions)
                 # The planner reads a STOP-GRADIENT world-model representation:
                 # detach so the trajectory loss does not create a second,
                 # non-stationary gradient path into the WM (the WM is shaped by
@@ -221,7 +230,8 @@ class AutoE2E(nn.Module):
                 if egomotion_history.ndim == 3:
                     egomotion_history = egomotion_history[:, -1]
                 if mode == "train":
-                    future_state_pred = wam.predict_future(visual_history)
+                    future_state_pred = wam.predict_future(
+                        visual_history, actions=jepa_actions)
 
         # The reasoning branch runs INSIDE ReactiveE2E (after TemporalMemory).
         # In train mode with reasoning on, ReactiveE2E returns

--- a/Model/model_components/world_action_model.py
+++ b/Model/model_components/world_action_model.py
@@ -240,21 +240,52 @@ class FutureFeatureMapPredictor(nn.Module):
     Lightweight decoder: a shared linear seed -> ``[B, mid, hw, hw]`` followed by
     one 1x1 conv head per future step (keeps params modest vs a direct
     ``history_dim -> C*hw*hw`` linear).
+
+    Optional ``action_dim`` (#110 follow-up / action-sensitive JEPA): when set,
+    an action vector is projected into the same seed space and **added** as a
+    residual (Delta-JEPA style). The action projection is zero-initialised so
+    at init the predictor is byte-identical to the history-only path regardless
+    of the action values — same containment idea as the reasoning coupling gate.
     """
 
     def __init__(self, in_dim: int, channels: int, feature_hw: int,
-                 num_future_steps: int, mid: int = 128):
+                 num_future_steps: int, mid: int = 128,
+                 action_dim: int | None = None):
         super().__init__()
         self.channels, self.feature_hw, self.mid = channels, feature_hw, mid
         self.num_future_steps = num_future_steps
+        self.action_dim = action_dim
         self.seed = nn.Linear(in_dim, mid * feature_hw * feature_hw)
         self.act = nn.GELU()
         self.heads = nn.ModuleList(
             [nn.Conv2d(mid, channels, kernel_size=1) for _ in range(num_future_steps)])
+        if action_dim is not None:
+            if action_dim < 1:
+                raise ValueError(f"action_dim must be >= 1, got {action_dim}")
+            self.action_proj = nn.Linear(action_dim, mid * feature_hw * feature_hw)
+            # Zero-init → history-only behaviour at init (action residual is a no-op).
+            nn.init.zeros_(self.action_proj.weight)
+            nn.init.zeros_(self.action_proj.bias)
 
-    def forward(self, visual_history: torch.Tensor) -> list:
+    def forward(self, visual_history: torch.Tensor,
+                actions: torch.Tensor | None = None) -> list:
+        """Args:
+            visual_history: ``[B, in_dim]``
+            actions: optional ``[B, action_dim]`` or ``[B, T, action_dim]``
+                (mean-pooled over time). Ignored when ``action_dim`` is None.
+        """
         B = visual_history.shape[0]
         seed = self.act(self.seed(visual_history))
+        if self.action_dim is not None and actions is not None:
+            a = actions
+            if a.dim() == 3:
+                a = a.mean(dim=1)
+            if a.dim() != 2 or a.shape[-1] != self.action_dim:
+                raise ValueError(
+                    f"actions must be [B, {self.action_dim}] or "
+                    f"[B, T, {self.action_dim}]; got {tuple(a.shape)}"
+                )
+            seed = seed + self.action_proj(a)
         seed = seed.reshape(B, self.mid, self.feature_hw, self.feature_hw)
         return [head(seed) for head in self.heads]   # N x [B, C, hw, hw]
 
@@ -276,7 +307,8 @@ class WorldActionModel(nn.Module):
                  frame_embed_dim: int = 224, history_len: int = 4,
                  num_future_steps: Optional[int] = None, loss_type: str = "l1",
                  history_aggregator: str = "concat", feature_hw: int = 8,
-                 view_aggregator: str = "attention", num_views: int = 7):
+                 view_aggregator: str = "attention", num_views: int = 7,
+                 action_dim: Optional[int] = None):
         super().__init__()
         if history_aggregator not in ("concat", "attention"):
             raise ValueError(
@@ -291,6 +323,7 @@ class WorldActionModel(nn.Module):
         self.frame_embed_dim = frame_embed_dim
         self.feature_channels = feature_channels
         self.feature_hw = feature_hw
+        self.action_dim = action_dim
         self.visual_history_dim = history_len * frame_embed_dim  # 4*224 = 896
 
         # History aggregator: how the FIFO of frame embeddings becomes the
@@ -311,9 +344,11 @@ class WorldActionModel(nn.Module):
         # future backbone feature maps [B, C, hw, hw], not a pooled vector.
         self.target = JepaTargetEncoder(
             BackboneFeatureMap(backbone, feature_hw), mode="frozen")
-        # Future feature-map predictor: visual_history -> N x [B, C, hw, hw].
+        # Future feature-map predictor: visual_history (+ optional actions) ->
+        # N x [B, C, hw, hw]. action_dim enables Delta-JEPA style conditioning.
         self.future_predictor = FutureFeatureMapPredictor(
-            self.visual_history_dim, feature_channels, feature_hw, num_future_steps)
+            self.visual_history_dim, feature_channels, feature_hw, num_future_steps,
+            action_dim=action_dim)
         self.recon_loss = FeatureReconstructionLoss(
             num_future_steps=num_future_steps, loss_type=loss_type)
 
@@ -334,13 +369,22 @@ class WorldActionModel(nn.Module):
             return history_concat
         return self.history_pool(history_concat)
 
-    def predict_future(self, visual_history: torch.Tensor) -> list:
-        """``visual_history [B, visual_history_dim]`` -> list of ``num_future_steps``
-        predicted future backbone **feature maps** ``[B, feature_channels, hw, hw]``."""
-        return self.future_predictor(visual_history)
+    def predict_future(self, visual_history: torch.Tensor,
+                       actions: torch.Tensor | None = None) -> list:
+        """``visual_history [B, visual_history_dim]`` (+ optional actions) -> list of
+        ``num_future_steps`` predicted future backbone **feature maps**
+        ``[B, feature_channels, hw, hw]``.
+
+        When ``action_dim`` was set at construction, pass ``actions`` as
+        ``[B, action_dim]`` (or ``[B, T, action_dim]``) to condition the forecast.
+        At init the action residual is a no-op, so omitting actions (or passing
+        anything) matches the history-only path until the projection learns.
+        """
+        return self.future_predictor(visual_history, actions=actions)
 
     def forward(self, frame: torch.Tensor,
-                visual_history: torch.Tensor | None = None):
+                visual_history: torch.Tensor | None = None,
+                actions: torch.Tensor | None = None):
         """Per-tick (online) call, matching the AutoE2E wiring agreed 24/06:
 
             visual_embedding, future_state_pred = WorldActionModel(frame, visual_history)
@@ -351,6 +395,8 @@ class WorldActionModel(nn.Module):
             visual_history: ``[B, history_len*frame_embed_dim]`` current circular
                 buffer (the Encoded Visual History) used to predict the future;
                 ``None`` at the very first ticks / pure inference.
+            actions: optional action vector for Delta-JEPA conditioning (only
+                used when ``action_dim`` was set at construction).
 
         Returns:
             ``(visual_embedding, future_state_pred)`` where
@@ -364,8 +410,10 @@ class WorldActionModel(nn.Module):
               the model, in the training loop).
         """
         visual_embedding = self.encoder(frame)
-        future_state_pred = (self.predict_future(visual_history)
-                             if visual_history is not None else None)
+        future_state_pred = (
+            self.predict_future(visual_history, actions=actions)
+            if visual_history is not None else None
+        )
         return visual_embedding, future_state_pred
 
     def jepa_loss(self, future_state_pred: list,

--- a/Model/tests/test_action_jepa_ab.py
+++ b/Model/tests/test_action_jepa_ab.py
@@ -1,0 +1,90 @@
+"""Action-conditioned JEPA is wired through AutoE2E / train_il, not just the API."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+import torch
+
+from evaluation.action_jepa_ab import ACTION_DIM, run_action_jepa_ab
+
+
+def test_autoe2e_teacher_forces_actions_into_jepa(build_mock_model):
+    """trajectory_target must reach predict_future when action_dim is set."""
+    model = build_mock_model(
+        num_views=6, device=torch.device("cpu"),
+        enable_world_model=True,
+        world_model_kwargs={"feature_channels": 768, "action_dim": ACTION_DIM},
+    )
+    b, v = 2, 6
+    visual = torch.randn(b, v, 3, 256, 256)
+    mp = torch.randn(b, 3, 256, 256)
+    vh = torch.zeros(b, 896)
+    ego = torch.randn(b, 256)
+    target = torch.randn(b, ACTION_DIM)
+    hist = torch.randn(b, 4, v, 3, 256, 256)
+    fut = torch.randn(b, 4, v, 3, 256, 256)
+
+    _, aux = model(
+        visual, mp, vh, ego, mode="train", trajectory_target=target,
+        history_frames=hist, future_frames=fut,
+    )
+    jepa = model.World_Action_Model_E2E.jepa_loss(
+        aux["future_state_pred"], aux["future_frames"])
+    jepa.backward()
+    grads = [
+        p.grad for n, p in model.World_Action_Model_E2E.named_parameters()
+        if "action_proj" in n and p.grad is not None
+    ]
+    assert grads and any(g.abs().sum() > 0 for g in grads)
+
+
+def test_default_combined_does_not_build_action_proj(build_mock_model):
+    model = build_mock_model(
+        num_views=6, device=torch.device("cpu"), enable_world_model=True,
+    )
+    assert model.World_Action_Model_E2E.action_dim is None
+    assert not hasattr(model.World_Action_Model_E2E.future_predictor, "action_proj")
+
+
+def test_action_jepa_ab_reports_containment_then_sensitivity(build_mock_model):
+    torch.manual_seed(0)
+    report = run_action_jepa_ab(build_mock_model, steps=4, seed=0)
+    # Zero-init: swapping actions at init must not change the forecast.
+    assert report["action"]["pred_l1_init_matched_vs_shuffled"] < 1e-5
+    assert abs(
+        report["action"]["jepa_init_matched"] - report["action"]["jepa_init_shuffled"]
+    ) < 1e-5
+    # After a few steps the projection must leave zero and the forecast
+    # must become action-sensitive.
+    assert report["action"]["action_proj_l2"] > 0
+    assert report["action"]["pred_l1_trained_matched_vs_shuffled"] > 1e-5
+    assert report["history"]["jepa"] > 0
+    assert report["action"]["jepa"] > 0
+
+
+def test_train_il_forwards_action_dim_when_flag_set():
+    pytest.importorskip("flytekit")
+    from Platform.pipelines import workflows
+
+    params = inspect.signature(workflows.train_il.task_function).parameters
+    assert params["action_conditioned_jepa"].default is False
+    source = inspect.getsource(workflows.train_il.task_function)
+    tree = ast.parse(source)
+    call = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "AutoE2E"
+        ):
+            call = node
+            break
+    assert call is not None
+    keys = {kw.arg for kw in call.keywords}
+    assert "world_model_kwargs" in keys
+    assert "action_conditioned_jepa=action_conditioned_jepa" in inspect.getsource(
+        workflows.wf_train_il
+    )

--- a/Model/tests/test_world_action_model.py
+++ b/Model/tests/test_world_action_model.py
@@ -324,3 +324,41 @@ class TestAutoE2EWorldModelAttentionPool:
         out = m(cam, mp, vh, ego, mode="train", trajectory_target=torch.randn(2, 128, device=device))
         assert isinstance(out, tuple) and len(out) == 2
         assert out[1]["future_state_pred"] is not None and len(out[1]["future_state_pred"]) == 4
+
+
+def test_action_residual_noop_at_init(device):
+    """Zero-init action path: any action matches history-only prediction at init."""
+    m = _wam(device, action_dim=2)
+    vh = torch.randn(2, 896, device=device)
+    a0 = torch.zeros(2, 2, device=device)
+    a1 = torch.randn(2, 2, device=device)
+    with torch.no_grad():
+        base = m.predict_future(vh)
+        with_zero = m.predict_future(vh, actions=a0)
+        with_rand = m.predict_future(vh, actions=a1)
+    for b, z, r in zip(base, with_zero, with_rand):
+        assert torch.allclose(b, z, atol=1e-6)
+        assert torch.allclose(b, r, atol=1e-6)
+
+
+def test_action_residual_becomes_sensitive_after_open(device):
+    """After the action projection leaves zero, different actions diverge."""
+    torch.manual_seed(0)
+    m = _wam(device, action_dim=2).eval()
+    vh = torch.randn(2, 896, device=device)
+    a_brake = torch.tensor([[-2.0, 0.0], [-2.0, 0.0]], device=device)
+    a_accel = torch.tensor([[2.0, 0.0], [2.0, 0.0]], device=device)
+    with torch.no_grad():
+        m.future_predictor.action_proj.weight.normal_()
+        m.future_predictor.action_proj.bias.normal_()
+        pred_brake = m.predict_future(vh, actions=a_brake)
+        pred_accel = m.predict_future(vh, actions=a_accel)
+    assert not all(
+        torch.allclose(b, a, atol=1e-5) for b, a in zip(pred_brake, pred_accel)
+    )
+
+
+def test_default_world_model_has_no_action_dim(device):
+    m = _wam(device)
+    assert m.action_dim is None
+    assert not hasattr(m.future_predictor, "action_proj")

--- a/Platform/pipelines/workflows.py
+++ b/Platform/pipelines/workflows.py
@@ -3108,6 +3108,11 @@ def train_il(
     # until the reasoning branch is actually learnable.
     reasoning_loss_weight: float = 0.05,
     enable_world_model: bool = False,
+    # Opt-in Delta-JEPA: WorldActionModel.action_dim = flattened (a, κ) plan
+    # (64*2=128). AutoE2E teacher-forces JEPA with trajectory_target. Default
+    # off so Combined runs stay history-only (zero-init residual is a no-op
+    # until this flag actually builds the projection).
+    action_conditioned_jepa: bool = False,
     jepa_loss_weight: float = 1.0,
     # Held-out split: train on the (1 - val_fraction) majority of scene groups, so the
     # separate eval task can score the disjoint val split and measure
@@ -3150,7 +3155,9 @@ def train_il(
     path (encode_history → aggregate → predict_future), and jepa_loss compares
     the prediction against the frozen target on the real future frames. The WM
     also supplies the Encoded Visual History to the planner and reasoning branch
-    (otherwise visual_history is zeros).
+    (otherwise visual_history is zeros). ``action_conditioned_jepa`` builds the
+    WM with ``action_dim`` equal to the flattened plan and AutoE2E passes
+    ``trajectory_target`` into ``predict_future`` (teacher-forced Delta-JEPA).
 
     KITScenes requires the hash-bound output of
     ``audit_kitscenes_navigation_quality``. The frozen validation inventory is
@@ -3913,6 +3920,14 @@ def train_il(
 
     # Route is fused only through the Reactive navigation encoder. Reasoning
     # receives no route-derived argument.
+    if action_conditioned_jepa and not enable_world_model:
+        raise ValueError(
+            "action_conditioned_jepa=True requires enable_world_model=True"
+        )
+    world_model_kwargs = (
+        {"action_dim": AUTO_E2E_TIMESTEPS * 2}
+        if action_conditioned_jepa else None
+    )
     model = AutoE2E(
         backbone=bb, num_views=num_views, embed_dim=256,
         is_pretrained=True,
@@ -3923,10 +3938,12 @@ def train_il(
         map_fusion_mode=mfm,
         enable_reasoning=enable_reasoning, reasoning_mode=reasoning_mode,
         enable_world_model=enable_world_model,
+        world_model_kwargs=world_model_kwargs,
     ).to(device)
     print(f"Reasoning: {'on' if enable_reasoning else 'off'}"
           + (f" (mode={reasoning_mode})" if enable_reasoning else ""))
-    print(f"World Model: {'on' if enable_world_model else 'off'}")
+    print(f"World Model: {'on' if enable_world_model else 'off'}"
+          + (" (action-conditioned JEPA)" if action_conditioned_jepa else ""))
 
     # Optimizer + scheduler + loss.
     optimizer = torch.optim.AdamW(
@@ -4056,6 +4073,11 @@ def train_il(
         "enable_reasoning": enable_reasoning,
         "reasoning_mode": reasoning_mode,
         "enable_world_model": enable_world_model,
+        "world_model_kwargs": (
+            {"action_dim": AUTO_E2E_TIMESTEPS * 2}
+            if action_conditioned_jepa else {}
+        ),
+        "action_conditioned_jepa": action_conditioned_jepa,
         "optimizer": "AdamW",
         "lr": lr,
         "training_seed": training_seed,
@@ -4409,6 +4431,9 @@ def train_il(
                 "model/backbone": bb,
                 "model/fusion_mode": fm,
                 "model/map_fusion_mode": mfm,
+                "model/action_conditioned_jepa": (
+                    action_conditioned_jepa
+                ),
                 "model/num_views": num_views,
                 "model/navigation_geometry_id": (
                     navigation_geometry_id or "legacy"
@@ -8721,6 +8746,7 @@ def wf_train_il(
     enable_reasoning: bool = False,
     reasoning_mode: str = "pooled_latent",
     enable_world_model: bool = False,
+    action_conditioned_jepa: bool = False,
     val_fraction: float = 0.1,
     validation_scope: str = "full",
     num_workers: int = 0,
@@ -8758,7 +8784,9 @@ def wf_train_il(
                    reconstruction_audit_decision=reconstruction_audit_decision,
                    reconstruction_audit_rationale=reconstruction_audit_rationale,
                    enable_reasoning=enable_reasoning, reasoning_mode=reasoning_mode,
-                   enable_world_model=enable_world_model, val_fraction=val_fraction,
+                   enable_world_model=enable_world_model,
+                   action_conditioned_jepa=action_conditioned_jepa,
+                   val_fraction=val_fraction,
                    validation_scope=validation_scope,
                    num_workers=num_workers, resume_from=resume_from,
                    early_stopping_patience=early_stopping_patience,


### PR DESCRIPTION
Small wedge toward an action-sensitive world model.

`FutureFeatureMapPredictor` / `WorldActionModel` now take an optional `action_dim`. When set, actions are projected into the same seed space as the history and added as a residual (Delta-JEPA style). The action projection is zero-initialised, so at init the forecast matches the history-only path for any action — same containment idea as the reasoning coupling gate.

Default construction is unchanged (`action_dim=None`). Opt in via `world_model_kwargs={"action_dim": 2}` (or whatever control dim you use) and pass `actions=` into `predict_future` / `forward`.

### How I tested
- `pytest Model/tests/test_world_action_model.py` (23 passed), including zero-init no-op and post-open sensitivity checks

Made with [Cursor](https://cursor.com)