### PR TITLE
fix(training): probe every planner parameter for optimizer progress

### DIFF
--- a/Model/tests/test_optimizer_progress_probe.py
+++ b/Model/tests/test_optimizer_progress_probe.py
@@ -1,0 +1,107 @@
+"""The optimizer-progress check must not hinge on one arbitrary parameter.
+
+`train_il` verifies the optimizer actually moved the planner. It used to clone
+whichever parameter `named_parameters()` yielded first for TrajectoryPlanner —
+which is `BezierPlanner.visual_history_proj.weight`, a parameter that is
+provably immovable under the default configuration. A healthy run then raised
+at the very end, after every epoch had been paid for.
+
+These tests pin the three facts that combine into that failure, so a future
+refactor that reintroduces single-parameter probing fails here instead of after
+a night of training.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+import torch
+import torch.nn as nn
+
+from model_components.trajectory_planning.bezier_planner import BezierPlanner
+
+
+def test_zero_init_weight_with_zero_input_never_moves():
+    """The mechanism: no gradient, and AdamW's decay scales rather than shifts.
+
+    This is why probing a single zero-init parameter is unsound — not a
+    hypothetical, this is exactly what `visual_history_proj.weight` does when
+    the World Model is off.
+    """
+    layer = nn.Linear(8, 8)
+    nn.init.zeros_(layer.weight)
+    nn.init.zeros_(layer.bias)
+    before = layer.weight.detach().clone()
+    # AdamW with decoupled weight decay, as train_il configures it.
+    optimizer = torch.optim.AdamW(layer.parameters(), lr=1e-4, weight_decay=1e-2)
+
+    for _ in range(50):
+        optimizer.zero_grad()
+        # All-zero input, which is what the packed shards carry for
+        # visual_history when world_model=False.
+        layer(torch.zeros(4, 8)).sum().backward()
+        optimizer.step()
+
+    assert torch.equal(layer.weight.detach(), before)
+    assert float(layer.weight.detach().norm()) == 0.0
+
+
+def test_a_parameter_that_receives_gradient_does_move():
+    """Control: the same optimizer moves a parameter that is actually fed."""
+    layer = nn.Linear(8, 8)
+    nn.init.zeros_(layer.weight)
+    before = layer.weight.detach().clone()
+    optimizer = torch.optim.AdamW(layer.parameters(), lr=1e-4, weight_decay=1e-2)
+
+    for _ in range(50):
+        optimizer.zero_grad()
+        layer(torch.randn(4, 8)).sum().backward()
+        optimizer.step()
+
+    assert not torch.equal(layer.weight.detach(), before)
+
+
+def test_bezier_planner_zero_inits_the_visual_history_projection():
+    """The premise holds in the real model, not just in the toy above."""
+    planner = BezierPlanner()
+
+    assert float(planner.visual_history_proj.weight.detach().abs().max()) == 0.0
+    assert float(planner.visual_history_proj.bias.detach().abs().max()) == 0.0
+
+
+def test_visual_history_projection_is_the_first_planner_parameter():
+    """Guards the ordering that made a single-parameter probe pick it.
+
+    If a refactor moves a gradient-receiving parameter back in front of it, the
+    old probe would start passing again by luck rather than by design. This test
+    failing is not a defect — it means the coincidence is gone and this file's
+    reason for existing should be re-read.
+    """
+    planner = BezierPlanner()
+    first_name = next(
+        name for name, parameter in planner.named_parameters()
+        if parameter.requires_grad
+    )
+
+    assert first_name.startswith("visual_history_proj")
+
+
+def test_train_il_probes_more_than_one_planner_parameter():
+    """The fix itself: the probe collects every trainable planner parameter."""
+    pytest.importorskip("flytekit")
+    from Platform.pipelines import workflows
+
+    source = inspect.getsource(workflows.train_il.task_function)
+    probe_start = source.index("optimizer_probe")
+    probe = source[probe_start:probe_start + 400]
+
+    assert "TrajectoryPlanner" in probe, "probe no longer scopes to the planner"
+    # The distinguishing property: the probe binds a COLLECTION, not the single
+    # element `next()` pulls off the generator. `next(` is what the bug was.
+    assert "= next(" not in probe, (
+        "optimizer progress is being probed on a single parameter again — "
+        "a zero-init planner parameter fed zero input can never move, so this "
+        "fails a healthy run at the end of training"
+    )
+    assert "optimizer_probe = [" in probe

--- a/Platform/pipelines/workflows.py
+++ b/Platform/pipelines/workflows.py
@@ -4622,12 +4622,24 @@ def train_il(
         "route_loss_gradient_budget": None,
         "objective_term_gradient_norms": None,
     }
-    optimizer_probe_name, optimizer_probe_parameter = next(
-        (name, parameter)
+    # Watch EVERY trainable planner parameter, not just the first one
+    # named_parameters() happens to yield. The probe asks "did the optimizer
+    # move the planner at all", and a single parameter cannot answer that: a
+    # zero-initialised projection fed an all-zero input is provably immovable
+    # (its gradient is zero, and AdamW's decoupled decay scales the parameter,
+    # so a zero parameter stays zero). BezierPlanner.visual_history_proj is
+    # exactly that whenever the World Model is off — which is the default, and
+    # which makes visual_history all-zero in the packed data. Probing it alone
+    # fails a perfectly healthy run.
+    optimizer_probe = [
+        (name, parameter, parameter.detach().clone())
         for name, parameter in model.named_parameters()
         if parameter.requires_grad and "TrajectoryPlanner" in name
-    )
-    optimizer_probe_before = optimizer_probe_parameter.detach().clone()
+    ]
+    if not optimizer_probe:
+        raise RuntimeError(
+            "no trainable TrajectoryPlanner parameters to verify progress on"
+        )
 
     def _branch_gradient_norm(name_fragment):
         total, count = 0.0, 0
@@ -5770,10 +5782,18 @@ def train_il(
             )
             break
 
-    optimizer_parameter_delta_norm = float(
+    # The planner moved if ANY of its parameters moved. Report the one that
+    # moved most, so a passing run still names a parameter and a failing run
+    # says how many were checked rather than pointing at one arbitrary name.
+    optimizer_probe_deltas = [
         (
-            optimizer_probe_parameter.detach() - optimizer_probe_before
-        ).norm().item()
+            name,
+            float((parameter.detach() - before).norm().item()),
+        )
+        for name, parameter, before in optimizer_probe
+    ]
+    optimizer_probe_name, optimizer_parameter_delta_norm = max(
+        optimizer_probe_deltas, key=lambda item: item[1]
     )
     if (
         not terminal_resume
@@ -5785,7 +5805,8 @@ def train_il(
         raise RuntimeError(
             "optimizer produced no parameter update: "
             f"steps={optimizer_step_count} "
-            f"parameter={optimizer_probe_name} "
+            f"parameters_checked={len(optimizer_probe_deltas)} "
+            f"largest_delta_parameter={optimizer_probe_name} "
             f"delta_norm={optimizer_parameter_delta_norm}"
         )
     first_gradient_evidence = gradient_evidence["first_step"] or {}
@@ -5998,6 +6019,9 @@ def train_il(
             "metric_history": metric_history,
             "optimizer_evidence": {
                 "step_count": optimizer_step_count,
+                "parameters_checked": len(optimizer_probe_deltas),
+                # The planner parameter that moved most, not an arbitrary one:
+                # the probe now watches every trainable planner parameter.
                 "probe_parameter": optimizer_probe_name,
                 "probe_parameter_delta_norm": (
                     optimizer_parameter_delta_norm


### PR DESCRIPTION
## The bug

Every KITScenes training run on `main` failed at the very end of my training last thursday after every epoch has run and every checkpoint has uploaded:

```
RuntimeError: optimizer produced no parameter update: steps=1074
parameter=Reactive_E2E.TrajectoryPlanner.visual_history_proj.weight
delta_norm=0.0
```

`train_il`'s sanity check clones **one** parameter before training and compares it after, to confirm the optimizer actually moved the planner. It uses whichever parameter `named_parameters()` yields first for `TrajectoryPlanner` — currently `visual_history_proj.weight`.

That parameter can never move under the current default config as it's zero-initialized on purpose, so World-Model visual history starts as a strict no-op.

So a completely healthy run gets reported as broken. This surfaced when `ac9988f7` removed two earlier planner parameters, which shifted which parameter happens to come first, nothing about the check's *intent* changed, only which parameter it happened to land on.

## The fix

Watch every trainable planner parameter instead of one, and pass if **any** of them moved. The failure message now reports how many parameters were checked and which moved most.

## Testing

`Model/tests/test_optimizer_progress_probe.py` five tests pinning the mechanism: a zero-init weight fed all-zero input provably never moves under AdamW even with weight decay, a control parameter that is fed does move, `BezierPlanner` really does zero-init `visual_history_proj` in the real model, that parameter really is first in `named_parameters()` order, and `train_il` binds a collection rather than consuming a single item off the generator. On a real run, the fixed probe reports `parameters_checked=8`, `largest_delta_parameter=context_mlp.0.weight`, `delta_norm=20.75`.

Run python -m pytest Model/tests/test_optimizer_progress_probe.py -v
